### PR TITLE
chore: bump sha2 0.10 -> 0.11; fix hex formatting + criterion fallout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,11 +123,11 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -278,10 +278,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -354,12 +360,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -382,11 +387,12 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -542,16 +548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +598,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +641,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1553,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1619,6 +1630,7 @@ dependencies = [
  "criterion",
  "dialoguer",
  "dirs",
+ "hex",
  "indicatif",
  "lazy_static",
  "libc",
@@ -1889,9 +1901,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -1940,12 +1952,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,8 @@ indicatif = "0.18"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 
 # Cryptographic hashing for checksums
-sha2 = "0.10"
+sha2 = "0.11"
+hex = "0.4"
 dirs = "6.0.0"
 dialoguer = "0.12.0"
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,5 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use std::fs;
+use std::hint::black_box;
 use std::path::Path;
 
 /// Benchmark log parsing performance

--- a/src/cache/hash.rs
+++ b/src/cache/hash.rs
@@ -22,7 +22,7 @@ pub fn hash_file(path: &Path) -> Result<String> {
     hasher.update(&content);
     let result = hasher.finalize();
 
-    Ok(format!("{:x}", result))
+    Ok(hex::encode(result))
 }
 
 /// Compute SHA256 hash of a string
@@ -30,7 +30,7 @@ pub fn hash_string(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
     let result = hasher.finalize();
-    format!("{:x}", result)
+    hex::encode(result)
 }
 
 /// Hash a script and all its dependencies, returning a map of paths to hashes
@@ -80,7 +80,7 @@ impl DependencyHashes {
         }
 
         let result = hasher.finalize();
-        format!("{:x}", result)
+        hex::encode(result)
     }
 }
 

--- a/src/packages/ssc.rs
+++ b/src/packages/ssc.rs
@@ -261,7 +261,7 @@ pub fn calculate_sha256(data: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(data);
     let result = hasher.finalize();
-    format!("{:x}", result)
+    hex::encode(result)
 }
 
 /// Calculate combined checksum from multiple checksums
@@ -275,7 +275,7 @@ pub fn calculate_combined_checksum(checksums: &[String]) -> String {
         hasher.update(checksum.as_bytes());
     }
     let result = hasher.finalize();
-    format!("{:x}", result)
+    hex::encode(result)
 }
 
 /// Check if an error is a connection/network error (vs. 404, etc.)

--- a/tests/test_review_regression.rs
+++ b/tests/test_review_regression.rs
@@ -34,7 +34,7 @@ fn stacy() -> Command {
 fn sha256_hex(data: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(data);
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }
 
 /// Compute combined checksum from individual file checksums
@@ -46,7 +46,7 @@ fn combined_checksum(checksums: &[String]) -> String {
     for cs in &sorted {
         hasher.update(cs.as_bytes());
     }
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }
 
 /// Set up a temp project directory with stacy.toml and stacy.lock,


### PR DESCRIPTION
## Summary

Closes #31. Replaces dependabot's #31 (which was failing CI because the bump alone doesn't compile).

`sha2 0.11` returns `Output<Sha256>` as a `hybrid_array::Array` that no longer impls `LowerHex`, so `format!(\"{:x}\", hasher.finalize())` errors with `E0277: the trait bound LowerHex is not satisfied`. Fixed by switching to `hex::encode(...)` at all seven call sites:

- `src/cache/hash.rs` (3): \`hash_file\`, \`hash_string\`, \`combined_hash\`
- `src/packages/ssc.rs` (2): \`calculate_sha256\`, \`calculate_combined_checksum\`
- `tests/test_review_regression.rs` (2): \`sha256_hex\`, \`combined_checksum\`

Adds \`hex = \"0.4\"\` as a direct dep — small (0 deps, ~10kB), the conventional Rust crate for this.

Also picks up the deprecated `criterion::black_box` in benches → `std::hint::black_box`, a small fallout from #32's criterion 0.5 → 0.8 bump that left clippy red on main.

## Test plan

- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 529 unit + 137 integration + 28 conformance + 26 stata-output + 6 cache hash tests all pass
- [x] `cargo xtask codegen --check` — clean