### PR TITLE
fix: comma-separate package names in post-install dependency hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Post-install dependency hints now comma-separate package names (`appears to need ftools, require`) instead of running them together (#63).
 - Log streaming (`-v`, `-vv`, TTY default) no longer hangs forever when Stata is killed (`--timeout` watchdog, external SIGKILL) or fails to launch without creating a log (#24).
 - `stacy run foo.do | head` no longer panics when the downstream pipe closes.
 - Log streaming now recovers from a truncated/recreated log file and no longer emits partially-written lines.

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -175,10 +175,11 @@ pub fn execute(args: &AddArgs) -> Result<()> {
                         let missing =
                             dep_scan::find_missing_deps(&package_lower, &cache_dir, &installed);
                         if !missing.is_empty() {
-                            let names = missing.join(" ");
                             println!(
                                 "    hint: {} appears to need {}. Run: stacy add {}",
-                                package_lower, names, names
+                                package_lower,
+                                missing.join(", "),
+                                missing.join(" ")
                             );
                         } else if let Some(hint) = hints::get_hint(&package_lower) {
                             // Fallback to hardcoded hints for edge cases


### PR DESCRIPTION
Closes #63. `appears to need ftools, require` instead of `ftools require` reading as one phrase; the `stacy add` command string keeps space separation. `make check` passes locally.