### PR TITLE
feat: package naming hints on SSC 404

### DIFF
--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -7,6 +7,7 @@ pub mod http;
 pub mod installer;
 pub mod local;
 pub mod lockfile;
+pub mod naming;
 pub mod net;
 pub mod pkg_parser;
 pub mod ssc;

--- a/src/packages/naming.rs
+++ b/src/packages/naming.rs
@@ -1,0 +1,157 @@
+//! Package naming hints for SSC
+//!
+//! Many Stata commands are provided by packages with different names.
+//! When a user tries to install a command name that isn't a package,
+//! this module suggests the correct package.
+
+/// Look up which package provides a given command name.
+///
+/// Returns `Some((package_name, commands))` where `commands` lists the
+/// well-known commands that package provides.
+pub fn find_provider(name: &str) -> Option<(&'static str, &'static [&'static str])> {
+    // Linear scan is fine — the map is small and lookups only happen on 404.
+    for &(package, commands) in COMMAND_TO_PACKAGE {
+        if commands.contains(&name) {
+            return Some((package, commands));
+        }
+    }
+    None
+}
+
+/// Curated map: (package_name, &[command_names_it_provides])
+///
+/// Only includes cases where the command name differs from the package name.
+/// Each entry maps a set of well-known commands to the SSC package that
+/// provides them.
+const COMMAND_TO_PACKAGE: &[(&str, &[&str])] = &[
+    // labutil: label manipulation utilities
+    ("labutil", &["labmask", "labvarch", "labvalch", "labcd"]),
+    // estout: estimation output tables
+    ("estout", &["esttab", "eststo", "estpost", "estadd"]),
+    // ftools: fast Stata tools
+    (
+        "ftools",
+        &[
+            "fegen",
+            "fcollapse",
+            "fmerge",
+            "fisid",
+            "flevelsof",
+            "fsort",
+            "ftab",
+        ],
+    ),
+    // gtools: fast group commands
+    (
+        "gtools",
+        &[
+            "gcollapse",
+            "gegen",
+            "gisid",
+            "glevelsof",
+            "gunique",
+            "gdistinct",
+            "gquantiles",
+            "gstats",
+            "hashsort",
+            "greshape",
+            "gduplicates",
+            "gtop",
+        ],
+    ),
+    // moremata: extended Mata functions
+    ("moremata", &["mf_mm_quantile", "mf_mm_density"]),
+    // palettes: color palettes
+    (
+        "palettes",
+        &["colorpalette", "symbolpalette", "linepalette"],
+    ),
+    // boottest: wild bootstrap
+    ("boottest", &["waldtest"]),
+    // rdrobust: regression discontinuity
+    ("rdrobust", &["rdplot", "rdbwselect"]),
+    // ietoolkit: World Bank impact evaluation
+    (
+        "ietoolkit",
+        &[
+            "iefolder", "iedorep", "iebaltab", "ieddtab", "iegraph", "iesave",
+        ],
+    ),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_provider_known() {
+        let (pkg, commands) = find_provider("labmask").unwrap();
+        assert_eq!(pkg, "labutil");
+        assert!(commands.contains(&"labmask"));
+    }
+
+    #[test]
+    fn test_find_provider_another() {
+        let (pkg, _) = find_provider("esttab").unwrap();
+        assert_eq!(pkg, "estout");
+    }
+
+    #[test]
+    fn test_find_provider_unknown() {
+        assert!(find_provider("notarealcommand").is_none());
+    }
+
+    #[test]
+    fn test_find_provider_gtools() {
+        let (pkg, _) = find_provider("gcollapse").unwrap();
+        assert_eq!(pkg, "gtools");
+    }
+
+    #[test]
+    fn test_find_provider_ftools() {
+        let (pkg, _) = find_provider("fcollapse").unwrap();
+        assert_eq!(pkg, "ftools");
+    }
+
+    #[test]
+    fn test_find_provider_case_sensitive() {
+        // Input should be lowercased before calling
+        assert!(find_provider("LabMask").is_none());
+    }
+
+    #[test]
+    fn test_no_duplicate_commands() {
+        let mut seen = std::collections::HashSet::new();
+        for &(pkg, commands) in COMMAND_TO_PACKAGE {
+            for &cmd in commands {
+                assert!(
+                    seen.insert(cmd),
+                    "Duplicate command '{}' (already mapped, now in '{}')",
+                    cmd,
+                    pkg
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_map_well_formed() {
+        for &(pkg, commands) in COMMAND_TO_PACKAGE {
+            assert!(!pkg.is_empty(), "Package name must not be empty");
+            assert!(
+                !commands.is_empty(),
+                "Commands list must not be empty for {}",
+                pkg
+            );
+            // Commands matching the package name would never trigger a 404,
+            // so they shouldn't be in the map.
+            for &cmd in commands {
+                assert_ne!(
+                    cmd, pkg,
+                    "Command '{}' equals package name — remove it (SSC will find it directly)",
+                    cmd
+                );
+            }
+        }
+    }
+}

--- a/src/packages/ssc.rs
+++ b/src/packages/ssc.rs
@@ -6,6 +6,7 @@
 
 use crate::error::{Error, Result};
 use crate::packages::http::StacyHttpClient;
+use crate::packages::naming;
 use crate::packages::pkg_parser::{parse_pkg_file, PackageManifest};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -157,12 +158,21 @@ impl SscDownloader {
                             download.from_mirror = true;
                             Ok(download)
                         }
-                        Err(_) => Err(Error::Config(format!(
-                            "Package '{}' not found on SSC. \
-                                 Check spelling or verify the package exists at \
-                                 https://ideas.repec.org/s/boc/bocode.html",
-                            name
-                        ))),
+                        Err(_) => {
+                            let mut msg = format!("Package '{}' not found on SSC.", name);
+                            if let Some((provider, _)) = naming::find_provider(&name) {
+                                msg.push_str(&format!(
+                                    " '{}' is provided by '{}'. Run: stacy add {}",
+                                    name, provider, provider
+                                ));
+                            } else {
+                                msg.push_str(
+                                    " Check spelling or verify the package exists at \
+                                     https://ideas.repec.org/s/boc/bocode.html",
+                                );
+                            }
+                            Err(Error::Config(msg))
+                        }
                     }
                 } else {
                     Err(primary_err)


### PR DESCRIPTION
## Summary

Closes #3.

- Curated command-to-package map (39 commands across 9 packages, e.g. `labmask` → `labutil`, `esttab` → `estout`)
- On SSC 404, suggests the correct package: `"Package 'labmask' not found on SSC. 'labmask' is provided by 'labutil'. Run: stacy add labutil"`
- All mappings verified against SSC package manifests

## Test plan

- [x] `cargo fmt --check && cargo test && cargo clippy && cargo xtask codegen --check`