### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering Cargo + GitHub Actions ecosystems.
- Weekly schedule (Mondays), `cargo-minor-patch` and `actions-minor-patch` groups bundle non-breaking updates into one PR per ecosystem.
- `open-pull-requests-limit: 5` per ecosystem.
- Major bumps still open individually so they get a review.
- Bumps `rustls-webpki` 0.103.8 → 0.103.13 via `Cargo.lock` to clear `RUSTSEC-2026-0049/0098/0099` (cargo-audit was failing on main; #23 covered the clippy fix).

## Dry-run findings (via `dependabot-cli` v1.85.0)
- **cargo**: ~46 updates pending. With grouping → ~1 patch/minor PR + ~7 individual majors (e.g. `thiserror 1→2`, `similar 2→3`, `sha2 0.10→0.11`, `criterion 0.5→0.8`).
- **github-actions**: 0 PRs — every action is on its current major.

## Note
- `dtolnay/rust-toolchain@master` and `@stable` are floating refs; Dependabot does not update those. Out of scope.

## Test plan
- [ ] CI green on this PR (clippy + audit).
- [ ] After merge, confirm Dependabot opens the expected grouped PR within ~24h.