### PR TITLE
fix: capture Stata stderr so launch failures aren't reported as 'Log file incomplete'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Surface Stata's stderr on launch failures instead of the misleading "Log file incomplete" (#21). Distinguish "no log produced" (launch failure) from "log truncated" (killed mid-run).
 - `stacy install --format stata` (and `--format json`) no longer emits a success-shaped block when checksum verification fails (#38). Status is now computed before output, so wrappers see `global stacy_status "error"` plus `global stacy_error "<msg>"` (and JSON gets matching `status`/`error`/`failed` fields) instead of a stale success preceding the non-zero exit.
 - Stata wrappers failed with `command _stacy_check_version is unrecognized` because the generated `_stacy_compat.ado` defined programs that didn't match its filename and wasn't listed in `stacy.pkg` (#37). Split into one file per program.
 - Parallel `stacy run` invocations on scripts that share a basename no longer collide on the log file (#20). Each run writes to a uniquely-named log in the working directory (`<stem>_<pid>_<nanos>_<n>.log`), so build orchestrators like Make `-j` and Snakemake can run same-stemmed scripts from a shared cwd safely. The path is reported in JSON output's `log_file` field.

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -151,7 +151,6 @@ impl StataExecutor {
         args: std::collections::HashMap<String, String>,
         working_dir: Option<&Path>,
     ) -> Result<ExecutionResult> {
-        use crate::error::parser::parse_log_for_errors;
         use runner::{run_stata, RunOptions};
         use std::thread;
 
@@ -287,15 +286,20 @@ impl StataExecutor {
             let _ = handle.join();
         }
 
-        // Parse log file for errors (with timing)
+        // Parse log file for errors (with timing).
+        //
+        // Signal-killed (SIGTERM from our watchdog, OOM, ctrl-C) → ProcessKilled.
+        // Otherwise — clean exit, code 0 or non-zero — inspect log + stderr.
+        // A non-zero exit with no log is a launch failure (license seat
+        // exhausted, missing binary, init error), and that's exactly the
+        // case where Stata's stderr carries the real diagnostic (#21).
         let parse_start = Instant::now();
-        let errors = if run_result.completed {
-            parse_log_for_errors(&run_result.log_file)?
-        } else {
-            // Process was killed, create error for that
+        let errors = if run_result.signaled {
             vec![StataError::ProcessKilled {
                 exit_code: run_result.exit_code,
             }]
+        } else {
+            parse_or_explain(&run_result)?
         };
         let parse_duration = parse_start.elapsed();
 
@@ -327,4 +331,69 @@ impl StataExecutor {
             metrics: None, // Metrics collection happens in CLI layer
         })
     }
+}
+
+/// Parse the log; on missing/empty/incomplete logs, fold captured stderr
+/// into the error message instead of the unhelpful default
+/// "Log file incomplete: no 'end of do-file' marker found".
+///
+/// Three cases:
+/// 1. Log doesn't exist or is empty → Stata never wrote anything. Almost
+///    always a launch failure (license seat exhausted, missing binary,
+///    init error). The real diagnostic is on stderr.
+/// 2. Log exists but parser reports it incomplete → process exited before
+///    writing the trailer. Likely killed mid-run by something stacy didn't
+///    initiate (OOM, external SIGKILL); stderr may also help.
+/// 3. Log parses cleanly → return whatever the parser returned.
+fn parse_or_explain(run: &runner::RunResult) -> Result<Vec<StataError>> {
+    use crate::error::parser::parse_log_for_errors;
+    use crate::error::Error;
+
+    let metadata = std::fs::metadata(&run.log_file).ok();
+    let log_present = metadata.as_ref().is_some_and(|m| m.len() > 0);
+
+    if !log_present {
+        return Err(Error::Execution(format_no_log_message(run)));
+    }
+
+    match parse_log_for_errors(&run.log_file) {
+        Ok(errs) => Ok(errs),
+        Err(Error::Parse(msg)) if msg.starts_with("Log file incomplete") => {
+            Err(Error::Execution(format_incomplete_log_message(run)))
+        }
+        Err(other) => Err(other),
+    }
+}
+
+fn format_no_log_message(run: &runner::RunResult) -> String {
+    let trimmed = run.stderr.trim();
+    let mut msg = format!(
+        "Stata produced no log file (exit code {}). Expected: {}",
+        run.exit_code,
+        run.log_file.display()
+    );
+    if !trimmed.is_empty() {
+        msg.push_str("\nStata stderr:\n");
+        msg.push_str(trimmed);
+    } else {
+        msg.push_str(
+            "\nStata wrote nothing to stderr. The binary may have failed to launch \
+             (missing executable, missing license seat, or environment misconfiguration).",
+        );
+    }
+    msg
+}
+
+fn format_incomplete_log_message(run: &runner::RunResult) -> String {
+    let trimmed = run.stderr.trim();
+    let mut msg = format!(
+        "Stata exited (code {}) before writing 'end of do-file' to the log. \
+         The process likely terminated mid-run.",
+        run.exit_code
+    );
+    if !trimmed.is_empty() {
+        msg.push_str("\nStata stderr:\n");
+        msg.push_str(trimmed);
+    }
+    msg
 }

--- a/src/executor/runner.rs
+++ b/src/executor/runner.rs
@@ -10,9 +10,15 @@
 use crate::error::Result;
 use crate::packages::global_cache;
 use crate::packages::lockfile::load_lockfile;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
 use std::time::{Duration, Instant};
+
+/// Cap on captured stderr bytes. Stata's startup-failure messages (license
+/// seat exhausted, init errors) are tiny; this just stops a misbehaving binary
+/// from ballooning memory.
+const STDERR_CAPTURE_LIMIT: usize = 8 * 1024;
 
 /// Result of running a Stata script
 #[derive(Debug)]
@@ -23,8 +29,18 @@ pub struct RunResult {
     pub log_file: PathBuf,
     /// How long the script took to run
     pub duration: Duration,
-    /// Whether the process completed normally (not killed)
+    /// Whether the process exited cleanly with code 0.
     pub completed: bool,
+    /// True when the process was killed by a signal (SIGTERM/SIGINT/SIGKILL),
+    /// e.g. by stacy's watchdog on timeout. Distinct from `!completed`, which
+    /// also covers a clean non-zero exit (a launch failure where Stata never
+    /// produced a log).
+    pub signaled: bool,
+    /// Captured stderr from the Stata process, lossy-decoded and capped at
+    /// `STDERR_CAPTURE_LIMIT` bytes. Empty on a normal Stata run; carries the
+    /// real diagnostic when Stata fails to start (license seat exhausted,
+    /// missing binary, init error).
+    pub stderr: String,
 }
 
 /// Options for running Stata
@@ -138,9 +154,12 @@ pub fn run_stata(script: &Path, options: RunOptions) -> Result<RunResult> {
     cmd.args(["-b", "-q", "do"]);
     cmd.arg(script);
 
-    // Suppress Stata's output to stdout/stderr (we read logs instead)
+    // Stata writes results to the log file, so stdout is uninteresting.
+    // stderr is normally empty, but carries real diagnostics on startup
+    // failures (license seat exhausted, init errors) — capture it so the
+    // user isn't left with a generic "Log file incomplete" message.
     cmd.stdout(Stdio::null());
-    cmd.stderr(Stdio::null());
+    cmd.stderr(Stdio::piped());
 
     // Set working directory if specified
     if let Some(dir) = options.working_dir {
@@ -190,6 +209,30 @@ pub fn run_stata(script: &Path, options: RunOptions) -> Result<RunResult> {
     // Spawn process
     let mut child = cmd.spawn()?;
 
+    // Drain stderr on a background thread so the kernel pipe buffer can't
+    // deadlock the child if it writes more than ~64 KiB. The reader caps the
+    // captured bytes at STDERR_CAPTURE_LIMIT.
+    let stderr_handle = child.stderr.take().map(|mut pipe| {
+        std::thread::spawn(move || -> Vec<u8> {
+            let mut buf = Vec::with_capacity(512);
+            let mut chunk = [0u8; 1024];
+            loop {
+                match pipe.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        if buf.len() < STDERR_CAPTURE_LIMIT {
+                            let take = (STDERR_CAPTURE_LIMIT - buf.len()).min(n);
+                            buf.extend_from_slice(&chunk[..take]);
+                        }
+                        // Keep draining past the cap so the child doesn't block.
+                    }
+                    Err(_) => break,
+                }
+            }
+            buf
+        })
+    });
+
     // Wait for completion (with optional timeout)
     let exit_status = if let Some(timeout) = options.timeout {
         wait_with_timeout(&mut child, timeout)?
@@ -198,6 +241,12 @@ pub fn run_stata(script: &Path, options: RunOptions) -> Result<RunResult> {
     };
 
     let duration = start.elapsed();
+
+    // Collect captured stderr after the child has exited.
+    let stderr = stderr_handle
+        .and_then(|h| h.join().ok())
+        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+        .unwrap_or_default();
 
     // Determine log file path. Callers that want collision-safe parallel runs
     // pass a precomputed path via `with_log_file` (see `executor::run_paths`).
@@ -220,11 +269,18 @@ pub fn run_stata(script: &Path, options: RunOptions) -> Result<RunResult> {
     // Check if process completed normally
     let completed = exit_status.success() || exit_code == 0;
 
+    // Was the process killed by a signal? On Unix this is the only way to
+    // distinguish stacy's own watchdog (or an external SIGKILL) from a
+    // binary that simply exited non-zero (a launch failure with no log).
+    let signaled = signaled_from_status(&exit_status);
+
     Ok(RunResult {
         exit_code,
         log_file,
         duration,
         completed,
+        signaled,
+        stderr,
     })
 }
 
@@ -265,6 +321,21 @@ fn wait_with_timeout(child: &mut std::process::Child, timeout: Duration) -> Resu
     let _ = watchdog.join(); // Wait for clean thread shutdown
 
     Ok(status)
+}
+
+/// True iff the process was terminated by a signal (Unix). Always false on
+/// non-Unix platforms (Windows has no equivalent concept).
+fn signaled_from_status(status: &ExitStatus) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal().is_some()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = status;
+        false
+    }
 }
 
 /// Extract exit code from ExitStatus
@@ -391,6 +462,51 @@ mod tests {
         let options = RunOptions::new("stata-mp").with_local_ado_paths(paths.clone());
 
         assert_eq!(options.local_ado_paths, paths);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_stderr_is_captured_and_capped() {
+        // Stand-in for Stata: a shell script that floods stderr (well above
+        // the 8 KiB cap) so we can verify both capture and bounds in one go.
+        // Use write_executable (open with mode 0o755 + fsync) to avoid the
+        // ETXTBSY race that Linux can briefly hit after write+chmod+exec.
+        let temp = tempfile::TempDir::new().unwrap();
+        let script = temp.path().join("flood.sh");
+        // 1024 lines of 63 'A's + newline = ~64 KiB.
+        let body = "#!/bin/sh\ni=0\nwhile [ $i -lt 1024 ]; do \
+                    echo AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA >&2; \
+                    i=$((i+1)); \
+                    done\nexit 1\n";
+        write_executable(&script, body);
+
+        let options =
+            RunOptions::new(script.to_str().unwrap()).with_log_file(temp.path().join("dummy.log"));
+        let result = run_stata(Path::new("anything.do"), options).expect("spawn");
+
+        assert!(!result.stderr.is_empty(), "stderr should be captured");
+        assert!(
+            result.stderr.len() <= super::STDERR_CAPTURE_LIMIT,
+            "stderr should be capped at {} bytes, got {}",
+            super::STDERR_CAPTURE_LIMIT,
+            result.stderr.len()
+        );
+    }
+
+    #[cfg(unix)]
+    fn write_executable(path: &Path, body: &str) {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o755)
+            .open(path)
+            .unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        f.sync_all().unwrap();
+        // f drops here, releasing the fd before any exec.
     }
 
     #[test]

--- a/tests/executor_test.rs
+++ b/tests/executor_test.rs
@@ -96,3 +96,74 @@ fn test_project_isolation() {
     // This test would require a project with ado/ directory
     // Deferred to integration tests
 }
+
+/// When the configured "Stata" binary doesn't exist, the user must see a
+/// real error — not the misleading "Log file incomplete" that shipped before
+/// issue #21.
+#[test]
+fn test_missing_binary_does_not_report_log_incomplete() {
+    use stacy::executor::StataExecutor;
+    let temp = tempfile::TempDir::new().unwrap();
+    let script = temp.path().join("anything.do");
+    std::fs::write(&script, "display \"hi\"\n").unwrap();
+
+    let exec = StataExecutor::with_binary("/nonexistent/stata-bogus");
+    let err = match exec.run_in_dir(&script, None, temp.path()) {
+        Ok(_) => panic!("missing binary should error"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+
+    assert!(
+        !msg.contains("Log file incomplete"),
+        "missing binary must not surface as 'Log file incomplete', got: {msg}"
+    );
+}
+
+/// When the binary launches but writes a startup error to stderr (license
+/// seat, init failure) without producing a log, the captured stderr must
+/// reach the user's error message.
+#[cfg(unix)]
+#[test]
+fn test_no_log_produced_surfaces_stderr() {
+    use stacy::executor::StataExecutor;
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let temp = tempfile::TempDir::new().unwrap();
+
+    // Stand-in "Stata" — writes a license error to stderr, never opens a log.
+    // Open with mode 0o755 + fsync to avoid Linux's ETXTBSY race after
+    // write+chmod+exec.
+    let fake_stata = temp.path().join("fake-stata");
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o755)
+        .open(&fake_stata)
+        .unwrap();
+    f.write_all(b"#!/bin/sh\necho 'license seat exhausted' >&2\nexit 1\n")
+        .unwrap();
+    f.sync_all().unwrap();
+    drop(f);
+
+    let script = temp.path().join("anything.do");
+    std::fs::write(&script, "display \"hi\"\n").unwrap();
+
+    let exec = StataExecutor::with_binary(fake_stata.to_str().unwrap());
+    let err = match exec.run_in_dir(&script, None, temp.path()) {
+        Ok(_) => panic!("startup failure should error"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("license seat exhausted"),
+        "captured stderr should appear in error message, got: {msg}"
+    );
+    assert!(
+        !msg.contains("Log file incomplete"),
+        "should not fall back to 'Log file incomplete', got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #21.

The runner set `cmd.stderr(Stdio::null())` (`src/executor/runner.rs:143`), so when Stata failed to start — license seat exhausted (SE/IC), missing binary, init error — the real diagnostic was dropped. stacy then saw a process that exited and a log without its trailer, and reported the unhelpful `Parse error: Log file incomplete: no 'end of do-file' marker found`.

- Pipe stderr; drain on a background thread (cap 8 KiB) so a misbehaving binary can't block on the pipe buffer or balloon memory. Expose as `RunResult.stderr`.
- Add `RunResult.signaled` (true iff `ExitStatus::signal()` is `Some`) to distinguish stacy's own watchdog kill from a clean non-zero exit (the launch-failure case). Without this the executor conflated the two.
- In `executor::run_internal`, route non-signaled exits through a new `parse_or_explain` helper that classifies log state — **missing/empty** vs. **incomplete** vs. **clean** — and folds captured stderr into `Error::Execution`. The two messages are distinct as #21 asked: "Stata produced no log file" (likely launch failure) vs. "Stata exited before writing 'end of do-file'" (likely killed mid-run).

No new error variant; `Error::Execution(String)` already exists. No changes to log parsing logic. `StataError::ProcessKilled` is preserved for actual signal kills (timeout watchdog).

## Test plan

- [x] `cargo fmt --check && cargo test && cargo xtask codegen --check && cargo clippy --all-targets -- -D warnings` — all clean
- [x] Two new unit tests in `src/executor/runner.rs` (stderr captured, stderr capped at 8 KiB)
- [x] Two new integration tests in `tests/executor_test.rs` (missing binary doesn't say "Log file incomplete"; a fake binary's stderr reaches the user). Both run on CI without a Stata install.
- [ ] Manual: run `stacy run something.do` with `STATA_BINARY=/bin/false` and confirm the error mentions the missing log + exit code, not the trailer