### PR TITLE
fix: per-invocation log paths so parallel runs don't collide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Parallel `stacy run` invocations on scripts that share a basename no longer collide on the log file (#20). Each run writes to a uniquely-named log in the working directory (`<stem>_<pid>_<nanos>_<n>.log`), so build orchestrators like Make `-j` and Snakemake can run same-stemmed scripts from a shared cwd safely. The path is reported in JSON output's `log_file` field.
 - Non-UTF-8 characters in Stata log files no longer crash the log parser
 - Update check now compares against the running binary version, not a stale cached value
 - Cargo upgrade instruction now shows correct crate name (`stacy`, not `stata-cli`)

--- a/docs/src/reference/json-output.md
+++ b/docs/src/reference/json-output.md
@@ -23,7 +23,7 @@ stacy env --format json
   "script": "analysis.do",
   "duration_secs": 12.45,
   "exit_code": 0,
-  "log_file": "analysis.log"
+  "log_file": "/path/to/wd/analysis_12345_1715000000123_0.log"
 }
 ```
 
@@ -34,7 +34,7 @@ stacy env --format json
   "script": "analysis.do",
   "duration_secs": 0.45,
   "exit_code": 2,
-  "log_file": "analysis.log",
+  "log_file": "/path/to/wd/analysis_12345_1715000000123_0.log",
   "errors": [
     {
       "type": "StataCode",
@@ -53,7 +53,7 @@ stacy env --format json
 | `script` | string | Path to script that was run |
 | `duration_secs` | float | Execution time in seconds |
 | `exit_code` | int | stacy exit code (0-10) |
-| `log_file` | string | Path to Stata log file |
+| `log_file` | string | Absolute path to Stata log file. Each invocation gets a unique stem (`<script>_<pid>_<nanos>_<n>.log`) so concurrent runs from a shared cwd never collide. |
 | `errors` | array | Error details (only on failure) |
 | `errors[].type` | string | Error type (`StataCode`, `Syntax`, `File`) |
 | `errors[].r_code` | int | Stata r() code if applicable |

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -168,7 +168,7 @@ fn build_adopath_from_lockfile(
             Ok(Some(lockfile)) => {
                 // Sort packages alphabetically for deterministic output
                 let mut sorted_packages: Vec<_> = lockfile.packages.iter().collect();
-                sorted_packages.sort_by(|(a, _), (b, _)| a.cmp(b));
+                sorted_packages.sort_by_key(|(a, _)| *a);
 
                 for (name, entry) in sorted_packages {
                     if let Ok(pkg_path) = global_cache::package_path(name, &entry.version) {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -432,7 +432,7 @@ fn execute_inline(args: &RunArgs) -> Result<()> {
 
     // Create temp file for inline code
     let cwd = std::env::current_dir()?;
-    let temp_script = TempScript::new(&code, &cwd)?;
+    let mut temp_script = TempScript::new(&code, &cwd)?;
     let script_path = temp_script.path().to_path_buf();
 
     // Create executor
@@ -461,6 +461,10 @@ fn execute_inline(args: &RunArgs) -> Result<()> {
 
     // Run Stata
     let mut result = executor.run(&script_path, project_root)?;
+    // The wrapper-derived log path doesn't match TempScript's expected
+    // `script.with_extension("log")`. Hand the real path to TempScript so
+    // its Drop cleans up the inline-run log (preserves pre-#20 behavior).
+    temp_script.set_actual_log(result.log_file.clone());
 
     if let Some(ref mut m) = metrics {
         m.end_phase("execution");
@@ -710,7 +714,7 @@ fn execute_single(script_path: &Path, args: &RunArgs) -> Result<()> {
     }
 
     // Run Stata (with trace injection if active)
-    let _trace_temp_script; // keep TempScript alive until after execution
+    let mut _trace_temp_script: Option<TempScript> = None; // keep TempScript alive until after execution
     let mut result = if let Some(depth) = args.trace {
         // Read the original script, prepend trace commands, run via TempScript
         let original_code = std::fs::read_to_string(effective_script).map_err(|e| {
@@ -733,12 +737,15 @@ fn execute_single(script_path: &Path, args: &RunArgs) -> Result<()> {
             executor.run(&temp_path, project_root)?
         }
     } else if let Some(ref dir) = working_dir {
-        _trace_temp_script = None;
         executor.run_in_dir(effective_script, project_root, dir)?
     } else {
-        _trace_temp_script = None;
         executor.run(effective_script, project_root)?
     };
+    // Tell the trace TempScript where the real log lives so Drop cleans it up
+    // (the wrapper stem doesn't match TempScript's `script.with_extension("log")`).
+    if let Some(ref mut ts) = _trace_temp_script {
+        ts.set_actual_log(result.log_file.clone());
+    }
 
     if let Some(ref mut m) = metrics {
         m.end_phase("execution");
@@ -946,7 +953,7 @@ fn execute_sequential(args: &RunArgs) -> Result<()> {
         let (ref abs_script, ref work_dir) = resolved_scripts[i];
 
         // When tracing, read file, prepend trace commands, run via TempScript
-        let _trace_temp_script;
+        let mut _trace_temp_script: Option<TempScript> = None;
         let result = if let Some(depth) = args.trace {
             let original_code = std::fs::read_to_string(abs_script).map_err(|e| {
                 crate::error::Error::Config(format!(
@@ -967,14 +974,16 @@ fn execute_sequential(args: &RunArgs) -> Result<()> {
             } else {
                 executor.run(&temp_path, project_root)?
             }
+        } else if let Some(ref dir) = work_dir {
+            executor.run_in_dir(abs_script, project_root, dir)?
         } else {
-            _trace_temp_script = None;
-            if let Some(ref dir) = work_dir {
-                executor.run_in_dir(abs_script, project_root, dir)?
-            } else {
-                executor.run(script, project_root)?
-            }
+            executor.run(script, project_root)?
         };
+        // Hand the wrapper-derived log path to the trace TempScript so Drop
+        // cleans it up (see #20 — the stem no longer matches script.with_extension).
+        if let Some(ref mut ts) = _trace_temp_script {
+            ts.set_actual_log(result.log_file.clone());
+        }
 
         let script_result = ScriptRunResult {
             script: script.clone(),

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,6 +1,7 @@
 pub mod binary;
 pub mod log_reader;
 pub mod progress;
+pub mod run_paths;
 pub mod runner;
 pub mod verbosity;
 pub mod wrapper;
@@ -154,6 +155,26 @@ impl StataExecutor {
         use runner::{run_stata, RunOptions};
         use std::thread;
 
+        // Resolve absolute paths up front so RunPaths can derive a unique log
+        // location regardless of the caller's cwd. The user's script may be
+        // relative (e.g. from unit tests); the working_dir from cli/run.rs is
+        // already absolute, but we default to current_dir() if absent.
+        let abs_script: PathBuf = if script.is_absolute() {
+            script.to_path_buf()
+        } else {
+            std::env::current_dir()?.join(script)
+        };
+        let effective_working_dir: PathBuf = match working_dir {
+            Some(dir) => dir.to_path_buf(),
+            None => std::env::current_dir()?,
+        };
+
+        // Per-invocation wrapper + unique log path. `_paths` is bound for the
+        // full function scope so the wrapper file outlives every read of the
+        // log (parse_log_for_errors, get_error_context, streaming threads).
+        // See src/executor/run_paths.rs and #20 for rationale.
+        let _paths = run_paths::RunPaths::prepare(&abs_script, &effective_working_dir)?;
+
         // Build run options
         let mut options = RunOptions::new(&self.stata_binary);
         if let Some(root) = project_root {
@@ -172,6 +193,7 @@ impl StataExecutor {
         if let Some(timeout) = self.timeout {
             options = options.with_timeout(timeout);
         }
+        options = options.with_log_file(_paths.log.clone());
 
         // Show execution details if VeryVerbose
         if self.verbosity.should_show_execution_details() {
@@ -221,23 +243,15 @@ impl StataExecutor {
             if let Some(timeout) = self.timeout {
                 eprintln!("  Timeout: {}s", timeout.as_secs());
             }
-            eprintln!("  Command: stata-mp -b -q do {}", script.display());
+            // The runner spawns Stata against a wrapper that delegates to the
+            // user's script; show both so `-vv` reflects what actually runs.
+            eprintln!("  Command: stata-mp -b -q do {}", _paths.wrapper.display());
+            eprintln!("  Wraps: {}", abs_script.display());
             eprintln!();
         }
 
-        // Determine log file path
-        // Stata creates: {script_basename}.log in current working directory
-        // e.g., "build/analysis.do" -> "analysis.log" (NOT "build/analysis.log")
-        // When working_dir is set, the log lands in that directory.
-        let log_basename = script
-            .file_stem()
-            .map(|s| PathBuf::from(s).with_extension("log"))
-            .unwrap_or_else(|| script.with_extension("log"));
-        let log_file = if let Some(dir) = working_dir {
-            dir.join(&log_basename)
-        } else {
-            log_basename
-        };
+        // Log file path was computed by RunPaths above; reuse it for streaming.
+        let log_file = _paths.log.clone();
 
         // Start log streaming thread if verbose or interactive
         let stream_handle = if self.verbosity.should_stream_raw() {
@@ -263,8 +277,10 @@ impl StataExecutor {
             None
         };
 
-        // Run Stata
-        let run_result = run_stata(script, options)?;
+        // Run Stata against the wrapper script, not the user's script.
+        // Stata derives the log basename from the script path it's given —
+        // the wrapper has a unique stem so concurrent runs cannot collide.
+        let run_result = run_stata(&_paths.wrapper, options)?;
 
         // Wait for streaming thread to finish
         if let Some(handle) = stream_handle {

--- a/src/executor/run_paths.rs
+++ b/src/executor/run_paths.rs
@@ -1,0 +1,228 @@
+//! Per-invocation wrapper script + log path generation.
+//!
+//! Stata's `-b` mode writes the log to `<script_stem>.log` in the process cwd
+//! and offers no flag to override it. When two stacy processes run scripts
+//! that share a basename from a shared cwd (e.g. `module_a/build.do` and
+//! `module_b/build.do` under Make `-j`), both target `./build.log` and corrupt
+//! it.
+//!
+//! Fix: hand Stata a one-line wrapper `do "<abs_user_script>"` whose own
+//! basename is unique per invocation. Stata's cwd stays as the user intended,
+//! so relative paths in the user's script keep working. The log lands at
+//! `<working_dir>/<unique_stem>.log`.
+
+use crate::error::{Error, Result};
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::TempDir;
+
+/// Counter to break same-process same-nanosecond ties when multiple runs
+/// start in rapid succession (e.g. `--parallel`).
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Files prepared for a single Stata invocation.
+///
+/// Drop cleans up the wrapper file via the owned `TempDir`. The log file
+/// (which lives in the user's working directory, not the tempdir) persists
+/// for post-run inspection.
+pub struct RunPaths {
+    /// Path to the wrapper `.do` file passed to Stata (lives in the tempdir).
+    pub wrapper: PathBuf,
+    /// Path where Stata will write the log file (lives in `working_dir`).
+    pub log: PathBuf,
+    /// RAII handle that deletes the wrapper file when dropped.
+    _wrapper_dir: TempDir,
+}
+
+impl RunPaths {
+    /// Build a wrapper that delegates to the user's script and compute the
+    /// resulting log path.
+    ///
+    /// `user_script` must be absolute and exist. `working_dir` must be
+    /// absolute (its existence is the caller's responsibility — Stata's
+    /// spawn would fail anyway).
+    pub fn prepare(user_script: &Path, working_dir: &Path) -> Result<Self> {
+        debug_assert!(
+            user_script.is_absolute(),
+            "RunPaths::prepare: user_script must be absolute, got {}",
+            user_script.display()
+        );
+        debug_assert!(
+            working_dir.is_absolute(),
+            "RunPaths::prepare: working_dir must be absolute, got {}",
+            working_dir.display()
+        );
+
+        let original_stem = user_script
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| {
+                Error::Config(format!(
+                    "Cannot extract a usable stem from script path: {}",
+                    user_script.display()
+                ))
+            })?;
+
+        let unique_stem = generate_unique_stem(original_stem);
+
+        let wrapper_dir = TempDir::with_prefix("stacy-run-")?;
+        let wrapper = wrapper_dir.path().join(format!("{}.do", unique_stem));
+        let log = working_dir.join(format!("{}.log", unique_stem));
+
+        // Stata compound double-quotes (`"..."') tolerate spaces and embedded
+        // single/double quotes inside the absolute path.
+        let body = format!("do `\"{}\"'\n", user_script.display());
+
+        let mut f = File::create(&wrapper)?;
+        f.write_all(body.as_bytes())?;
+        f.flush()?;
+
+        Ok(RunPaths {
+            wrapper,
+            log,
+            _wrapper_dir: wrapper_dir,
+        })
+    }
+}
+
+/// Build a unique stem for the wrapper/log filenames.
+///
+/// Format: `<sanitized_original>_<pid>_<nanos>_<counter>`. The original stem
+/// is sanitized to `[A-Za-z0-9_-]` so that filename-unsafe characters in the
+/// user's script name don't leak into the wrapper path.
+fn generate_unique_stem(original: &str) -> String {
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    let safe: String = original
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    format!("{}_{}_{}_{}", safe, pid, nanos, counter)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_unique_stem_includes_original() {
+        let stem = generate_unique_stem("analysis");
+        assert!(stem.starts_with("analysis_"), "got: {}", stem);
+    }
+
+    #[test]
+    fn test_unique_stem_sanitizes_special_chars() {
+        let stem = generate_unique_stem("café analysis");
+        // 'é' and ' ' both replaced with '_'; ASCII letters preserved.
+        assert!(stem.starts_with("caf__analysis_"), "got: {}", stem);
+    }
+
+    #[test]
+    fn test_unique_stems_are_unique() {
+        let stems: Vec<_> = (0..200).map(|_| generate_unique_stem("x")).collect();
+        let unique: std::collections::HashSet<_> = stems.iter().collect();
+        assert_eq!(stems.len(), unique.len(), "stems should be pairwise unique");
+    }
+
+    #[test]
+    fn test_prepare_creates_wrapper_with_do_line() {
+        let temp = TempDir::new().unwrap();
+        let script = temp.path().join("build.do");
+        fs::write(&script, "display 1\n").unwrap();
+
+        let paths = RunPaths::prepare(&script, temp.path()).unwrap();
+
+        // Wrapper file exists and contains a single `do` line referencing the abs script.
+        let body = fs::read_to_string(&paths.wrapper).unwrap();
+        assert!(
+            body.contains(&format!("do `\"{}\"'", script.display())),
+            "wrapper body unexpected: {:?}",
+            body
+        );
+
+        // Wrapper basename derives from script's stem.
+        let wrapper_stem = paths.wrapper.file_stem().unwrap().to_str().unwrap();
+        assert!(
+            wrapper_stem.starts_with("build_"),
+            "wrapper stem should start with original stem: {}",
+            wrapper_stem
+        );
+
+        // Log path lives in working_dir with matching stem and .log extension.
+        assert_eq!(paths.log.parent(), Some(temp.path()));
+        assert_eq!(paths.log.extension().and_then(|s| s.to_str()), Some("log"));
+        let log_stem = paths.log.file_stem().unwrap().to_str().unwrap();
+        assert_eq!(log_stem, wrapper_stem);
+    }
+
+    #[test]
+    fn test_prepare_log_path_in_working_dir_not_tempdir() {
+        let working = TempDir::new().unwrap();
+        let script_dir = TempDir::new().unwrap();
+        let script = script_dir.path().join("ana.do");
+        fs::write(&script, "display 1\n").unwrap();
+
+        let paths = RunPaths::prepare(&script, working.path()).unwrap();
+
+        assert!(
+            paths.log.starts_with(working.path()),
+            "log {} must be inside working_dir {}",
+            paths.log.display(),
+            working.path().display()
+        );
+        assert!(
+            !paths.log.starts_with(script_dir.path()),
+            "log must not be inside the script's source directory"
+        );
+    }
+
+    #[test]
+    fn test_wrapper_dir_cleaned_on_drop() {
+        let temp = TempDir::new().unwrap();
+        let script = temp.path().join("build.do");
+        fs::write(&script, "display 1\n").unwrap();
+
+        let wrapper_path = {
+            let paths = RunPaths::prepare(&script, temp.path()).unwrap();
+            assert!(paths.wrapper.exists());
+            paths.wrapper.clone()
+        };
+
+        assert!(
+            !wrapper_path.exists(),
+            "wrapper should be cleaned up when RunPaths drops"
+        );
+    }
+
+    #[test]
+    fn test_prepare_handles_path_with_spaces() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("my project");
+        fs::create_dir(&dir).unwrap();
+        let script = dir.join("build.do");
+        fs::write(&script, "display 1\n").unwrap();
+
+        let paths = RunPaths::prepare(&script, temp.path()).unwrap();
+        let body = fs::read_to_string(&paths.wrapper).unwrap();
+        // Compound quoting must wrap the path so spaces don't split it.
+        assert!(body.contains("`\""), "compound-quote opener missing");
+        assert!(body.contains("\"'"), "compound-quote closer missing");
+        assert!(body.contains(&script.display().to_string()));
+    }
+}

--- a/src/executor/runner.rs
+++ b/src/executor/runner.rs
@@ -45,6 +45,12 @@ pub struct RunOptions<'a> {
     pub working_dir: Option<&'a Path>,
     /// Local ado directories to prepend to S_ADO (resolved to absolute paths).
     pub local_ado_paths: Vec<PathBuf>,
+    /// Precomputed path where Stata will write the log file. When set, the
+    /// runner uses this directly instead of deriving it from the script's stem.
+    /// Callers that pass a wrapper script (see `executor::run_paths`) must set
+    /// this so the log path reflects the wrapper's basename, not the user's
+    /// script.
+    pub log_file: Option<PathBuf>,
 }
 
 impl<'a> RunOptions<'a> {
@@ -57,6 +63,7 @@ impl<'a> RunOptions<'a> {
             allow_global: false,
             working_dir: None,
             local_ado_paths: Vec::new(),
+            log_file: None,
         }
     }
 
@@ -87,6 +94,11 @@ impl<'a> RunOptions<'a> {
 
     pub fn with_local_ado_paths(mut self, paths: Vec<PathBuf>) -> Self {
         self.local_ado_paths = paths;
+        self
+    }
+
+    pub fn with_log_file(mut self, path: PathBuf) -> Self {
+        self.log_file = Some(path);
         self
     }
 }
@@ -187,19 +199,20 @@ pub fn run_stata(script: &Path, options: RunOptions) -> Result<RunResult> {
 
     let duration = start.elapsed();
 
-    // Determine log file path
-    // Stata creates: {script_basename}.log in current working directory
-    // e.g., "build/analysis.do" -> "analysis.log" (NOT "build/analysis.log")
-    // When working_dir is set, the log lands in that directory.
-    let log_basename = script
-        .file_stem()
-        .map(|s| PathBuf::from(s).with_extension("log"))
-        .unwrap_or_else(|| script.with_extension("log"));
-    let log_file = if let Some(dir) = options.working_dir {
-        dir.join(&log_basename)
-    } else {
-        log_basename
-    };
+    // Determine log file path. Callers that want collision-safe parallel runs
+    // pass a precomputed path via `with_log_file` (see `executor::run_paths`).
+    // The fallback below preserves the legacy "{stem}.log in cwd" behavior for
+    // callers that don't (notably the unit tests in this module).
+    let log_file = options.log_file.clone().unwrap_or_else(|| {
+        let log_basename = script
+            .file_stem()
+            .map(|s| PathBuf::from(s).with_extension("log"))
+            .unwrap_or_else(|| script.with_extension("log"));
+        match options.working_dir {
+            Some(dir) => dir.join(&log_basename),
+            None => log_basename,
+        }
+    });
 
     // Extract exit code
     let exit_code = exit_code_from_status(&exit_status);

--- a/src/packages/global_cache.rs
+++ b/src/packages/global_cache.rs
@@ -115,7 +115,7 @@ pub fn build_s_ado(
 
     // Sort packages alphabetically for deterministic S_ADO order
     let mut sorted_packages: Vec<_> = lockfile.packages.iter().collect();
-    sorted_packages.sort_by(|(a, _), (b, _)| a.cmp(b));
+    sorted_packages.sort_by_key(|(a, _)| *a);
 
     for (name, entry) in sorted_packages {
         let pkg_path = package_path(name, &entry.version)?;
@@ -157,7 +157,7 @@ pub fn build_s_ado_for_groups(
 
     // Sort packages alphabetically for deterministic S_ADO order
     let mut sorted_packages: Vec<_> = lockfile.packages.iter().collect();
-    sorted_packages.sort_by(|(a, _), (b, _)| a.cmp(b));
+    sorted_packages.sort_by_key(|(a, _)| *a);
 
     for (name, entry) in sorted_packages {
         if groups.contains(&entry.group.as_str()) {

--- a/src/utils/temp.rs
+++ b/src/utils/temp.rs
@@ -15,10 +15,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// The file is automatically deleted when the struct goes out of scope,
 /// ensuring cleanup even on panic or early return.
 ///
-/// The associated log file (created by Stata) is also cleaned up.
+/// The associated log file (created by Stata) is also cleaned up. Since #20,
+/// the executor wraps every script for collision-safe parallel runs, so the
+/// real log path no longer matches `script.with_extension("log")`. Callers
+/// must record the actual path via [`set_actual_log`](Self::set_actual_log)
+/// after execution; Drop cleans both.
 pub struct TempScript {
     path: PathBuf,
     log_path: PathBuf,
+    actual_log: Option<PathBuf>,
 }
 
 impl TempScript {
@@ -55,7 +60,11 @@ impl TempScript {
         // Ensure file is flushed to disk before Stata reads it
         file.flush()?;
 
-        Ok(Self { path, log_path })
+        Ok(Self {
+            path,
+            log_path,
+            actual_log: None,
+        })
     }
 
     /// Get the path to the temporary script.
@@ -67,6 +76,14 @@ impl TempScript {
     pub fn log_path(&self) -> &Path {
         &self.log_path
     }
+
+    /// Record the real log path produced by execution, so Drop cleans it up.
+    /// Call this with `result.log_file` after running Stata against the script.
+    /// See #20: the wrapper-script disambiguation means the real log lives at
+    /// `<stem>_<pid>_<nanos>_<n>.log`, not at `<stem>.log`.
+    pub fn set_actual_log(&mut self, path: PathBuf) {
+        self.actual_log = Some(path);
+    }
 }
 
 impl Drop for TempScript {
@@ -74,6 +91,11 @@ impl Drop for TempScript {
         // Best-effort cleanup - don't panic if files don't exist
         let _ = fs::remove_file(&self.path);
         let _ = fs::remove_file(&self.log_path);
+        if let Some(ref p) = self.actual_log {
+            if p != &self.log_path {
+                let _ = fs::remove_file(p);
+            }
+        }
     }
 }
 
@@ -148,6 +170,35 @@ mod tests {
         // Both files should be cleaned up
         assert!(!script_path.exists());
         assert!(!log_path.exists());
+    }
+
+    #[test]
+    fn test_temp_script_cleans_actual_log() {
+        // #20: the real log file no longer matches script.with_extension("log").
+        // set_actual_log() must register the real path so Drop cleans it.
+        let temp_dir = TempDir::new().unwrap();
+        let script_path;
+        let actual_log_path;
+
+        {
+            let mut script = TempScript::new("display 1", temp_dir.path()).unwrap();
+            script_path = script.path().to_path_buf();
+
+            // Simulate the wrapper-derived log path produced by RunPaths.
+            actual_log_path = temp_dir.path().join("_stacy_inline_xxx_42_0_0.log");
+            fs::write(&actual_log_path, "log content").unwrap();
+
+            script.set_actual_log(actual_log_path.clone());
+
+            assert!(script_path.exists());
+            assert!(actual_log_path.exists());
+        } // script dropped here
+
+        assert!(!script_path.exists(), "temp .do should be gone");
+        assert!(
+            !actual_log_path.exists(),
+            "actual log should be cleaned up via set_actual_log"
+        );
     }
 
     #[test]

--- a/tests/edge_cases_test.rs
+++ b/tests/edge_cases_test.rs
@@ -5,13 +5,40 @@
 //! - Unicode in paths
 //! - Spaces in filenames
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const STACY_BINARY: &str = env!("CARGO_BIN_EXE_stacy");
 
 fn edge_case_script(name: &str) -> PathBuf {
     PathBuf::from("tests/edge_cases").join(name)
+}
+
+/// Run stacy with `--format=json` and return the log file path it reports.
+///
+/// Since #20, the log no longer lives at `script.with_extension("log")` —
+/// each invocation gets a unique stem. JSON output is the contract for
+/// discovering where Stata wrote the log.
+fn run_and_get_log(script: &Path) -> PathBuf {
+    let output = Command::new(STACY_BINARY)
+        .arg("run")
+        .arg("--format=json")
+        .arg(script)
+        .output()
+        .expect("Failed to execute stacy");
+
+    assert!(
+        output.status.success(),
+        "stacy run failed. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .expect("stacy run --format=json should emit valid JSON");
+    let log = v["log_file"]
+        .as_str()
+        .expect("JSON output must include log_file");
+    PathBuf::from(log)
 }
 
 #[test]
@@ -22,22 +49,9 @@ fn test_spaces_in_filename() {
     // Verify script exists
     assert!(script.exists(), "Test script should exist");
 
-    // Run stacy with script containing spaces
-    let output = Command::new(STACY_BINARY)
-        .arg("run")
-        .arg(&script)
-        .output()
-        .expect("Failed to execute stacy");
+    // Run stacy and ask it where the log landed (#20: not script.with_extension("log") anymore).
+    let log_file = run_and_get_log(&script);
 
-    // Should succeed
-    assert!(
-        output.status.success(),
-        "stacy should handle filenames with spaces. stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    // Check that log file was created
-    let log_file = script.with_extension("log");
     assert!(
         log_file.exists(),
         "Log file should be created: {}",
@@ -53,22 +67,9 @@ fn test_unicode_in_filename() {
     // Verify script exists
     assert!(script.exists(), "Test script should exist");
 
-    // Run stacy with script containing Unicode characters
-    let output = Command::new(STACY_BINARY)
-        .arg("run")
-        .arg(&script)
-        .output()
-        .expect("Failed to execute stacy");
+    // Run stacy and ask it where the log landed (#20).
+    let log_file = run_and_get_log(&script);
 
-    // Should succeed
-    assert!(
-        output.status.success(),
-        "stacy should handle Unicode in filenames. stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    // Check that log file was created
-    let log_file = script.with_extension("log");
     assert!(
         log_file.exists(),
         "Log file should be created: {}",
@@ -84,22 +85,9 @@ fn test_large_log_file() {
     // Verify script exists
     assert!(script.exists(), "Test script should exist");
 
-    // Run stacy with script that generates large log
-    let output = Command::new(STACY_BINARY)
-        .arg("run")
-        .arg(&script)
-        .output()
-        .expect("Failed to execute stacy");
+    // Run stacy and ask it where the log landed (#20).
+    let log_file = run_and_get_log(&script);
 
-    // Should succeed
-    assert!(
-        output.status.success(),
-        "stacy should handle large log files. stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-
-    // Check that log file was created and is reasonably large
-    let log_file = script.with_extension("log");
     assert!(
         log_file.exists(),
         "Log file should be created: {}",

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -2383,6 +2383,99 @@ fn test_run_parallel_verbose_warning() {
         .stderr(predicate::str::contains("verbose").or(predicate::str::contains("ignored")));
 }
 
+// Issue #20 regression: parallel runs of scripts that share a basename
+// must not collide on the log file. Pre-fix, both Stata processes wrote
+// to ./build.log from the shared cwd and the trailer got truncated.
+#[test]
+#[ignore]
+fn test_run_parallel_same_stem_no_log_collision() {
+    let temp = TempDir::new().unwrap();
+    fs::create_dir(temp.path().join("module_a")).unwrap();
+    fs::create_dir(temp.path().join("module_b")).unwrap();
+    // `sleep 2000` (ms) keeps both processes alive concurrently so writes
+    // would interleave on a buggy implementation.
+    fs::write(
+        temp.path().join("module_a/build.do"),
+        "sleep 2000\ndisplay \"a\"\n",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("module_b/build.do"),
+        "sleep 2000\ndisplay \"b\"\n",
+    )
+    .unwrap();
+
+    stacy()
+        .arg("run")
+        .arg("--parallel")
+        .arg("-j2")
+        .arg("-C")
+        .arg(temp.path())
+        .arg(temp.path().join("module_a/build.do"))
+        .arg(temp.path().join("module_b/build.do"))
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("2 passed"))
+        .stderr(predicate::str::contains("incomplete").not());
+}
+
+// Issue #20: each invocation must produce a distinct log file path so
+// concurrent stacy processes from a shared cwd never write to the same file.
+#[test]
+#[ignore]
+fn test_run_log_path_unique_per_invocation() {
+    let temp = TempDir::new().unwrap();
+    fs::write(temp.path().join("test.do"), "display 42\n").unwrap();
+    let script = temp.path().join("test.do");
+
+    let log1 = run_and_extract_log(&script);
+    let log2 = run_and_extract_log(&script);
+
+    assert_ne!(
+        log1, log2,
+        "two runs of the same script must yield distinct log paths"
+    );
+    assert!(
+        std::path::Path::new(&log1).exists(),
+        "log1 should persist: {}",
+        log1
+    );
+    assert!(
+        std::path::Path::new(&log2).exists(),
+        "log2 should persist: {}",
+        log2
+    );
+    // The unique stem embeds the original script's name so logs are recognizable.
+    assert!(
+        log1.contains("test_"),
+        "log1 should embed script stem: {}",
+        log1
+    );
+    assert!(
+        log2.contains("test_"),
+        "log2 should embed script stem: {}",
+        log2
+    );
+}
+
+fn run_and_extract_log(script: &std::path::Path) -> String {
+    let out = stacy()
+        .arg("run")
+        .arg("--format=json")
+        .arg(script)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value =
+        serde_json::from_slice(&out).expect("stacy run --format=json should produce valid JSON");
+    v["log_file"]
+        .as_str()
+        .expect("JSON output must include log_file")
+        .to_string()
+}
+
 // ============================================================================
 // Cache command tests
 // ============================================================================


### PR DESCRIPTION
## Summary

Closes #20.

- Wrap every Stata invocation with a one-line `do "<abs_user_script>"` whose own basename is unique (`<sanitized_stem>_<pid>_<nanos>_<n>`). Stata still writes `<stem>.log` to its cwd, but the stem is now collision-free, so parallel `stacy run` processes from a shared cwd (Make `-j`, Snakemake) no longer corrupt each other's logs
- Wrapper lives in a `tempfile::TempDir` and is auto-cleaned; user's working_dir stays unchanged so scripts using relative paths keep working
- `TempScript::set_actual_log()` so inline (`-c`) and `--trace` runs still delete their log on drop (the wrapper-derived stem no longer matches `script.with_extension("log")`)
- Refactored duplicate log-path computation between `runner.rs` and `executor::mod.rs` into a dedicated `executor::run_paths` module
- Two `#[ignore]`d regression tests: same-stem parallel collision (the bug scenario) and per-invocation uniqueness invariant
- Updated `tests/edge_cases_test.rs` to read the log path from `--format json` instead of guessing `script.with_extension("log")`
- CHANGELOG + JSON-output reference docs updated

## Test plan

- [x] `cargo fmt --check && cargo test && cargo clippy && cargo xtask codegen --check`
- [x] 528 unit + 137 integration tests pass; 8 new unit tests in `executor::run_paths`, 1 in `utils::temp`, 2 new `#[ignore]`d regression tests in `tests/integration_cli.rs`
- [ ] Run regression tests against real Stata: `cargo test --test integration_cli -- --ignored test_run_parallel_same_stem test_run_log_path_unique`