### PR TITLE
feat: runtime check that wrapper version matches binary version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Stata wrappers now verify that the `stacy` binary they invoke is version-compatible (#35). On mismatch, `_stacy_exec` aborts with a clear error and a `stacy_setup, force` hint instead of silently running against a stale binary. The check shells out once per Stata session (cached in `$stacy_version_checked`).
+
 ### Fixed
 
 - Parallel `stacy run` invocations on scripts that share a basename no longer collide on the log file (#20). Each run writes to a uniquely-named log in the working directory (`<stem>_<pid>_<nanos>_<n>.log`), so build orchestrators like Make `-j` and Snakemake can run same-stemmed scripts from a shared cwd safely. The path is reported in JSON output's `log_file` field.

--- a/stata/_stacy_compat.ado
+++ b/stata/_stacy_compat.ado
@@ -1,0 +1,143 @@
+*! _stacy_compat.ado - Wrapper/binary version compatibility check
+*! Part of stacy: Reproducible Stata Workflow Tool
+*! Version: 1.2.0
+*! AUTO-GENERATED - DO NOT EDIT
+*! Regenerate with: cargo xtask codegen
+
+/*
+    Provides:
+      _stacy_compat_version  - returns r(version) with the wrapper version
+      _stacy_check_version   - validates that the stacy binary version is
+                               compatible with these wrappers (>= wrapper
+                               version, same major). Caches success in
+                               $stacy_version_checked.
+      _stacy_semver_cmp      - helper: compares two semver strings, sets
+                               r(cmp) in {-1, 0, 1} and r(same_major).
+
+    The version constant is generated from Cargo.toml's package.version, so
+    the wrapper expectation always matches the binary built from the same
+    source tree. On mismatch, _stacy_check_version errors with a
+    `stacy_setup, force` hint and exits 198.
+*/
+
+program define _stacy_compat_version, rclass
+    version 14.0
+    return local version "1.2.0"
+end
+
+program define _stacy_semver_cmp, rclass
+    version 14.0
+    args a b
+
+    * Strip optional pre-release / build suffix after '-' or '+'.
+    local a_clean = `"`a'"'
+    local dash = strpos(`"`a_clean'"', "-")
+    if `dash' > 0 local a_clean = substr(`"`a_clean'"', 1, `dash' - 1)
+    local plus = strpos(`"`a_clean'"', "+")
+    if `plus' > 0 local a_clean = substr(`"`a_clean'"', 1, `plus' - 1)
+
+    local b_clean = `"`b'"'
+    local dash = strpos(`"`b_clean'"', "-")
+    if `dash' > 0 local b_clean = substr(`"`b_clean'"', 1, `dash' - 1)
+    local plus = strpos(`"`b_clean'"', "+")
+    if `plus' > 0 local b_clean = substr(`"`b_clean'"', 1, `plus' - 1)
+
+    * Tokenize on '.': "1.2.3" -> tokens 1, ., 2, ., 3 at positions 1,2,3,4,5.
+    tokenize "`a_clean'", parse(".")
+    local a_major = real(`"`1'"')
+    local a_minor = real(`"`3'"')
+    local a_patch = real(`"`5'"')
+
+    tokenize "`b_clean'", parse(".")
+    local b_major = real(`"`1'"')
+    local b_minor = real(`"`3'"')
+    local b_patch = real(`"`5'"')
+
+    * Coerce missing components (e.g. "1.2") to 0.
+    if `a_major' >= . local a_major = 0
+    if `a_minor' >= . local a_minor = 0
+    if `a_patch' >= . local a_patch = 0
+    if `b_major' >= . local b_major = 0
+    if `b_minor' >= . local b_minor = 0
+    if `b_patch' >= . local b_patch = 0
+
+    local cmp = 0
+    if `a_major' < `b_major' local cmp = -1
+    else if `a_major' > `b_major' local cmp = 1
+    else if `a_minor' < `b_minor' local cmp = -1
+    else if `a_minor' > `b_minor' local cmp = 1
+    else if `a_patch' < `b_patch' local cmp = -1
+    else if `a_patch' > `b_patch' local cmp = 1
+
+    return scalar cmp = `cmp'
+    return scalar same_major = (`a_major' == `b_major')
+end
+
+program define _stacy_check_version, rclass
+    version 14.0
+    args binary
+
+    * Cached for the session - skip if already verified.
+    if "$stacy_version_checked" == "1" {
+        exit 0
+    }
+
+    local expected "1.2.0"
+
+    * Capture `<binary> --version` output.
+    tempfile ver_out
+    capture quietly shell "`binary'" --version > "`ver_out'" 2>&1
+    local shell_rc = _rc
+
+    tempname fh
+    local raw ""
+    capture file open `fh' using "`ver_out'", read text
+    if _rc == 0 {
+        file read `fh' raw
+        file close `fh'
+    }
+
+    if `shell_rc' != 0 | `"`raw'"' == "" {
+        di as error "stacy: could not determine binary version from `binary' --version"
+        di as error "Run {bf:stacy_setup, force} to (re)install the binary."
+        exit 198
+    }
+
+    * Output is typically `stacy X.Y.Z' - take the second whitespace token.
+    local raw_trim = strtrim(`"`raw'"')
+    tokenize `"`raw_trim'"'
+    local actual `"`2'"'
+    if `"`actual'"' == "" {
+        local actual `"`1'"'
+    }
+    * Strip leading 'v' if present (defensive; clap default does not emit it).
+    if substr(`"`actual'"', 1, 1) == "v" {
+        local actual = substr(`"`actual'"', 2, .)
+    }
+
+    if `"`actual'"' == "" {
+        di as error "stacy: could not parse binary version from output: `raw'"
+        di as error "Run {bf:stacy_setup, force} to (re)install the binary."
+        exit 198
+    }
+
+    _stacy_semver_cmp `"`actual'"' `"`expected'"'
+    local cmp = r(cmp)
+    local same_major = r(same_major)
+
+    if `same_major' == 0 {
+        di as error "stacy: binary version `actual' is from a different major version than the Stata wrappers (`expected')."
+        di as error "Run {bf:stacy_setup, force} to install a matching binary."
+        exit 198
+    }
+    if `cmp' < 0 {
+        di as error "stacy: binary version `actual' is older than the Stata wrappers expect (>= `expected', same major)."
+        di as error "Run {bf:stacy_setup, force} to install a matching binary."
+        exit 198
+    }
+
+    * Cache success for the rest of the session.
+    global stacy_version_checked "1"
+    return local actual `"`actual'"'
+    return local expected `"`expected'"'
+end

--- a/stata/_stacy_exec.ado
+++ b/stata/_stacy_exec.ado
@@ -1,6 +1,6 @@
 *! _stacy_exec.ado - Execute stacy command and capture Stata-native output
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.0.1
+*! Version: 1.2.0
 
 /*
     Execute a stacy CLI command and capture Stata-native output.
@@ -35,6 +35,11 @@ program define _stacy_exec, rclass
         exit 601
     }
     local binary `"`r(binary)'"'
+
+    * Verify the binary's version is compatible with these wrappers.
+    * Cached in $stacy_version_checked, so the shell-out only happens once
+    * per Stata session even when many _stacy_exec calls follow.
+    _stacy_check_version `"`binary'"'
 
     * Create temp file for Stata output
     tempfile stata_out

--- a/stata/_stacy_find_binary.ado
+++ b/stata/_stacy_find_binary.ado
@@ -1,6 +1,6 @@
 *! _stacy_find_binary.ado - Locate stacy binary
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.0.1
+*! Version: 1.2.0
 
 /*
     Find the stacy binary path.

--- a/stata/stacy_setup.ado
+++ b/stata/stacy_setup.ado
@@ -1,6 +1,6 @@
 *! stacy_setup.ado - Download and install stacy binary
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.0.1
+*! Version: 1.2.0
 
 /*
     Download and install the stacy binary from GitHub releases.
@@ -111,9 +111,11 @@ program define stacy_setup, rclass
         exit 198
     }
 
-    * Determine version
+    * Determine version (default: the version these wrappers were generated
+    * against, so `stacy_setup, force` always installs a binary that matches).
     if "`version'" == "" {
-        local version "v1.0.1"
+        _stacy_compat_version
+        local version "v`r(version)'"
     }
 
     * Construct download URL

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -2458,6 +2458,77 @@ fn test_run_log_path_unique_per_invocation() {
     );
 }
 
+// Issue #35 regression: when the binary stacy --version reports a version
+// older than the Stata wrappers expect, _stacy_check_version must fail fast
+// with a `stacy_setup, force` hint instead of letting the wrappers silently
+// run against a mismatched binary.
+//
+// This test shells out to Stata; run with: cargo test test_version_check -- --ignored
+#[test]
+#[ignore]
+fn test_version_check_rejects_stale_binary() {
+    let temp = TempDir::new().unwrap();
+
+    // Shim that pretends to be an old stacy: --version prints "stacy 0.0.1".
+    let shim = temp.path().join("stacy_shim");
+    fs::write(
+        &shim,
+        "#!/usr/bin/env bash\nif [ \"$1\" = \"--version\" ]; then\n  echo 'stacy 0.0.1'\n  exit 0\nfi\nexit 1\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perm = fs::metadata(&shim).unwrap().permissions();
+        perm.set_mode(0o755);
+        fs::set_permissions(&shim, perm).unwrap();
+    }
+
+    let stata_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("stata");
+    let do_path = temp.path().join("check.do");
+    let do_body = format!(
+        "adopath ++ \"{stata}\"\nglobal stacy_binary \"{shim}\"\ncapture noisily _stacy_exec doctor\ndi \"_rc=\" _rc\n",
+        stata = stata_dir.display(),
+        shim = shim.display(),
+    );
+    fs::write(&do_path, do_body).unwrap();
+
+    // Run the .do via stata-mp (or whatever the user has on PATH). Skip the
+    // test gracefully if no Stata binary is found.
+    let path_var = std::env::var_os("PATH").unwrap_or_default();
+    let stata = ["stata-mp", "stata-se", "stata"].iter().find_map(|name| {
+        std::env::split_paths(&path_var)
+            .map(|p| p.join(name))
+            .find(|p| p.is_file())
+    });
+    let Some(stata) = stata else {
+        eprintln!("skipping: no stata binary found on PATH");
+        return;
+    };
+
+    let out = std::process::Command::new(stata)
+        .arg("-b")
+        .arg("do")
+        .arg(&do_path)
+        .current_dir(temp.path())
+        .output()
+        .expect("failed to run stata");
+    // Stata batch mode writes a log next to the .do file.
+    let log_path = temp.path().join("check.log");
+    let log = fs::read_to_string(&log_path).unwrap_or_default();
+    let combined = format!(
+        "stdout:\n{}\nstderr:\n{}\nlog:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+        log,
+    );
+    assert!(
+        combined.contains("0.0.1") && combined.contains("stacy_setup, force"),
+        "expected version-mismatch error mentioning 0.0.1 and `stacy_setup, force`, got:\n{}",
+        combined
+    );
+}
+
 fn run_and_extract_log(script: &std::path::Path) -> String {
     let out = stacy()
         .arg("run")

--- a/tests/test_schema_conformance.rs
+++ b/tests/test_schema_conformance.rs
@@ -623,6 +623,108 @@ fn test_init_schema_has_interactive_not_yes() {
     );
 }
 
+// =============================================================================
+// Wrapper/binary version-compat guard (issue #35)
+// =============================================================================
+
+/// `_stacy_compat.ado` is generated from `Cargo.toml`'s `package.version`.
+/// If a release bumps Cargo.toml without re-running `cargo xtask codegen`,
+/// the wrappers and binary disagree at runtime. This test (plus the existing
+/// codegen --check in CI) makes that drift impossible to merge.
+#[test]
+fn test_compat_ado_version_matches_cargo_toml() {
+    let cargo_toml = fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+        .expect("Failed to read Cargo.toml");
+    let parsed: toml::Value = toml::from_str(&cargo_toml).expect("Failed to parse Cargo.toml");
+    let pkg_version = parsed["package"]["version"]
+        .as_str()
+        .expect("Cargo.toml missing package.version");
+
+    let compat_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("stata/_stacy_compat.ado");
+    let compat = fs::read_to_string(&compat_path).expect("Failed to read _stacy_compat.ado");
+
+    // Header line.
+    assert!(
+        compat.contains(&format!("*! Version: {}", pkg_version)),
+        "_stacy_compat.ado header version does not match Cargo.toml ({}). \
+         Run `cargo xtask codegen`.",
+        pkg_version
+    );
+
+    // Constant returned by _stacy_compat_version.
+    assert!(
+        compat.contains(&format!("return local version \"{}\"", pkg_version)),
+        "_stacy_compat.ado _stacy_compat_version constant does not match \
+         Cargo.toml ({}). Run `cargo xtask codegen`.",
+        pkg_version
+    );
+
+    // The min-compat constant inside _stacy_check_version.
+    assert!(
+        compat.contains(&format!("local expected \"{}\"", pkg_version)),
+        "_stacy_compat.ado expected-version constant does not match \
+         Cargo.toml ({}). Run `cargo xtask codegen`.",
+        pkg_version
+    );
+}
+
+/// Hand-maintained wrappers must keep their `*! Version:` header in lockstep
+/// with `Cargo.toml` — `cargo xtask codegen` rewrites the line. If this test
+/// ever fails, run codegen.
+#[test]
+fn test_hand_maintained_ado_headers_match_cargo_toml() {
+    let cargo_toml = fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+        .expect("Failed to read Cargo.toml");
+    let parsed: toml::Value = toml::from_str(&cargo_toml).expect("Failed to parse Cargo.toml");
+    let pkg_version = parsed["package"]["version"]
+        .as_str()
+        .expect("Cargo.toml missing package.version");
+
+    let stata_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("stata");
+    for file in [
+        "_stacy_exec.ado",
+        "_stacy_find_binary.ado",
+        "stacy_setup.ado",
+    ] {
+        let content = fs::read_to_string(stata_dir.join(file))
+            .unwrap_or_else(|_| panic!("Failed to read {}", file));
+        assert!(
+            content.contains(&format!("*! Version: {}", pkg_version)),
+            "{} *! Version: header does not match Cargo.toml ({}). \
+             Run `cargo xtask codegen`.",
+            file,
+            pkg_version
+        );
+    }
+}
+
+/// `_stacy_exec` must call `_stacy_check_version` so a stale binary against
+/// newer wrappers (or vice versa) fails fast instead of silently mismatching.
+#[test]
+fn test_stacy_exec_calls_version_check() {
+    let exec =
+        fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("stata/_stacy_exec.ado"))
+            .expect("Failed to read _stacy_exec.ado");
+    assert!(
+        exec.contains("_stacy_check_version"),
+        "_stacy_exec.ado must call _stacy_check_version after _stacy_find_binary"
+    );
+}
+
+/// `stacy_setup` must default to the wrapper version (not a hard-coded
+/// literal), so `stacy_setup, force` actually fixes the mismatch hinted at
+/// in the version-check error.
+#[test]
+fn test_stacy_setup_uses_compat_version_default() {
+    let setup =
+        fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("stata/stacy_setup.ado"))
+            .expect("Failed to read stacy_setup.ado");
+    assert!(
+        setup.contains("_stacy_compat_version"),
+        "stacy_setup.ado must call _stacy_compat_version for its default install version"
+    );
+}
+
 #[test]
 fn test_doctor_schema_has_refresh() {
     let schema = load_schema();

--- a/xtask/src/codegen.rs
+++ b/xtask/src/codegen.rs
@@ -28,6 +28,32 @@ fn package_version() -> Result<String> {
         .context("Missing package.version in Cargo.toml")
 }
 
+/// Hand-maintained .ado files whose `*! Version:` header is kept in sync with
+/// `Cargo.toml` by codegen. The bodies remain hand-edited.
+const HAND_MAINTAINED_VERSIONED_ADOS: &[&str] = &[
+    "_stacy_exec.ado",
+    "_stacy_find_binary.ado",
+    "stacy_setup.ado",
+];
+
+/// Replace the `*! Version: ...` header line in a hand-maintained .ado file
+/// with the current package version. Other lines are preserved verbatim.
+fn rewrite_version_header(content: &str, version: &str) -> String {
+    let mut out = String::with_capacity(content.len());
+    for line in content.split_inclusive('\n') {
+        let stripped = line.strip_suffix('\n').unwrap_or(line);
+        if stripped.starts_with("*! Version: ") {
+            out.push_str(&format!("*! Version: {}", version));
+            if line.ends_with('\n') {
+                out.push('\n');
+            }
+        } else {
+            out.push_str(line);
+        }
+    }
+    out
+}
+
 /// Run code generation
 pub fn run(check: bool, verbose: bool) -> Result<()> {
     let schema_path = project_root().join("schema/commands.toml");
@@ -68,6 +94,21 @@ pub fn run(check: bool, verbose: bool) -> Result<()> {
     // Generate main stacy.sthlp
     let main_sthlp = generate_main_sthlp(&schema)?;
     generated_files.push((stata_dir.join("stacy.sthlp"), main_sthlp));
+
+    // Generate wrapper/binary version-compatibility helper
+    let compat_ado = generate_compat_ado(&version);
+    generated_files.push((stata_dir.join("_stacy_compat.ado"), compat_ado));
+
+    // Bump the *! Version: header in hand-maintained .ado files so they stay
+    // in lockstep with the binary. Bodies are still hand-edited; only the
+    // version line is rewritten by codegen.
+    for file in HAND_MAINTAINED_VERSIONED_ADOS {
+        let path = stata_dir.join(file);
+        let existing = std::fs::read_to_string(&path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        let updated = rewrite_version_header(&existing, &version);
+        generated_files.push((path, updated));
+    }
 
     // Generate documentation markdown files
     println!("Generating documentation...");
@@ -1087,6 +1128,168 @@ fn generate_citation_cff(version: &str) -> Result<String> {
 
 /// Extract release date for a version from CHANGELOG.md
 ///
+// =============================================================================
+// COMPAT (VERSION CHECK) GENERATION
+// =============================================================================
+
+/// Generate `stata/_stacy_compat.ado`, which provides the runtime check that
+/// the `stacy` binary's version is compatible with the wrappers.
+///
+/// Compatibility rule (matches issue #35): binary version `>=` wrapper version
+/// AND same major. Older binary or cross-major fails with a `stacy_setup, force`
+/// hint. Success is cached in `$stacy_version_checked` for the Stata session.
+///
+/// The version constant comes from `Cargo.toml`'s `package.version`, so the
+/// wrapper expectation always matches the binary built from the same source.
+fn generate_compat_ado(version: &str) -> String {
+    format!(
+        r#"*! _stacy_compat.ado - Wrapper/binary version compatibility check
+*! Part of stacy: Reproducible Stata Workflow Tool
+*! Version: {version}
+*! AUTO-GENERATED - DO NOT EDIT
+*! Regenerate with: cargo xtask codegen
+
+/*
+    Provides:
+      _stacy_compat_version  - returns r(version) with the wrapper version
+      _stacy_check_version   - validates that the stacy binary version is
+                               compatible with these wrappers (>= wrapper
+                               version, same major). Caches success in
+                               $stacy_version_checked.
+      _stacy_semver_cmp      - helper: compares two semver strings, sets
+                               r(cmp) in {{-1, 0, 1}} and r(same_major).
+
+    The version constant is generated from Cargo.toml's package.version, so
+    the wrapper expectation always matches the binary built from the same
+    source tree. On mismatch, _stacy_check_version errors with a
+    `stacy_setup, force` hint and exits 198.
+*/
+
+program define _stacy_compat_version, rclass
+    version 14.0
+    return local version "{version}"
+end
+
+program define _stacy_semver_cmp, rclass
+    version 14.0
+    args a b
+
+    * Strip optional pre-release / build suffix after '-' or '+'.
+    local a_clean = `"`a'"'
+    local dash = strpos(`"`a_clean'"', "-")
+    if `dash' > 0 local a_clean = substr(`"`a_clean'"', 1, `dash' - 1)
+    local plus = strpos(`"`a_clean'"', "+")
+    if `plus' > 0 local a_clean = substr(`"`a_clean'"', 1, `plus' - 1)
+
+    local b_clean = `"`b'"'
+    local dash = strpos(`"`b_clean'"', "-")
+    if `dash' > 0 local b_clean = substr(`"`b_clean'"', 1, `dash' - 1)
+    local plus = strpos(`"`b_clean'"', "+")
+    if `plus' > 0 local b_clean = substr(`"`b_clean'"', 1, `plus' - 1)
+
+    * Tokenize on '.': "1.2.3" -> tokens 1, ., 2, ., 3 at positions 1,2,3,4,5.
+    tokenize "`a_clean'", parse(".")
+    local a_major = real(`"`1'"')
+    local a_minor = real(`"`3'"')
+    local a_patch = real(`"`5'"')
+
+    tokenize "`b_clean'", parse(".")
+    local b_major = real(`"`1'"')
+    local b_minor = real(`"`3'"')
+    local b_patch = real(`"`5'"')
+
+    * Coerce missing components (e.g. "1.2") to 0.
+    if `a_major' >= . local a_major = 0
+    if `a_minor' >= . local a_minor = 0
+    if `a_patch' >= . local a_patch = 0
+    if `b_major' >= . local b_major = 0
+    if `b_minor' >= . local b_minor = 0
+    if `b_patch' >= . local b_patch = 0
+
+    local cmp = 0
+    if `a_major' < `b_major' local cmp = -1
+    else if `a_major' > `b_major' local cmp = 1
+    else if `a_minor' < `b_minor' local cmp = -1
+    else if `a_minor' > `b_minor' local cmp = 1
+    else if `a_patch' < `b_patch' local cmp = -1
+    else if `a_patch' > `b_patch' local cmp = 1
+
+    return scalar cmp = `cmp'
+    return scalar same_major = (`a_major' == `b_major')
+end
+
+program define _stacy_check_version, rclass
+    version 14.0
+    args binary
+
+    * Cached for the session - skip if already verified.
+    if "$stacy_version_checked" == "1" {{
+        exit 0
+    }}
+
+    local expected "{version}"
+
+    * Capture `<binary> --version` output.
+    tempfile ver_out
+    capture quietly shell "`binary'" --version > "`ver_out'" 2>&1
+    local shell_rc = _rc
+
+    tempname fh
+    local raw ""
+    capture file open `fh' using "`ver_out'", read text
+    if _rc == 0 {{
+        file read `fh' raw
+        file close `fh'
+    }}
+
+    if `shell_rc' != 0 | `"`raw'"' == "" {{
+        di as error "stacy: could not determine binary version from `binary' --version"
+        di as error "Run {{bf:stacy_setup, force}} to (re)install the binary."
+        exit 198
+    }}
+
+    * Output is typically `stacy X.Y.Z' - take the second whitespace token.
+    local raw_trim = strtrim(`"`raw'"')
+    tokenize `"`raw_trim'"'
+    local actual `"`2'"'
+    if `"`actual'"' == "" {{
+        local actual `"`1'"'
+    }}
+    * Strip leading 'v' if present (defensive; clap default does not emit it).
+    if substr(`"`actual'"', 1, 1) == "v" {{
+        local actual = substr(`"`actual'"', 2, .)
+    }}
+
+    if `"`actual'"' == "" {{
+        di as error "stacy: could not parse binary version from output: `raw'"
+        di as error "Run {{bf:stacy_setup, force}} to (re)install the binary."
+        exit 198
+    }}
+
+    _stacy_semver_cmp `"`actual'"' `"`expected'"'
+    local cmp = r(cmp)
+    local same_major = r(same_major)
+
+    if `same_major' == 0 {{
+        di as error "stacy: binary version `actual' is from a different major version than the Stata wrappers (`expected')."
+        di as error "Run {{bf:stacy_setup, force}} to install a matching binary."
+        exit 198
+    }}
+    if `cmp' < 0 {{
+        di as error "stacy: binary version `actual' is older than the Stata wrappers expect (>= `expected', same major)."
+        di as error "Run {{bf:stacy_setup, force}} to install a matching binary."
+        exit 198
+    }}
+
+    * Cache success for the rest of the session.
+    global stacy_version_checked "1"
+    return local actual `"`actual'"'
+    return local expected `"`expected'"'
+end
+"#
+    )
+}
+
 /// Looks for lines like: ## [1.1.0] - 2026-02-22
 fn extract_changelog_date(version: &str) -> Option<String> {
     let changelog_path = project_root().join("CHANGELOG.md");


### PR DESCRIPTION
## Summary

Closes #35.

Stata wrappers now verify the stacy binary they invoke is version-compatible. On mismatch, `_stacy_exec` aborts with a clear error and a `stacy_setup, force` hint — pre-fix, a stale binary against newer wrappers (or vice versa) silently mismatched: flags got rejected or, worse, accepted with different semantics.

- New generated `stata/_stacy_compat.ado` defines `_stacy_compat_version`, `_stacy_check_version`, and a `_stacy_semver_cmp` helper. Compatibility rule: binary `>=` wrapper expected, same major. Success cached in `$stacy_version_checked` so the shell-out happens once per Stata session even when many `_stacy_exec` calls follow.
- Single source of truth: `Cargo.toml`'s `package.version`. `cargo xtask codegen` now also rewrites the `*! Version:` header in hand-maintained `_stacy_exec.ado`, `_stacy_find_binary.ado`, and `stacy_setup.ado`, so wrappers and binary always agree (the existing `--check` mode in CI catches forgotten regen).
- `stacy_setup` default install version is now derived from `_stacy_compat_version` instead of a hard-coded `v1.0.1` literal — so `stacy_setup, force` always installs the binary the wrappers expect, which is what the error hint promises.
- Four new conformance tests guard sync: compat constants match `Cargo.toml`, hand-maintained headers match, `_stacy_exec` calls the version check, `stacy_setup` uses the dynamic default.
- One `#[ignore]`d integration test runs a shim binary that fakes `stacy 0.0.1` for `--version`, drives `_stacy_exec` from Stata, and asserts the mismatch error mentions `stacy_setup, force`.

## Test plan

- [x] `cargo fmt --check && cargo test && cargo clippy && cargo xtask codegen --check`
- [x] 529 unit + 137 integration + 26 conformance tests pass; 4 new conformance tests in `tests/test_schema_conformance.rs`
- [ ] Run regression test against real Stata: `cargo test --test integration_cli test_version_check_rejects_stale_binary -- --ignored`