### PR TITLE
feat: stream output live in piped mode; add --log; internal log retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `stacy run` streams program output to stdout live in piped mode, matching `Rscript`/`python`, instead of printing it after execution (#24). Output content is unchanged (boilerplate-stripped); stacy's status and error messages stay on stderr. Note: on failure, partial output now appears on stdout before the failure is reported.
+- The batch log file is now internal: removed on success, kept on failure (path shown in the failure output). Machine-readable formats (`--format json|stata`) keep the log since their output references it. Use `--log <path>` for a durable log artifact.
+- `--parallel` prints each script's output as a grouped block on completion (`==> script.do <==` headers on stdout, status lines on stderr) instead of discarding it.
+- Raw `-v` streaming runs to process exit instead of stopping a few lines after the end-of-do-file marker.
+- `stacy task` output streams live as well (tasks run with the same piped-mode default).
+
+### Added
+
+- `stacy run --log <path>`: write the raw Stata log to a chosen path (works with `--quiet` for silent file-artifact mode).
+
+### Fixed
+
+- Log streaming (`-v`, `-vv`, TTY default) no longer hangs forever when Stata is killed (`--timeout` watchdog, external SIGKILL) or fails to launch without creating a log (#24).
+- `stacy run foo.do | head` no longer panics when the downstream pipe closes.
+- Log streaming now recovers from a truncated/recreated log file and no longer emits partially-written lines.
+- `--trace` no longer leaks its temporary traced script and log file on exit.
+
 ## [1.2.1] - 2026-05-06
 
 ### Added

--- a/docs/src/commands/run.md
+++ b/docs/src/commands/run.md
@@ -17,10 +17,16 @@ succeeded or failed—enabling integration with Make, Snakemake, and CI/CD.
 The command runs Stata with `-b -q`, parses the log for error patterns, and
 returns an appropriate exit code (0 for success, 1-10 for various errors).
 
-By default, clean output is shown after execution (boilerplate stripped). On
-failure, error details with official Stata documentation links and the log file
-path are displayed. Use `-v` to stream the raw log in real-time instead, or
-`-q` to suppress all output.
+Program output (boilerplate-stripped) streams to stdout live as Stata writes
+it — like `Rscript` or `python` — so `stacy run foo.do > out.log` and pipes
+behave as expected. stacy's own status and error messages go to stderr. On
+failure, error details with official Stata documentation links and the log
+file path are displayed. Use `-v` to stream the raw log instead, or `-q` to
+suppress all output.
+
+The batch log file is internal: removed on success, kept on failure. Use
+`--log <path>` to keep the raw Stata log as a durable artifact
+(`--quiet --log out.log` for a silent file-only run).
 
 Multiple scripts can be run sequentially (default, fail-fast) or in parallel
 (`--parallel`). Parallel mode runs all scripts regardless of failures.
@@ -46,6 +52,7 @@ For interactive use where you want to quickly check a result, see `stacy eval`.
 | `--engine` | Stata engine to use (overrides config and auto-detection) |
 | `--force` | Force rebuild even if cached |
 | `-j, --jobs` | Max parallel jobs (default: CPU count) |
+| `--log` | Write the raw Stata log to this path |
 | `-P, --parallel` | Run scripts in parallel |
 | `--profile` | Include execution metrics |
 | `-q, --quiet` | Suppress output |

--- a/docs/src/reference/how-it-works.md
+++ b/docs/src/reference/how-it-works.md
@@ -147,16 +147,24 @@ On `stacy install`, checksums are verified to ensure:
 
 ### Real-time Logs
 
-Use `-v` (verbose) to stream Stata's log output as it runs:
+Program output streams to stdout live by default — boilerplate-stripped
+(command echoes removed, blank runs collapsed), both in a terminal and when
+piped. Use `-v` (verbose) to stream the raw, unstripped log instead:
 
 ```bash
 stacy run -v long_analysis.do
 ```
 
-This displays log lines in real-time, useful for:
-- Monitoring long-running scripts
-- Debugging interactively
-- Seeing progress indicators
+Streaming stops when the Stata process exits, so killed or timed-out runs
+terminate cleanly. Closed pipes (`stacy run foo.do | head`) end the stream
+without error.
+
+### Log Files
+
+The batch log is internal: removed on success, kept on failure (the path is
+shown in the error output). `--log <path>` writes the raw log to a chosen
+location regardless of outcome. Machine-readable formats keep the log and
+report its path.
 
 ### Progress Reporting
 
@@ -175,14 +183,13 @@ progress_interval_seconds = 30
 
 ### Structured Logging
 
-For automated pipelines, combine `--format json` with verbose output:
+For automated pipelines, use `--format json`. Machine-readable formats imply
+quiet execution (no streaming); the JSON result's `log_file` field points to
+the kept Stata log:
 
 ```bash
-stacy run --format json -v analysis.do 2>log.txt
+stacy run --format json analysis.do
 ```
-
-- stdout: JSON result
-- stderr: Real-time log stream
 
 ---
 

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -56,10 +56,16 @@ succeeded or failed—enabling integration with Make, Snakemake, and CI/CD.
 The command runs Stata with `-b -q`, parses the log for error patterns, and
 returns an appropriate exit code (0 for success, 1-10 for various errors).
 
-By default, clean output is shown after execution (boilerplate stripped). On
-failure, error details with official Stata documentation links and the log file
-path are displayed. Use `-v` to stream the raw log in real-time instead, or
-`-q` to suppress all output.
+Program output (boilerplate-stripped) streams to stdout live as Stata writes
+it — like `Rscript` or `python` — so `stacy run foo.do > out.log` and pipes
+behave as expected. stacy's own status and error messages go to stderr. On
+failure, error details with official Stata documentation links and the log
+file path are displayed. Use `-v` to stream the raw log instead, or `-q` to
+suppress all output.
+
+The batch log file is internal: removed on success, kept on failure. Use
+`--log <path>` to keep the raw Stata log as a durable artifact
+(`--quiet --log out.log` for a silent file-only run).
 
 Multiple scripts can be run sequentially (default, fail-fast) or in parallel
 (`--parallel`). Parallel mode runs all scripts regardless of failures.
@@ -86,6 +92,7 @@ cache = { type = "bool", description = "Enable build cache (skip re-execution if
 force = { type = "bool", description = "Force rebuild even if cached", stata_option = "Force" }
 cache_only = { type = "bool", long = "cache-only", description = "Fail if not in cache (useful for CI)", stata_option = "CacheOnly" }
 engine = { type = "string", long = "engine", description = "Stata engine to use (overrides config and auto-detection)", stata_option = "Engine(string)" }
+log = { type = "path", long = "log", description = "Write the raw Stata log to this path", stata_option = "Log(string)" }
 
 [commands.run.returns]
 # Scalars (numeric values)

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -175,7 +175,8 @@ Examples:
   stacy run --cd reports/table.do         Auto cd to script's directory
   stacy run script.do --engine /path/to/stata
                                         Use specific Stata binary
-  stacy run script.do -v                  Stream log output in real-time
+  stacy run script.do -v                  Stream the raw log in real-time
+  stacy run script.do --log run.log       Also write the raw Stata log to run.log
   stacy run script.do --format json       Machine-readable output
   stacy run script.do --trace 2           Trace execution at depth 2
   stacy run script.do --trace 2 -v        Trace + stream live
@@ -265,6 +266,11 @@ pub struct RunArgs {
     /// Kill script if it exceeds this many seconds (SIGTERM, then SIGKILL after 5s grace)
     #[arg(long, value_name = "SECONDS", value_parser = clap::value_parser!(u64).range(1..))]
     pub timeout: Option<u64>,
+
+    /// Write the raw Stata log to this path (in addition to normal output).
+    /// Without this flag the log is internal: removed on success, kept on failure.
+    #[arg(long, value_name = "PATH", conflicts_with = "parallel")]
+    pub log: Option<PathBuf>,
 }
 
 /// Check if a path is the stdin marker "-"
@@ -301,6 +307,13 @@ fn resolve_local_ado_paths(project: &Option<crate::project::Project>) -> Vec<Pat
 /// Main entry point - dispatches to appropriate execution mode
 pub fn execute(args: &RunArgs) -> Result<()> {
     use std::process;
+
+    // --log writes a single artifact; ambiguous with multiple scripts
+    if args.log.is_some() && args.scripts.len() > 1 {
+        return Err(Error::Config(
+            "--log requires a single script (or inline code)".into(),
+        ));
+    }
 
     // Check for stdin marker
     if args.scripts.len() == 1 && is_stdin_marker(&args.scripts[0]) {
@@ -373,6 +386,39 @@ fn resolve_working_dir(script: &Path, args: &RunArgs) -> Result<(PathBuf, Option
         Ok((abs_script, Some(abs_dir)))
     } else {
         Ok((abs_script, None))
+    }
+}
+
+/// Apply the log-retention policy after a run.
+///
+/// `--log <path>` moves the raw log there (the durable artifact) and returns
+/// that path. Otherwise the log is an internal file: removed when `delete`
+/// is set (success in human mode, where output was already streamed), kept
+/// for inspection when not (failures, and machine-readable formats whose
+/// output references it).
+fn finalize_log(log_file: &Path, delete: bool, dest: Option<&Path>) -> PathBuf {
+    match dest {
+        Some(dest) => {
+            // Rename, falling back to copy+remove across filesystems
+            let moved = std::fs::rename(log_file, dest).or_else(|_| {
+                std::fs::copy(log_file, dest).map(|_| {
+                    let _ = std::fs::remove_file(log_file);
+                })
+            });
+            match moved {
+                Ok(()) => dest.to_path_buf(),
+                Err(e) => {
+                    eprintln!("Warning: could not write log to {}: {}", dest.display(), e);
+                    log_file.to_path_buf()
+                }
+            }
+        }
+        None => {
+            if delete {
+                let _ = std::fs::remove_file(log_file);
+            }
+            log_file.to_path_buf()
+        }
     }
 }
 
@@ -465,6 +511,8 @@ fn execute_inline(args: &RunArgs) -> Result<()> {
     // `script.with_extension("log")`. Hand the real path to TempScript so
     // its Drop cleans up the inline-run log (preserves pre-#20 behavior).
     temp_script.set_actual_log(result.log_file.clone());
+    // --log moves it out first; TempScript's best-effort Drop then no-ops.
+    result.log_file = finalize_log(&result.log_file, false, args.log.as_deref());
 
     if let Some(ref mut m) = metrics {
         m.end_phase("execution");
@@ -533,16 +581,6 @@ fn execute_inline(args: &RunArgs) -> Result<()> {
                     "\x1b[32mPASS\x1b[0m  <inline code>  ({:.2}s)",
                     result.duration.as_secs_f64()
                 );
-                // Show clean output post-hoc only when not already streamed and not tracing
-                if !tracing && verbosity.should_show_clean_output_post_hoc() {
-                    if let Ok(raw) = crate::executor::log_reader::read_full_log(&result.log_file) {
-                        let clean = crate::executor::log_reader::strip_boilerplate(&raw);
-                        if !clean.is_empty() {
-                            println!();
-                            println!("{}", clean);
-                        }
-                    }
-                }
             }
 
             if args.profile {
@@ -766,6 +804,15 @@ fn execute_single(script_path: &Path, args: &RunArgs) -> Result<()> {
         }
     }
 
+    // Log retention: --log moves it aside; otherwise internal — removed on
+    // success in human mode (output was already streamed), kept on failure
+    // and for machine formats whose output references it.
+    result.log_file = finalize_log(
+        &result.log_file,
+        result.success && !format.is_machine_readable(),
+        args.log.as_deref(),
+    );
+
     // Build output
     let output = RunOutput {
         success: result.success,
@@ -825,16 +872,6 @@ fn execute_single(script_path: &Path, args: &RunArgs) -> Result<()> {
                     script_path.display(),
                     result.duration.as_secs_f64()
                 );
-                // Show clean output post-hoc only when not already streamed and not tracing
-                if !tracing && verbosity.should_show_clean_output_post_hoc() {
-                    if let Ok(raw) = crate::executor::log_reader::read_full_log(&result.log_file) {
-                        let clean = crate::executor::log_reader::strip_boilerplate(&raw);
-                        if !clean.is_empty() {
-                            println!();
-                            println!("{}", clean);
-                        }
-                    }
-                }
             }
 
             if args.profile {
@@ -846,6 +883,9 @@ fn execute_single(script_path: &Path, args: &RunArgs) -> Result<()> {
         }
     }
 
+    // process::exit skips destructors — drop explicitly so the trace
+    // TempScript cleans up its wrapper and log.
+    drop(_trace_temp_script);
     process::exit(result.exit_code);
 }
 
@@ -985,12 +1025,20 @@ fn execute_sequential(args: &RunArgs) -> Result<()> {
             ts.set_actual_log(result.log_file.clone());
         }
 
+        // Log retention: internal file — removed on success in human mode
+        // (output was already streamed), kept on failure / machine formats.
+        let final_log = finalize_log(
+            &result.log_file,
+            result.success && !format.is_machine_readable(),
+            None,
+        );
+
         let script_result = ScriptRunResult {
             script: script.clone(),
             success: result.success,
             exit_code: result.exit_code,
             duration_secs: result.duration.as_secs_f64(),
-            log_file: result.log_file.clone(),
+            log_file: final_log,
             error_message: if !result.success {
                 result.errors.first().map(format_stata_error)
             } else {
@@ -1163,13 +1211,31 @@ fn execute_parallel(args: &RunArgs) -> Result<()> {
         let mut script_results = Vec::with_capacity(total_scripts);
         let mut completed = 0;
 
-        for result in rx {
+        for mut result in rx {
             completed += 1;
 
             // Print progress in human mode (streaming output)
             if !args.quiet && format == OutputFormat::Human {
                 print_script_result(&result, completed, total_scripts);
+                // Script output as a grouped block (status on stderr,
+                // output on stdout) — never interleaved across scripts.
+                if let Ok(raw) = crate::executor::log_reader::read_full_log(&result.log_file) {
+                    let clean = crate::executor::log_reader::strip_boilerplate(&raw);
+                    if !clean.is_empty() {
+                        println!("==> {} <==", result.script.display());
+                        println!("{}", clean);
+                        println!();
+                    }
+                }
             }
+
+            // Log retention: removed on success in human mode (output shown
+            // above), kept on failure / machine formats.
+            result.log_file = finalize_log(
+                &result.log_file,
+                result.success && !format.is_machine_readable(),
+                None,
+            );
 
             script_results.push(result);
         }
@@ -1271,6 +1337,10 @@ fn print_script_result(result: &ScriptRunResult, index: usize, total: usize) {
         );
         if let Some(ref msg) = result.error_message {
             eprintln!("              {}", msg);
+        }
+        // Failures keep their log (successes don't) — say where it is
+        if !result.log_file.as_os_str().is_empty() {
+            eprintln!("              Log: {}", result.log_file.display());
         }
     }
 }

--- a/src/executor/verbosity.rs
+++ b/src/executor/verbosity.rs
@@ -12,9 +12,11 @@ pub enum Verbosity {
     /// ```
     Quiet = 0,
 
-    /// Non-TTY default: quiet during execution, show clean output post-hoc
+    /// Non-TTY default: stream clean output to stdout live, no status chrome
     ///
-    /// Used when stdout is piped (not a terminal).
+    /// Used when stdout is piped (not a terminal). Program output goes to
+    /// stdout as Stata writes it — like `Rscript`/`python` — so
+    /// `stacy run foo.do > foo.log` and downstream pipes work as expected.
     ///
     /// ```bash
     /// stacy run script.do | less
@@ -61,9 +63,13 @@ impl Verbosity {
         matches!(self, Verbosity::Verbose | Verbosity::VeryVerbose)
     }
 
-    /// Should we stream clean (boilerplate-stripped) output in real-time? (TTY default)
+    /// Should we stream clean (boilerplate-stripped) output in real-time?
+    /// (both defaults: TTY and piped)
     pub fn should_stream_clean(&self) -> bool {
-        matches!(self, Verbosity::DefaultInteractive)
+        matches!(
+            self,
+            Verbosity::DefaultInteractive | Verbosity::PipedDefault
+        )
     }
 
     /// Should we show error context (last 20 lines) on failure?
@@ -77,14 +83,6 @@ impl Verbosity {
     /// Should we show execution details (binary, command, etc.)?
     pub fn should_show_execution_details(&self) -> bool {
         matches!(self, Verbosity::VeryVerbose)
-    }
-
-    /// Should we show clean post-processed output after execution? (piped default only)
-    ///
-    /// Only at PipedDefault: Quiet suppresses everything, DefaultInteractive streams
-    /// clean output in real-time, Verbose/VeryVerbose stream the raw log instead.
-    pub fn should_show_clean_output_post_hoc(&self) -> bool {
-        matches!(self, Verbosity::PipedDefault)
     }
 
     /// Should we show "Running..." indicator and PASS/FAIL status?
@@ -137,7 +135,7 @@ mod tests {
     #[test]
     fn test_should_stream_clean() {
         assert!(!Verbosity::Quiet.should_stream_clean());
-        assert!(!Verbosity::PipedDefault.should_stream_clean());
+        assert!(Verbosity::PipedDefault.should_stream_clean());
         assert!(Verbosity::DefaultInteractive.should_stream_clean());
         assert!(!Verbosity::Verbose.should_stream_clean());
         assert!(!Verbosity::VeryVerbose.should_stream_clean());
@@ -160,15 +158,6 @@ mod tests {
         assert!(!Verbosity::DefaultInteractive.should_show_execution_details());
         assert!(!Verbosity::Verbose.should_show_execution_details());
         assert!(Verbosity::VeryVerbose.should_show_execution_details());
-    }
-
-    #[test]
-    fn test_should_show_clean_output_post_hoc() {
-        assert!(!Verbosity::Quiet.should_show_clean_output_post_hoc());
-        assert!(Verbosity::PipedDefault.should_show_clean_output_post_hoc());
-        assert!(!Verbosity::DefaultInteractive.should_show_clean_output_post_hoc());
-        assert!(!Verbosity::Verbose.should_show_clean_output_post_hoc());
-        assert!(!Verbosity::VeryVerbose.should_show_clean_output_post_hoc());
     }
 
     #[test]

--- a/stata/stacy_run.ado
+++ b/stata/stacy_run.ado
@@ -19,6 +19,7 @@
         Engine(string)       - Stata engine to use (overrides config and auto-detection)
         Force                - Force rebuild even if cached
         Jobs(integer)        - Max parallel jobs (default: CPU count)
+        Log(string)          - Write the raw Stata log to this path
         PARALLEL             - Run scripts in parallel
         Profile              - Include execution metrics
         Quietly              - Suppress output
@@ -38,7 +39,7 @@
 
 program define stacy_run, rclass
     version 14.0
-    syntax [anything(name=script)] [, AllowGlobal Cache CacheOnly Code(string) Directory(string) Engine(string) Force Jobs(string) PARALLEL Profile Quietly Timeout(string) Trace(string) Verbose]
+    syntax [anything(name=script)] [, AllowGlobal Cache CacheOnly Code(string) Directory(string) Engine(string) Force Jobs(string) Log(string) PARALLEL Profile Quietly Timeout(string) Trace(string) Verbose]
 
     * Build command arguments
     local cmd "run"
@@ -77,6 +78,10 @@ program define stacy_run, rclass
 
     if `"`jobs'"' != "" {
         local cmd `"`cmd' --jobs "`jobs'""'
+    }
+
+    if `"`log'"' != "" {
+        local cmd `"`cmd' --log "`log'""'
     }
 
     if "`parallel'" != "" {

--- a/stata/stacy_run.sthlp
+++ b/stata/stacy_run.sthlp
@@ -29,6 +29,7 @@
 {synopt:{opt:engine(string)}}Stata engine to use (overrides config and auto-detection){p_end}
 {synopt:{opt:force}}Force rebuild even if cached{p_end}
 {synopt:{opt:jobs(integer)}}Max parallel jobs (default: CPU count){p_end}
+{synopt:{opt:log(string)}}Write the raw Stata log to this path{p_end}
 {synopt:{opt:parallel}}Run scripts in parallel{p_end}
 {synopt:{opt:profile}}Include execution metrics{p_end}
 {synopt:{opt:quietly}}Suppress output{p_end}
@@ -74,6 +75,9 @@
 
 {phang}
 {opt jobs} max parallel jobs (default: cpu count).
+
+{phang}
+{opt log} write the raw stata log to this path.
 
 {phang}
 {opt parallel} run scripts in parallel.


### PR DESCRIPTION
PR 2 of 2 for #24, on top of #61. Closes #24.

Piped mode now streams boilerplate-stripped output to stdout as Stata writes it, like `Rscript`/`python`. stdout content is unchanged from the old post-hoc print — only the timing changes. Status and errors stay on stderr, so `stacy run foo.do > out.log` and pipes behave as expected.

- `--log <path>` writes the raw Stata log to a chosen path (`--quiet --log out.log` = silent file-artifact mode)
- Log retention: the batch log is internal — removed on success in human mode, kept on failure with its path in the FAIL output. Machine formats (`--format json|stata`) keep it since their output references it. Ends the `foo_<pid>_<nanos>.log` litter.
- `--parallel`: each script's output prints as a grouped block on completion (`==> script.do <==` on stdout, status on stderr) instead of being discarded
- Bug fix found on the way: `--trace` leaked its temp script and log (`process::exit` skips `Drop`)
- Docs: run.md (via schema codegen), how-it-works.md — also fixes the incorrect claim that `--format json -v` streams to stderr (machine formats imply quiet)

Verified end-to-end against real Stata: piped success/failure streaming + exit codes, `--log`, `--quiet --log`, `| head` (no panic), parallel grouping, `--timeout 3 -v` terminates in 8s (was: hang forever). `make check` passes locally.