### PR TITLE
feat: expose missing CLI flags as Stata options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Stata wrappers: `AllowGlobal` and `Trace(integer)` options for `stacy_run`
+- Stata wrappers: `With(string)`, `FROZEN`, and `NOVerify` options for `stacy_install`
 - `[paths]` config section for project-local ado directories prepended to `S_ADO`
 - Post-install dependency scanning: after `stacy add`, scans `.ado` files for `require`/`which`/`findfile` patterns and warns about missing dependencies
 - `stacy doctor` now checks all installed packages for missing implicit dependencies

--- a/docs/src/commands/install.md
+++ b/docs/src/commands/install.md
@@ -25,6 +25,9 @@ lockfile. Can also install individual packages directly from SSC or GitHub.
 | Option | Description |
 |--------|-------------|
 | `--from` | Source: ssc or github:user/repo |
+| `--frozen` | Fail if lockfile doesn't match stacy.toml |
+| `--no_verify` | Skip checksum verification |
+| `--with` | Include dependency groups (dev, test) |
 
 ## Examples
 

--- a/docs/src/commands/run.md
+++ b/docs/src/commands/run.md
@@ -37,6 +37,7 @@ For interactive use where you want to quickly check a result, see `stacy eval`.
 
 | Option | Description |
 |--------|-------------|
+| `--allow_global` | Allow globally installed packages |
 | `--cd` | Change to script's parent directory |
 | `-c, --code` | Inline Stata code |
 | `-C, --directory` | Run Stata in this directory |

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -77,7 +77,8 @@ quiet = { type = "bool", short = "q", description = "Suppress output", stata_opt
 verbose = { type = "bool", description = "Extra output", stata_option = "Verbose" }
 json = { type = "bool", description = "JSON output (internal)" }
 profile = { type = "bool", description = "Include execution metrics", stata_option = "Profile" }
-trace = { type = "int", long = "trace", description = "Enable execution tracing at given depth" }
+allow_global = { type = "bool", long = "allow-global", description = "Allow globally installed packages", stata_option = "AllowGlobal" }
+trace = { type = "int", long = "trace", description = "Enable execution tracing at given depth", stata_option = "Trace(integer)" }
 
 [commands.run.returns]
 # Scalars (numeric values)
@@ -270,6 +271,9 @@ see_also = ["add", "lock", "list"]
 [commands.install.args]
 package = { type = "string", positional = true, description = "Package name (optional)" }
 from = { type = "string", description = "Source: ssc or github:user/repo", stata_option = "From(string)" }
+with = { type = "string", long = "with", description = "Include dependency groups (dev, test)", stata_option = "With(string)" }
+frozen = { type = "bool", long = "frozen", description = "Fail if lockfile doesn't match stacy.toml", stata_option = "FROZEN" }
+no_verify = { type = "bool", long = "no-verify", description = "Skip checksum verification", stata_option = "NOVerify" }
 json = { type = "bool", description = "JSON output (internal)" }
 
 [commands.install.returns]

--- a/stata/stacy_install.ado
+++ b/stata/stacy_install.ado
@@ -12,6 +12,9 @@
 
     Options:
         From(string)         - Source: ssc or github:user/repo
+        FROZEN               - Fail if lockfile doesn't match stacy.toml
+        NOVerify             - Skip checksum verification
+        With(string)         - Include dependency groups (dev, test)
 
     Returns:
         r(already_installed   ) - Number already installed (scalar)
@@ -24,7 +27,7 @@
 
 program define stacy_install, rclass
     version 14.0
-    syntax [anything(name=package)] [, From(string)]
+    syntax [anything(name=package)] [, From(string) FROZEN NOVerify With(string)]
 
     * Build command arguments
     local cmd "install"
@@ -35,6 +38,18 @@ program define stacy_install, rclass
 
     if `"`from'"' != "" {
         local cmd `"`cmd' --from "`from'""'
+    }
+
+    if "`frozen'" != "" {
+        local cmd `"`cmd' --frozen"'
+    }
+
+    if "`noverify'" != "" {
+        local cmd `"`cmd' --no-verify"'
+    }
+
+    if `"`with'"' != "" {
+        local cmd `"`cmd' --with "`with'""'
     }
 
     * Execute via _stacy_exec

--- a/stata/stacy_install.sthlp
+++ b/stata/stacy_install.sthlp
@@ -22,6 +22,9 @@
 {synoptline}
 {syntab:Main}
 {synopt:{opt:from(string)}}Source: ssc or github:user/repo{p_end}
+{synopt:{opt:frozen}}Fail if lockfile doesn't match stacy.toml{p_end}
+{synopt:{opt:noverify}}Skip checksum verification{p_end}
+{synopt:{opt:with(string)}}Include dependency groups (dev, test){p_end}
 {synoptline}
 
 
@@ -37,6 +40,15 @@
 
 {phang}
 {opt from} source: ssc or github:user/repo.
+
+{phang}
+{opt frozen} fail if lockfile doesn't match stacy.toml.
+
+{phang}
+{opt no_verify} skip checksum verification.
+
+{phang}
+{opt with} include dependency groups (dev, test).
 
 
 {marker returns}{...}

--- a/stata/stacy_run.ado
+++ b/stata/stacy_run.ado
@@ -11,10 +11,12 @@
         stacy_run [script] [, options]
 
     Options:
+        AllowGlobal          - Allow globally installed packages
         Code(string)         - Inline Stata code
         Directory(string)    - Run Stata in this directory
         Profile              - Include execution metrics
         Quietly              - Suppress output
+        Trace(integer)       - Enable execution tracing at given depth
         Verbose              - Extra output
 
     Returns:
@@ -29,13 +31,17 @@
 
 program define stacy_run, rclass
     version 14.0
-    syntax [anything(name=script)] [, Code(string) Directory(string) Profile Quietly Verbose]
+    syntax [anything(name=script)] [, AllowGlobal Code(string) Directory(string) Profile Quietly Trace(string) Verbose]
 
     * Build command arguments
     local cmd "run"
 
     if `"`script'"' != "" {
         local cmd `"`cmd' "`script'""'
+    }
+
+    if "`allowglobal'" != "" {
+        local cmd `"`cmd' --allow-global"'
     }
 
     if `"`code'"' != "" {
@@ -52,6 +58,10 @@ program define stacy_run, rclass
 
     if "`quietly'" != "" {
         local cmd `"`cmd' --quiet"'
+    }
+
+    if `"`trace'"' != "" {
+        local cmd `"`cmd' --trace "`trace'""'
     }
 
     if "`verbose'" != "" {

--- a/stata/stacy_run.sthlp
+++ b/stata/stacy_run.sthlp
@@ -21,10 +21,12 @@
 {synopthdr}
 {synoptline}
 {syntab:Main}
+{synopt:{opt:allowglobal}}Allow globally installed packages{p_end}
 {synopt:{opt:code(string)}}Inline Stata code{p_end}
 {synopt:{opt:directory(string)}}Run Stata in this directory{p_end}
 {synopt:{opt:profile}}Include execution metrics{p_end}
 {synopt:{opt:quietly}}Suppress output{p_end}
+{synopt:{opt:trace(integer)}}Enable execution tracing at given depth{p_end}
 {synopt:{opt:verbose}}Extra output{p_end}
 {synoptline}
 
@@ -38,6 +40,9 @@
 
 {marker options}{...}
 {title:Options}
+
+{phang}
+{opt allow_global} allow globally installed packages.
 
 {phang}
 {opt cd} change to script's parent directory.


### PR DESCRIPTION
## Summary

Closes #12.

- Add `AllowGlobal` and `Trace(integer)` options to `stacy_run` schema
- Add `With(string)`, `FROZEN`, and `NOVerify` options to `stacy_install` schema
- Regenerate Stata wrappers and docs via codegen

## Test plan

- [x] `cargo fmt --check && cargo test && cargo clippy && cargo xtask codegen --check`