### PR TITLE
feat: first-run UX polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `[paths]` config section for project-local ado directories prepended to `S_ADO`
 - Post-install dependency scanning: after `stacy add`, scans `.ado` files for `require`/`which`/`findfile` patterns and warns about missing dependencies
 - `stacy doctor` now checks all installed packages for missing implicit dependencies
+- `stacy init` and `stacy add` now show the package cache location in output
+
+### Changed
+
+- `stacy init` template trimmed to essentials (`[project]` and `[packages.dependencies]` examples only)
+- Package dependencies in `stacy.toml` are now written in alphabetical order
 
 ## [1.1.0] - 2026-02-22
 

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -359,6 +359,10 @@ fn print_json_output(results: &[AddedPackage], output: &AddOutput) {
         })
         .collect();
 
+    let cache_dir = global_cache::cache_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+
     let json_output = json!({
         "status": output.status,
         "packages": packages,
@@ -368,7 +372,8 @@ fn print_json_output(results: &[AddedPackage], output: &AddOutput) {
             "failed": output.failed,
             "total": output.total,
             "group": output.group,
-        }
+        },
+        "cache_dir": cache_dir,
     });
 
     println!("{}", serde_json::to_string_pretty(&json_output).unwrap());
@@ -392,6 +397,9 @@ fn print_human_summary(output: &AddOutput) {
     } else {
         let dep_type = format!("{} dependencies", output.group);
         println!("Updated {}: {}", dep_type, summary.join(", "));
+    }
+    if let Ok(cache) = global_cache::cache_dir() {
+        println!("Package cache: {}", cache.display());
     }
 }
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -9,6 +9,7 @@
 use crate::cli::output_format::OutputFormat;
 use crate::cli::output_types::{CommandOutput, InitOutput};
 use crate::error::Result;
+use crate::packages::global_cache;
 use crate::project::structure::{
     create_project_structure, create_project_structure_with_metadata, has_project_markers,
     PackageSource, PackageToInstall, ProjectMetadata,
@@ -351,6 +352,9 @@ fn format_source_display(source: &PackageSource) -> String {
 
 fn print_human_output(path: &std::path::Path, created: &[String], packages: &[PackageToInstall]) {
     println!("Initialized stacy project in: {}", path.display());
+    if let Ok(cache) = global_cache::cache_dir() {
+        println!("Package cache: {}", cache.display());
+    }
     println!();
 
     if created.is_empty() {
@@ -398,6 +402,10 @@ fn print_json_output(path: &std::path::Path, created: &[String], packages: &[Pac
         })
         .collect();
 
+    let cache_dir = global_cache::cache_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+
     let output = json!({
         "status": "success",
         "path": path.display().to_string(),
@@ -405,6 +413,7 @@ fn print_json_output(path: &std::path::Path, created: &[String], packages: &[Pac
         "created_count": created.len(),
         "packages": pkg_list,
         "package_count": pkg_list.len(),
+        "cache_dir": cache_dir,
     });
 
     println!("{}", serde_json::to_string_pretty(&output).unwrap());

--- a/src/project/config.rs
+++ b/src/project/config.rs
@@ -5,7 +5,7 @@
 
 use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 /// Project configuration loaded from stacy.toml
@@ -146,14 +146,14 @@ impl std::fmt::Display for DependencyGroup {
 #[serde(default)]
 pub struct PackagesSection {
     /// Production dependencies: package_name -> source spec
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub dependencies: HashMap<String, PackageSpec>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub dependencies: BTreeMap<String, PackageSpec>,
     /// Development dependencies: package_name -> source spec
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub dev: HashMap<String, PackageSpec>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub dev: BTreeMap<String, PackageSpec>,
     /// Test dependencies: package_name -> source spec
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub test: HashMap<String, PackageSpec>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub test: BTreeMap<String, PackageSpec>,
 }
 
 impl PackagesSection {
@@ -395,34 +395,10 @@ pub fn generate_config_template() -> &'static str {
 
 [project]
 # name = "my-analysis"
-# authors = ["Your Name <you@example.com>"]
-# description = "Analysis project"
-# url = "https://github.com/user/repo"
 
-[run]
-log_dir = "logs"
-show_progress = true
-# progress_interval_seconds = 10
-# max_log_size_mb = 50
-
-# Local ado directories (prepended to S_ADO, relative to project root)
-# [paths]
-# ado = ["ado", "lib/custom"]
-
-# Package dependencies (installed to global cache at ~/.cache/stacy/packages/)
 # [packages.dependencies]
 # estout = "ssc"
 # reghdfe = "github:sergiocorreia/reghdfe"
-
-# Task definitions for `stacy task` command
-# [scripts]
-# clean = "src/01_clean.do"
-# analyze = "src/02_analyze.do"
-# all = ["clean", "analyze"]
-# outputs = { parallel = ["tables", "figures"] }
-
-# Note: Stata binary path is NOT set here (it's machine-specific).
-# Configure it in ~/.config/stacy/config.toml or use $STATA_BINARY env var.
 "#
 }
 

--- a/src/project/structure.rs
+++ b/src/project/structure.rs
@@ -7,6 +7,7 @@
 //! Other files (stacy.lock, ado/) are created on demand by `stacy install`.
 
 use crate::error::{Error, Result};
+use crate::project::config;
 use std::path::Path;
 
 /// Create minimal project structure (stacy.toml + .gitignore only).
@@ -35,7 +36,7 @@ pub fn create_project_structure(root: &Path, force: bool) -> Result<Vec<String>>
     // Create stacy.toml
     let config_path = root.join("stacy.toml");
     if !config_path.exists() || force {
-        std::fs::write(&config_path, generate_config_template()).map_err(|e| {
+        std::fs::write(&config_path, config::generate_config_template()).map_err(|e| {
             Error::Config(format!(
                 "Failed to create stacy.toml at {}: {}",
                 config_path.display(),
@@ -104,35 +105,6 @@ pub enum PackageSource {
     },
 }
 
-/// Generate stacy.toml template with commented defaults.
-fn generate_config_template() -> &'static str {
-    r#"# stacy project configuration
-# See: https://github.com/janfasnacht/stacy
-
-[project]
-# name = "my-analysis"
-# authors = ["Your Name <you@example.com>"]
-# description = "Analysis project"
-# url = "https://github.com/user/repo"
-
-[run]
-# show_progress = true
-# progress_interval_seconds = 10
-
-# Local ado directories (prepended to S_ADO, relative to project root)
-# [paths]
-# ado = ["ado", "lib/custom"]
-
-# Package dependencies (installed to global cache at ~/.cache/stacy/packages/)
-# [packages.dependencies]
-# estout = "ssc"
-# reghdfe = "github:sergiocorreia/reghdfe"
-
-# Note: Stata binary path is NOT set here (it's machine-specific).
-# Configure it in ~/.config/stacy/config.toml or use $STATA_BINARY env var.
-"#
-}
-
 /// Generate stacy.toml with provided metadata.
 pub fn generate_config_with_metadata(metadata: &ProjectMetadata) -> String {
     let mut config = String::from(
@@ -159,8 +131,6 @@ pub fn generate_config_with_metadata(metadata: &ProjectMetadata) -> String {
     if let Some(ref url) = metadata.url {
         config.push_str(&format!("url = \"{}\"\n", url));
     }
-
-    config.push_str("\n[run]\nshow_progress = true\n");
 
     config
 }
@@ -294,7 +264,7 @@ mod tests {
 
     #[test]
     fn test_config_template_is_valid_toml() {
-        let template = generate_config_template();
+        let template = config::generate_config_template();
         let _: toml::Value = toml::from_str(template).unwrap();
     }
 


### PR DESCRIPTION
## Summary

Closes #4.

- Show package cache location in `stacy init` and `stacy add` output (human + JSON)
- Sort `[packages.dependencies]` alphabetically (HashMap → BTreeMap)
- Trim `stacy init` template to essentials, consolidate duplicate template functions

## Test plan

- [x] `cargo fmt --check && cargo test && cargo clippy && cargo xtask codegen --check`
- [x] All 510 unit + 134 integration tests pass