### PR TITLE
fix: emit error-shaped install output when checksum verification fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `stacy install --format stata` (and `--format json`) no longer emits a success-shaped block when checksum verification fails (#38). Status is now computed before output, so wrappers see `global stacy_status "error"` plus `global stacy_error "<msg>"` (and JSON gets matching `status`/`error`/`failed` fields) instead of a stale success preceding the non-zero exit.
 - Stata wrappers failed with `command _stacy_check_version is unrecognized` because the generated `_stacy_compat.ado` defined programs that didn't match its filename and wasn't listed in `stacy.pkg` (#37). Split into one file per program.
 - Parallel `stacy run` invocations on scripts that share a basename no longer collide on the log file (#20). Each run writes to a uniquely-named log in the working directory (`<stem>_<pid>_<nanos>_<n>.log`), so build orchestrators like Make `-j` and Snakemake can run same-stemmed scripts from a shared cwd safely. The path is reported in JSON output's `log_file` field.
 - Non-UTF-8 characters in Stata log files no longer crash the log parser

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -142,8 +142,10 @@ fn install_from_lockfile(args: &InstallArgs) -> Result<()> {
             installed: 0,
             already_installed: 0,
             skipped: 0,
+            failed: 0,
             total: 0,
             package_count: 0,
+            error: None,
         };
 
         match format {
@@ -194,8 +196,36 @@ fn install_from_lockfile(args: &InstallArgs) -> Result<()> {
         .filter(|r| matches!(r.action, SyncAction::Skipped(_)))
         .count() as i32;
 
+    // Compute checksum failures *before* emitting output, so the Stata/JSON
+    // output reflects the real outcome instead of a stale "success".
+    let failed_names: Vec<&str> = if verify {
+        results
+            .iter()
+            .filter(|r| r.checksum_ok == Some(false))
+            .map(|r| r.name.as_str())
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let failed_count = failed_names.len() as i32;
+
+    let error_message: Option<String> = if failed_count > 0 {
+        Some(format!(
+            "{} package(s) failed checksum verification: {}. Use --no-verify to skip.",
+            failed_count,
+            failed_names.join(", ")
+        ))
+    } else if skipped_count > 0 && installed_count == 0 {
+        Some(format!(
+            "{} package(s) skipped, none installed",
+            skipped_count
+        ))
+    } else {
+        None
+    };
+
     let output = InstallOutput {
-        status: if skipped_count > 0 && installed_count == 0 {
+        status: if error_message.is_some() {
             "error".to_string()
         } else {
             "success".to_string()
@@ -203,29 +233,21 @@ fn install_from_lockfile(args: &InstallArgs) -> Result<()> {
         installed: installed_count,
         already_installed: already_count,
         skipped: skipped_count,
+        failed: failed_count,
         total: results.len() as i32,
         package_count: results.len(),
+        error: error_message.clone(),
     };
 
     // Output results
     match format {
-        OutputFormat::Json => print_sync_json_output(&results),
+        OutputFormat::Json => print_sync_json_output(&results, &output),
         OutputFormat::Stata => println!("{}", output.to_stata()),
         OutputFormat::Human => print_sync_human_output(&results),
     }
 
-    // Checksum failure is a hard error
-    if verify {
-        let fail_count = results
-            .iter()
-            .filter(|r| r.checksum_ok == Some(false))
-            .count();
-        if fail_count > 0 {
-            return Err(Error::Config(format!(
-                "{} package(s) failed checksum verification. Use --no-verify to skip.",
-                fail_count
-            )));
-        }
+    if failed_count > 0 {
+        return Err(Error::Config(error_message.unwrap()));
     }
 
     Ok(())
@@ -444,7 +466,7 @@ fn verify_package_checksum(name: &str, entry: &crate::project::PackageEntry) -> 
     Some(actual == expected)
 }
 
-fn print_sync_json_output(results: &[SyncedPackage]) {
+fn print_sync_json_output(results: &[SyncedPackage], summary: &InstallOutput) {
     use serde_json::json;
 
     let packages: Vec<_> = results
@@ -467,27 +489,16 @@ fn print_sync_json_output(results: &[SyncedPackage]) {
         })
         .collect();
 
-    let installed_count = results
-        .iter()
-        .filter(|r| matches!(r.action, SyncAction::Installed))
-        .count();
-    let already_count = results
-        .iter()
-        .filter(|r| matches!(r.action, SyncAction::AlreadyInstalled))
-        .count();
-    let skipped_count = results
-        .iter()
-        .filter(|r| matches!(r.action, SyncAction::Skipped(_)))
-        .count();
-
     let output = json!({
-        "status": "success",
+        "status": summary.status,
+        "error": summary.error,
         "packages": packages,
         "summary": {
-            "installed": installed_count,
-            "already_installed": already_count,
-            "skipped": skipped_count,
-            "total": results.len(),
+            "installed": summary.installed,
+            "already_installed": summary.already_installed,
+            "skipped": summary.skipped,
+            "failed": summary.failed,
+            "total": summary.total,
         }
     });
 

--- a/src/cli/output_types.rs
+++ b/src/cli/output_types.rs
@@ -570,10 +570,15 @@ pub struct InstallOutput {
     pub package_count: usize,
     /// Number skipped (errors)
     pub skipped: i32,
+    /// Number that failed checksum verification
+    pub failed: i32,
     /// Total packages processed
     pub total: i32,
     /// 'success' or 'error'
     pub status: String,
+    /// Error summary (present iff status == "error")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 impl CommandOutput for InstallOutput {
@@ -591,11 +596,15 @@ impl CommandOutput for InstallOutput {
             self.already_installed as i64,
         ));
         lines.push(format_stata_scalar_int("skipped", self.skipped as i64));
+        lines.push(format_stata_scalar_int("failed", self.failed as i64));
         lines.push(format_stata_scalar_int("total", self.total as i64));
         lines.push(format_stata_scalar_usize(
             "package_count",
             self.package_count,
         ));
+        if let Some(msg) = &self.error {
+            lines.push(format_stata_local("error", msg));
+        }
         lines.join("\n")
     }
 }
@@ -1237,8 +1246,10 @@ mod tests {
             installed: 3,
             already_installed: 2,
             skipped: 1,
+            failed: 0,
             total: 6,
             package_count: 6,
+            error: None,
         };
 
         let stata = output.to_stata();
@@ -1246,6 +1257,29 @@ mod tests {
         assert!(stata.contains("scalar stacy_installed = 3"));
         assert!(stata.contains("scalar stacy_already_installed = 2"));
         assert!(stata.contains("scalar stacy_skipped = 1"));
+        assert!(stata.contains("scalar stacy_failed = 0"));
+        assert!(!stata.contains("stacy_error"));
+    }
+
+    #[test]
+    fn test_install_output_to_stata_error() {
+        let output = InstallOutput {
+            status: "error".to_string(),
+            installed: 0,
+            already_installed: 4,
+            skipped: 0,
+            failed: 2,
+            total: 4,
+            package_count: 4,
+            error: Some("2 package(s) failed checksum verification: ftools, reghdfe".to_string()),
+        };
+
+        let stata = output.to_stata();
+        assert!(stata.contains("global stacy_status \"error\""));
+        assert!(stata.contains("scalar stacy_failed = 2"));
+        assert!(stata.contains(
+            "global stacy_error \"2 package(s) failed checksum verification: ftools, reghdfe\""
+        ));
     }
 
     #[test]
@@ -1981,8 +2015,10 @@ mod tests {
                     installed: 3,
                     already_installed: 1,
                     skipped: 0,
+                    failed: 0,
                     total: 4,
                     package_count: 4,
+                    error: None,
                 }
                 .to_stata(),
             ),

--- a/tests/test_review_regression.rs
+++ b/tests/test_review_regression.rs
@@ -147,6 +147,85 @@ fn test_poisoned_cache_fails_install() {
         .stderr(predicate::str::contains("checksum"));
 }
 
+/// Issue #38 regression: poisoned cache must NOT emit success-shaped Stata
+/// output. Wrappers branch on `$stacy_status`, so a stale "success" before a
+/// non-zero exit would silently degrade reproducibility.
+#[test]
+fn test_poisoned_cache_emits_stata_error_output() {
+    let (project, cache, _checksum) = create_test_project_with_cache();
+    poison_cache(cache.path(), "testpkg", "1.0.0");
+
+    let assert = stacy()
+        .arg("install")
+        .arg("--frozen")
+        .arg("--format")
+        .arg("stata")
+        .current_dir(project.path())
+        .env("XDG_CACHE_HOME", cache.path())
+        .env("LOCALAPPDATA", cache.path())
+        .assert()
+        .failure();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("global stacy_status \"error\""),
+        "expected stacy_status=error in stdout, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("global stacy_error"),
+        "expected stacy_error global in stdout, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("scalar stacy_failed = 1"),
+        "expected scalar stacy_failed=1 in stdout, got: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("global stacy_status \"success\""),
+        "stdout must not announce success on a failed install: {}",
+        stdout
+    );
+}
+
+/// Issue #38 regression: same fix in the JSON output path. The hard-coded
+/// "status": "success" is replaced with the real status, and the summary
+/// carries the error message and failed-count for downstream consumers.
+#[test]
+fn test_poisoned_cache_emits_json_error_output() {
+    let (project, cache, _checksum) = create_test_project_with_cache();
+    poison_cache(cache.path(), "testpkg", "1.0.0");
+
+    let assert = stacy()
+        .arg("install")
+        .arg("--frozen")
+        .arg("--format")
+        .arg("json")
+        .current_dir(project.path())
+        .env("XDG_CACHE_HOME", cache.path())
+        .env("LOCALAPPDATA", cache.path())
+        .assert()
+        .failure();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("\"status\": \"error\""),
+        "expected status=error in JSON, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("\"failed\": 1"),
+        "expected failed=1 in JSON summary, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("checksum verification"),
+        "expected error message about checksum verification, got: {}",
+        stdout
+    );
+}
+
 /// Behavior preservation: --no-verify skips checksum on tampered cache.
 ///
 /// Even with a poisoned cache, `--no-verify` should allow install to succeed


### PR DESCRIPTION
## Summary

Closes #38.

`stacy install --format stata` emitted the success block (`global stacy_status "success"` + scalars) **before** checksum verification ran, then exited non-zero. Wrappers that captured stdout saw success and proceeded; reproducibility silently degraded to no-guarantee. Same hole in `--format json` — `"status"` was hard-coded.

Fix: compute checksum failures before building `InstallOutput`, with a single error message threaded through both the output and the final `Err`.

- `InstallOutput` gains `failed: i32` and `error: Option<String>`.
- Stata: adds `scalar stacy_failed = N` and, on error, `global stacy_error "<msg>"`. Wrappers branch on `$stacy_status`; read `$stacy_error` only when it equals `"error"`.
- JSON: real `status`, plus `error` and `summary.failed`.

## Test plan

- [x] `cargo fmt --check && cargo test && cargo xtask codegen --check && cargo clippy --all-targets -- -D warnings` — all clean
- [x] Two new integration tests in `tests/test_review_regression.rs` (Stata + JSON) reuse the existing poisoned-cache helpers and assert the new contract end-to-end
- [x] Two new unit tests on `InstallOutput.to_stata()` cover success/error branches