### PR TITLE
chore: clean up clippy 1.91 lints

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -56,7 +56,7 @@ fn bench_error_extraction(c: &mut Criterion) {
                 if line.starts_with("r(") && line.ends_with(");") {
                     let code_str = &line[2..line.len() - 2];
                     let _code: Result<u32, _> = code_str.parse();
-                    black_box(_code);
+                    let _ = black_box(_code);
                 }
             }
         });

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -217,7 +217,7 @@ mod tests {
 
     #[test]
     fn test_package_info_sorting() {
-        let mut packages = vec![
+        let mut packages = [
             PackageInfo {
                 name: "zebra".to_string(),
                 version: "1.0".to_string(),

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_outdated_info_sorting() {
-        let mut packages = vec![
+        let mut packages = [
             OutdatedInfo {
                 name: "zebra".to_string(),
                 current: "1.0".to_string(),

--- a/src/executor/binary.rs
+++ b/src/executor/binary.rs
@@ -306,7 +306,6 @@ mod tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn test_macos_locations_defined() {
-        assert!(!MACOS_APP_LOCATIONS.is_empty());
         // Should include StataNow path
         assert!(MACOS_APP_LOCATIONS.iter().any(|p| p.contains("StataNow")));
     }
@@ -314,7 +313,6 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_linux_locations_defined() {
-        assert!(!LINUX_LOCATIONS.is_empty());
         // Should include stata18 path
         assert!(LINUX_LOCATIONS.iter().any(|p| p.contains("stata18")));
     }
@@ -322,7 +320,6 @@ mod tests {
     #[test]
     #[cfg(target_os = "windows")]
     fn test_windows_locations_defined() {
-        assert!(!WINDOWS_LOCATIONS.is_empty());
         // Should include StataNow path
         assert!(WINDOWS_LOCATIONS.iter().any(|p| p.contains("StataNow")));
         // Should include both 64-bit and 32-bit locations

--- a/src/executor/log_reader.rs
+++ b/src/executor/log_reader.rs
@@ -607,7 +607,7 @@ end of do-file\n";
         let mut temp = NamedTempFile::new()?;
         writeln!(temp, ". display \"hello\"")?;
         writeln!(temp, "hello")?;
-        writeln!(temp, "")?;
+        writeln!(temp)?;
         writeln!(temp, "end of do-file")?;
         temp.flush()?;
 
@@ -617,9 +617,9 @@ end of do-file\n";
         let mut temp_fail = NamedTempFile::new()?;
         writeln!(temp_fail, ". invalid command")?;
         writeln!(temp_fail, "unrecognized command")?;
-        writeln!(temp_fail, "")?;
+        writeln!(temp_fail)?;
         writeln!(temp_fail, "end of do-file")?;
-        writeln!(temp_fail, "")?;
+        writeln!(temp_fail)?;
         writeln!(temp_fail, "r(199);")?;
         temp_fail.flush()?;
 

--- a/src/packages/github.rs
+++ b/src/packages/github.rs
@@ -615,8 +615,6 @@ mod tests {
     #[test]
     fn test_synthesize_manifest_from_tree_response() {
         // Test the tree filtering logic by simulating what synthesize_manifest would find
-        use crate::packages::pkg_parser::FileType;
-
         let stata_extensions = ["ado", "sthlp", "hlp", "dlg", "mlib", "mata"];
         let name = "mypkg";
 

--- a/src/utils/date.rs
+++ b/src/utils/date.rs
@@ -68,7 +68,7 @@ mod tests {
 
         // Year should be reasonable (2020-2099)
         let year: u32 = result[..4].parse().unwrap();
-        assert!(year >= 2020 && year <= 2099);
+        assert!((2020..=2099).contains(&year));
 
         // Month 01-12
         let month: u32 = result[4..6].parse().unwrap();

--- a/tests/executor_test.rs
+++ b/tests/executor_test.rs
@@ -50,7 +50,7 @@ fn test_syntax_error_script() {
 
     // But our parser should detect the error
     let errors = parse_log_for_errors(&result.log_file).expect("Failed to parse log");
-    assert!(errors.len() > 0, "Syntax error script should have errors");
+    assert!(!errors.is_empty(), "Syntax error script should have errors");
 
     // Should detect r(199)
     let has_199 = errors.iter().any(|e| e.r_code() == Some(199));
@@ -70,7 +70,7 @@ fn test_file_not_found_script() {
 
     // Parse should detect file error
     let errors = parse_log_for_errors(&result.log_file).expect("Failed to parse log");
-    assert!(errors.len() > 0, "File error script should have errors");
+    assert!(!errors.is_empty(), "File error script should have errors");
 
     // Should detect r(601)
     let has_601 = errors.iter().any(|e| e.r_code() == Some(601));

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -2,14 +2,14 @@
 //!
 //! Tests the complete CLI workflow from init to run.
 
-use assert_cmd::Command;
+use assert_cmd::{cargo_bin_cmd, Command};
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
 
 /// Get the stacy binary
 fn stacy() -> Command {
-    Command::cargo_bin("stacy").unwrap()
+    cargo_bin_cmd!("stacy")
 }
 
 #[test]

--- a/tests/test_review_regression.rs
+++ b/tests/test_review_regression.rs
@@ -4,7 +4,7 @@
 //! validating fixes for cache integrity (C1), error honesty (C4),
 //! S_ADO isolation (NEW-1), deterministic ordering (M1), and --Break-- detection (C6).
 
-use assert_cmd::Command;
+use assert_cmd::{cargo_bin_cmd, Command};
 use predicates::prelude::*;
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -23,7 +23,7 @@ fn cache_packages_dir(root: &Path) -> PathBuf {
 
 /// Get the stacy binary for testing.
 fn stacy() -> Command {
-    Command::cargo_bin("stacy").unwrap()
+    cargo_bin_cmd!("stacy")
 }
 
 // ============================================================================

--- a/tests/test_schema_conformance.rs
+++ b/tests/test_schema_conformance.rs
@@ -838,7 +838,7 @@ fn read_all_generated_ado_files() -> Vec<(String, String)> {
     for entry in fs::read_dir(&stata_dir).expect("Failed to read stata directory") {
         let entry = entry.expect("Failed to read directory entry");
         let path = entry.path();
-        if path.extension().map_or(false, |e| e == "ado") {
+        if path.extension().is_some_and(|e| e == "ado") {
             let name = path.file_name().unwrap().to_string_lossy().to_string();
             let content = fs::read_to_string(&path).expect("Failed to read ado file");
             // Only check auto-generated files

--- a/tests/test_signal_handling.rs
+++ b/tests/test_signal_handling.rs
@@ -1,7 +1,6 @@
 /// Tests for signal handling (SIGINT, SIGTERM, SIGKILL)
 ///
 /// Verifies that stacy correctly handles process interruption
-use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
@@ -79,7 +78,7 @@ fn test_background_kill() {
     // 3. Check exit code
 
     let mut child = Command::new("./target/debug/stacy")
-        .args(&["run", "tests/log-analysis/07_infinite_loop.do", "--quiet"])
+        .args(["run", "tests/log-analysis/07_infinite_loop.do", "--quiet"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -91,7 +90,6 @@ fn test_background_kill() {
     // Kill with SIGTERM
     #[cfg(unix)]
     {
-        use std::os::unix::process::CommandExt;
         unsafe {
             libc::kill(child.id() as i32, libc::SIGTERM);
         }

--- a/tests/test_stata_output.rs
+++ b/tests/test_stata_output.rs
@@ -2,14 +2,14 @@
 //!
 //! Verifies that all commands produce valid Stata syntax that can be directly executed.
 
-use assert_cmd::Command;
+use assert_cmd::{cargo_bin_cmd, Command};
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
 
 /// Get the stacy binary
 fn stacy() -> Command {
-    Command::cargo_bin("stacy").unwrap()
+    cargo_bin_cmd!("stacy")
 }
 
 // =============================================================================
@@ -322,7 +322,7 @@ fn test_stata_booleans_are_0_or_1() {
 
     // Check boolean fields specifically
     if let Some(ready_line) = stdout.lines().find(|l| l.contains("stacy_ready")) {
-        let value = ready_line.split('=').last().unwrap().trim();
+        let value = ready_line.split('=').next_back().unwrap().trim();
         assert!(
             value == "0" || value == "1",
             "Boolean should be 0 or 1: {}",


### PR DESCRIPTION
## Summary

Gets `cargo clippy --all-targets -- -D warnings` back to green on Rust 1.91 — 18 lints across `src/`, `tests/`, and `benches/`. None affect behavior; this is purely the release-checklist clippy step.

Notable categories:

- **Deprecated `assert_cmd::Command::cargo_bin`** — migrated three test files to `cargo_bin_cmd!("stacy")` (assert_cmd 2.1).
- **Stata-version-induced `clippy::const_is_empty`** — dropped tautological `assert!(!CONST.is_empty())` lines in three platform-gated `binary.rs` tests (the next assertion in each test would have failed first if the list were empty).
- **`writeln!(f, "")` → `writeln!(f)`**, **`map_or(false, ..)` → `is_some_and`**, **`vec![] → []`** for fixed-size test data, **`Iterator::last` → `next_back`** on a `DoubleEndedIterator`, etc.

Full per-file change list is in the commit message.

## Test plan

- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 529 unit + 137 integration + 28 conformance + 26 stata-output tests pass
- [x] `cargo xtask codegen --check` — clean