### PR TITLE
feat: post-install dependency detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `[paths]` config section for project-local ado directories prepended to `S_ADO`
+- Post-install dependency scanning: after `stacy add`, scans `.ado` files for `require`/`which`/`findfile` patterns and warns about missing dependencies
+- `stacy doctor` now checks all installed packages for missing implicit dependencies
 
 ## [1.1.0] - 2026-02-22
 

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -5,6 +5,8 @@
 use crate::cli::output_format::OutputFormat;
 use crate::cli::output_types::{AddOutput, CommandOutput};
 use crate::error::{Error, Result};
+use crate::packages::dep_scan;
+use crate::packages::global_cache;
 use crate::packages::hints;
 use crate::packages::installer::{
     install_from_local, install_from_net, install_from_ssc, install_package_github,
@@ -12,6 +14,7 @@ use crate::packages::installer::{
 use crate::project::config::{load_config, write_config, DependencyGroup, PackageSpec};
 use crate::project::Project;
 use clap::Args;
+use std::collections::HashSet;
 
 #[derive(Args)]
 #[command(after_help = "\
@@ -162,7 +165,26 @@ pub fn execute(args: &AddArgs) -> Result<()> {
 
                 if format == OutputFormat::Human {
                     println!("  + {} ({})", package_lower, result.version);
-                    if let Some(hint) = hints::get_hint(&package_lower) {
+
+                    // Scan installed files for implicit dependencies
+                    let installed: HashSet<String> =
+                        config.packages.all_package_names().into_iter().collect();
+                    if let Ok(cache_dir) =
+                        global_cache::package_path(&package_lower, &result.version)
+                    {
+                        let missing =
+                            dep_scan::find_missing_deps(&package_lower, &cache_dir, &installed);
+                        if !missing.is_empty() {
+                            let names = missing.join(" ");
+                            println!(
+                                "    hint: {} appears to need {}. Run: stacy add {}",
+                                package_lower, names, names
+                            );
+                        } else if let Some(hint) = hints::get_hint(&package_lower) {
+                            // Fallback to hardcoded hints for edge cases
+                            println!("    hint: {}", hint);
+                        }
+                    } else if let Some(hint) = hints::get_hint(&package_lower) {
                         println!("    hint: {}", hint);
                     }
                 }

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -12,10 +12,14 @@ use crate::cli::output_types::{CommandOutput, DoctorOutput};
 use crate::error::error_db::ErrorCodeCache;
 use crate::error::Result;
 use crate::executor::binary::detect_stata_binary;
+use crate::packages::dep_scan;
 use crate::packages::global_cache;
+use crate::packages::lockfile;
+use crate::project::config::load_config;
 use crate::project::Project;
 use crate::update_check;
 use clap::Args;
+use std::collections::HashSet;
 
 #[derive(Args)]
 #[command(after_help = "\
@@ -143,6 +147,7 @@ fn run_all_checks() -> Result<Vec<DiagnosticResult>> {
         check_project(),
         check_config(),
         check_local_ado_paths(),
+        check_package_dependencies(),
         check_cache_dir(),
         check_error_codes(),
         check_write_permissions(),
@@ -303,6 +308,84 @@ fn check_local_ado_paths() -> DiagnosticResult {
             message: "Could not check (config error)".to_string(),
             suggestion: None,
         },
+    }
+}
+
+fn check_package_dependencies() -> DiagnosticResult {
+    let project = match Project::find() {
+        Ok(Some(p)) => p,
+        _ => {
+            return DiagnosticResult {
+                name: "Package Dependencies".to_string(),
+                status: CheckStatus::Pass,
+                message: "No project found".to_string(),
+                suggestion: None,
+            }
+        }
+    };
+
+    let config = match load_config(&project.root) {
+        Ok(Some(c)) => c,
+        _ => {
+            return DiagnosticResult {
+                name: "Package Dependencies".to_string(),
+                status: CheckStatus::Pass,
+                message: "No configuration found".to_string(),
+                suggestion: None,
+            }
+        }
+    };
+
+    let lock = match lockfile::load_lockfile(&project.root) {
+        Ok(Some(l)) => l,
+        _ => {
+            return DiagnosticResult {
+                name: "Package Dependencies".to_string(),
+                status: CheckStatus::Pass,
+                message: "No lockfile found".to_string(),
+                suggestion: None,
+            }
+        }
+    };
+
+    let installed: HashSet<String> = config.packages.all_package_names().into_iter().collect();
+    let mut all_missing: Vec<(String, Vec<String>)> = Vec::new();
+
+    for (pkg_name, entry) in &lock.packages {
+        if let Ok(cache_dir) = global_cache::package_path(pkg_name, &entry.version) {
+            let missing = dep_scan::find_missing_deps(pkg_name, &cache_dir, &installed);
+            if !missing.is_empty() {
+                all_missing.push((pkg_name.clone(), missing));
+            }
+        }
+    }
+
+    if all_missing.is_empty() {
+        DiagnosticResult {
+            name: "Package Dependencies".to_string(),
+            status: CheckStatus::Pass,
+            message: "No missing dependencies detected".to_string(),
+            suggestion: None,
+        }
+    } else {
+        let details: Vec<String> = all_missing
+            .iter()
+            .map(|(pkg, deps)| format!("{} needs {}", pkg, deps.join(", ")))
+            .collect();
+        let all_deps: Vec<&str> = all_missing
+            .iter()
+            .flat_map(|(_, deps)| deps.iter().map(|s| s.as_str()))
+            .collect::<HashSet<&str>>()
+            .into_iter()
+            .collect();
+        let mut sorted_deps: Vec<&str> = all_deps;
+        sorted_deps.sort();
+        DiagnosticResult {
+            name: "Package Dependencies".to_string(),
+            status: CheckStatus::Warn,
+            message: format!("Missing dependencies: {}", details.join("; ")),
+            suggestion: Some(format!("Run: stacy add {}", sorted_deps.join(" "))),
+        }
     }
 }
 

--- a/src/packages/dep_scan.rs
+++ b/src/packages/dep_scan.rs
@@ -1,0 +1,331 @@
+//! Post-install dependency scanning for Stata packages
+//!
+//! Scans a package's `.ado` files for dependency patterns (`require`, `which`,
+//! `findfile`) and reports any that are missing from the project's config.
+//! This catches implicit dependencies that would otherwise only surface at
+//! runtime when Stata errors out.
+
+use regex::Regex;
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::LazyLock;
+
+/// Matches: `require ftools`, `cap require reghdfe`, `capture require pkg`
+static REQUIRE_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*(?:cap(?:ture)?\s+)?require\s+(\w+)").unwrap());
+
+/// Matches: `which ftools`, `cap which reghdfe`, `capture which pkg.ado`
+static WHICH_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?im)^\s*(?:cap(?:ture)?\s+)?which\s+(\w+)(?:\.ado)?"#).unwrap()
+});
+
+/// Matches: `findfile "moremata.ado"`, `findfile "pkg.mata"`, `findfile "pkg.hlp"`
+static FINDFILE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?im)^\s*(?:cap(?:ture)?\s+)?findfile\s+"(\w+)\.\w+""#).unwrap()
+});
+
+/// Stata built-in commands and keywords that should never be flagged as deps.
+const BUILTINS: &[&str] = &[
+    "using",
+    "stata",
+    "merge",
+    "sort",
+    "by",
+    "egen",
+    "generate",
+    "replace",
+    "drop",
+    "keep",
+    "rename",
+    "reshape",
+    "collapse",
+    "append",
+    "save",
+    "use",
+    "describe",
+    "summarize",
+    "tabulate",
+    "regress",
+    "logit",
+    "probit",
+    "mata",
+    "program",
+    "capture",
+    "quietly",
+    "noisily",
+    "display",
+    "set",
+    "local",
+    "global",
+    "tempvar",
+    "tempname",
+    "tempfile",
+    "foreach",
+    "forvalues",
+    "while",
+    "if",
+    "else",
+    "preserve",
+    "restore",
+    "assert",
+    "confirm",
+    "matrix",
+    "scalar",
+    "return",
+    "ereturn",
+    "sreturn",
+    "estimates",
+    "constraint",
+    "predict",
+    "margins",
+    "test",
+    "lincom",
+    "nlcom",
+    "bootstrap",
+    "jackknife",
+    "simulate",
+    "graph",
+    "label",
+    "notes",
+    "encode",
+    "decode",
+    "destring",
+    "tostring",
+    "insheet",
+    "outsheet",
+    "infile",
+    "import",
+    "export",
+    "file",
+    "log",
+    "timer",
+];
+
+/// Scan `.ado` file content for dependency patterns.
+/// Returns package names that appear to be required.
+fn scan_content(content: &str) -> HashSet<String> {
+    let mut deps = HashSet::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        // Skip comment lines
+        if trimmed.starts_with('*') || trimmed.starts_with("//") {
+            continue;
+        }
+
+        // Strip inline comments before matching
+        let code = if let Some(pos) = trimmed.find("//") {
+            &trimmed[..pos]
+        } else {
+            trimmed
+        };
+
+        for cap in REQUIRE_PATTERN.captures_iter(code) {
+            if let Some(m) = cap.get(1) {
+                deps.insert(m.as_str().to_lowercase());
+            }
+        }
+        for cap in WHICH_PATTERN.captures_iter(code) {
+            if let Some(m) = cap.get(1) {
+                deps.insert(m.as_str().to_lowercase());
+            }
+        }
+        for cap in FINDFILE_PATTERN.captures_iter(code) {
+            if let Some(m) = cap.get(1) {
+                deps.insert(m.as_str().to_lowercase());
+            }
+        }
+    }
+
+    deps
+}
+
+/// Scan `.ado` files in a directory for dependency patterns.
+/// Returns package names that appear to be required.
+pub fn scan_package_deps(package_dir: &Path) -> Vec<String> {
+    let mut all_deps = HashSet::new();
+    let builtins: HashSet<&str> = BUILTINS.iter().copied().collect();
+
+    let entries = match std::fs::read_dir(package_dir) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "ado") {
+            if let Ok(content) = std::fs::read_to_string(&path) {
+                all_deps.extend(scan_content(&content));
+            }
+        }
+    }
+
+    // Filter out built-ins
+    all_deps.retain(|name| !builtins.contains(name.as_str()));
+
+    let mut result: Vec<String> = all_deps.into_iter().collect();
+    result.sort();
+    result
+}
+
+/// Compare scanned deps against installed packages.
+/// Returns names that are detected but missing from the project.
+pub fn find_missing_deps(
+    package_name: &str,
+    package_dir: &Path,
+    installed: &HashSet<String>,
+) -> Vec<String> {
+    let deps = scan_package_deps(package_dir);
+    let pkg_lower = package_name.to_lowercase();
+
+    deps.into_iter()
+        .filter(|dep| dep != &pkg_lower && !installed.contains(dep))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_require_pattern() {
+        let content = "require ftools\nsome other code\n";
+        let deps = scan_content(content);
+        assert!(deps.contains("ftools"));
+    }
+
+    #[test]
+    fn test_capture_require() {
+        let content = "cap require reghdfe\n";
+        let deps = scan_content(content);
+        assert!(deps.contains("reghdfe"));
+    }
+
+    #[test]
+    fn test_capture_full_require() {
+        let content = "capture require moremata\n";
+        let deps = scan_content(content);
+        assert!(deps.contains("moremata"));
+    }
+
+    #[test]
+    fn test_which_pattern() {
+        let content = "which ftools\n";
+        let deps = scan_content(content);
+        assert!(deps.contains("ftools"));
+    }
+
+    #[test]
+    fn test_cap_which_pattern() {
+        let content = "cap which reghdfe\n";
+        let deps = scan_content(content);
+        assert!(deps.contains("reghdfe"));
+    }
+
+    #[test]
+    fn test_which_with_ado_extension() {
+        let content = "which ftools.ado\n";
+        let deps = scan_content(content);
+        assert!(deps.contains("ftools"));
+    }
+
+    #[test]
+    fn test_findfile_pattern() {
+        let content = "findfile \"moremata.hlp\"\n";
+        let deps = scan_content(content);
+        assert!(deps.contains("moremata"));
+    }
+
+    #[test]
+    fn test_findfile_ado() {
+        let content = "findfile \"ftools.ado\"\n";
+        let deps = scan_content(content);
+        assert!(deps.contains("ftools"));
+    }
+
+    #[test]
+    fn test_findfile_mata() {
+        let content = "findfile \"moremata.mata\"\n";
+        let deps = scan_content(content);
+        assert!(deps.contains("moremata"));
+    }
+
+    #[test]
+    fn test_comments_skipped() {
+        let content = "* require ftools\n// which reghdfe\nrequire real_dep\n";
+        let deps = scan_content(content);
+        assert!(!deps.contains("ftools"));
+        assert!(!deps.contains("reghdfe"));
+        assert!(deps.contains("real_dep"));
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        let content = "REQUIRE Ftools\nWhich RegHDFE\n";
+        let deps = scan_content(content);
+        assert!(deps.contains("ftools"));
+        assert!(deps.contains("reghdfe"));
+    }
+
+    #[test]
+    fn test_builtins_filtered() {
+        let content = "require stata\nwhich mata\nrequire ftools\n";
+        let deps = scan_content(content);
+        // scan_content doesn't filter builtins, scan_package_deps does
+        assert!(deps.contains("stata"));
+        assert!(deps.contains("ftools"));
+    }
+
+    #[test]
+    fn test_self_reference_filtered() {
+        let installed: HashSet<String> = HashSet::new();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("mypkg.ado"),
+            "require mypkg\nrequire otherpkg\n",
+        )
+        .unwrap();
+
+        let missing = find_missing_deps("mypkg", dir.path(), &installed);
+        assert!(!missing.contains(&"mypkg".to_string()));
+        assert!(missing.contains(&"otherpkg".to_string()));
+    }
+
+    #[test]
+    fn test_installed_deps_not_reported() {
+        let mut installed = HashSet::new();
+        installed.insert("ftools".to_string());
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pkg.ado"),
+            "require ftools\nrequire missing\n",
+        )
+        .unwrap();
+
+        let missing = find_missing_deps("pkg", dir.path(), &installed);
+        assert!(!missing.contains(&"ftools".to_string()));
+        assert!(missing.contains(&"missing".to_string()));
+    }
+
+    #[test]
+    fn test_inline_comment_stripped() {
+        let content = "some code // require fakepkg\nrequire realpkg\n";
+        let deps = scan_content(content);
+        assert!(!deps.contains("fakepkg"));
+        assert!(deps.contains("realpkg"));
+    }
+
+    #[test]
+    fn test_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let deps = scan_package_deps(dir.path());
+        assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn test_nonexistent_dir() {
+        let deps = scan_package_deps(Path::new("/nonexistent/path"));
+        assert!(deps.is_empty());
+    }
+}

--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod dep_scan;
 pub mod github;
 pub mod global_cache;
 pub mod hints;

--- a/src/project/config.rs
+++ b/src/project/config.rs
@@ -211,6 +211,16 @@ impl PackagesSection {
             .or_else(|| self.test.remove(name))
     }
 
+    /// Get all package names across all groups
+    pub fn all_package_names(&self) -> Vec<String> {
+        self.dependencies
+            .keys()
+            .chain(self.dev.keys())
+            .chain(self.test.keys())
+            .cloned()
+            .collect()
+    }
+
     /// Get all packages with their group
     pub fn all_packages(&self) -> impl Iterator<Item = (&String, &PackageSpec, DependencyGroup)> {
         self.dependencies


### PR DESCRIPTION
## Summary

Closes #7.

- New `src/packages/dep_scan.rs` module scans a package's cached `.ado` files for `require`, `which`, and `findfile` patterns to detect implicit dependencies
- After `stacy add`, warns if any scanned dependencies are missing from `stacy.toml` (falls back to hardcoded hints when scanner finds nothing)
- Adds a "Package Dependencies" check to `stacy doctor` that scans all installed packages

## Test plan

- [x] `cargo test` — all 182 tests pass (14 new in dep_scan)
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean
- [x] `cargo xtask codegen --check` — in sync
- [x] Manual: `stacy add reghdfe` in a test project shows scanner-derived hint about ftools