### PR TITLE
feat: accept script paths in sequential/parallel task arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Sequential/parallel task arrays now accept script paths (`all = ["clean", "src/02_analyze.do"]`), as the docs showed (#64). Defined task names take precedence.
 - Post-install dependency hints now comma-separate package names (`appears to need ftools, require`) instead of running them together (#63).
 - Failure context no longer loads the entire log into memory to number its last 20 lines (#66).
 - Log streaming (`-v`, `-vv`, TTY default) no longer hangs forever when Stata is killed (`--timeout` watchdog, external SIGKILL) or fails to launch without creating a log (#24).

--- a/src/task/executor.rs
+++ b/src/task/executor.rs
@@ -190,19 +190,29 @@ impl<'a> TaskExecutor<'a> {
         Ok(task_result)
     }
 
+    /// Resolve a sequential/parallel array entry: a defined task name wins;
+    /// otherwise a path-looking entry runs as a script (#64).
+    fn resolve_entry(&self, parent: &str, entry: &str) -> Result<TaskDef> {
+        if let Some(task) = self.graph.get_task(entry) {
+            return Ok(task.clone());
+        }
+        if crate::task::is_script_ref(entry) {
+            return Ok(TaskDef::Simple(std::path::PathBuf::from(entry)));
+        }
+        Err(Error::Config(format!(
+            "Task '{}' references unknown task '{}'",
+            parent, entry
+        )))
+    }
+
     /// Execute tasks sequentially
     fn execute_sequential(&self, name: &str, tasks: &[String]) -> Result<TaskResult> {
         let mut result = TaskResult::empty(name);
 
         for task_name in tasks {
-            let task = self.graph.get_task(task_name).ok_or_else(|| {
-                Error::Config(format!(
-                    "Task '{}' references unknown task '{}'",
-                    name, task_name
-                ))
-            })?;
+            let task = self.resolve_entry(name, task_name)?;
 
-            let task_result = self.execute_task(task_name, task)?;
+            let task_result = self.execute_task(task_name, &task)?;
 
             // Merge results
             let failed = !task_result.success;
@@ -227,15 +237,8 @@ impl<'a> TaskExecutor<'a> {
         let task_defs: Vec<_> = tasks
             .iter()
             .map(|task_name| {
-                self.graph
-                    .get_task(task_name)
-                    .map(|t| (task_name.clone(), t.clone()))
-                    .ok_or_else(|| {
-                        Error::Config(format!(
-                            "Task '{}' references unknown task '{}'",
-                            name, task_name
-                        ))
-                    })
+                self.resolve_entry(name, task_name)
+                    .map(|t| (task_name.clone(), t))
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -126,9 +126,12 @@ impl TaskGraph {
         None
     }
 
-    /// Get all task names referenced by a task definition
+    /// Get all task names referenced by a task definition.
+    ///
+    /// Script-path entries (see [`is_script_ref`]) are not task references —
+    /// they run directly and can't participate in cycles.
     fn get_task_references(&self, task: &TaskDef) -> Vec<String> {
-        match task {
+        let refs = match task {
             TaskDef::Simple(_) => vec![],
             TaskDef::Sequential(tasks) => tasks.clone(),
             TaskDef::Complex(complex) => {
@@ -138,7 +141,10 @@ impl TaskGraph {
                     vec![]
                 }
             }
-        }
+        };
+        refs.into_iter()
+            .filter(|r| !is_script_ref(r) || self.tasks.contains_key(r))
+            .collect()
     }
 
     /// Find similar task names for "did you mean" suggestions
@@ -201,6 +207,15 @@ fn levenshtein_distance(a: &str, b: &str) -> usize {
     }
 
     matrix[m][n]
+}
+
+/// Does a sequential/parallel array entry name a script rather than a task?
+///
+/// Task names take precedence: this only decides how to treat entries that
+/// don't match any defined task. Anything with a path separator or a `.do`
+/// extension is run as a script.
+pub fn is_script_ref(entry: &str) -> bool {
+    entry.contains('/') || entry.contains('\\') || entry.ends_with(".do")
 }
 
 /// Get a description for a task definition
@@ -316,6 +331,60 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("references unknown task"));
+    }
+
+    #[test]
+    fn test_script_paths_in_arrays_validate() {
+        // Path-looking entries are scripts, not task references (#64)
+        let scripts = make_scripts(vec![
+            ("clean", TaskDef::Simple(PathBuf::from("src/01_clean.do"))),
+            (
+                "all",
+                TaskDef::Sequential(vec!["clean".to_string(), "src/02_analyze.do".to_string()]),
+            ),
+        ]);
+
+        let graph = TaskGraph::from_config(&scripts).unwrap();
+        assert_eq!(graph.len(), 2);
+    }
+
+    #[test]
+    fn test_task_name_wins_over_script_ref() {
+        // An entry that both names a task and looks like a path resolves to
+        // the task — it stays a reference for validation/cycles.
+        let scripts = make_scripts(vec![
+            ("a.do", TaskDef::Sequential(vec!["b.do".to_string()])),
+            ("b.do", TaskDef::Sequential(vec!["a.do".to_string()])),
+        ]);
+
+        let result = TaskGraph::from_config(&scripts);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Circular dependency"));
+    }
+
+    #[test]
+    fn test_bare_unknown_name_still_errors() {
+        let scripts = make_scripts(vec![(
+            "all",
+            TaskDef::Sequential(vec!["analyze".to_string()]),
+        )]);
+
+        let result = TaskGraph::from_config(&scripts);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("references unknown task"));
+    }
+
+    #[test]
+    fn test_is_script_ref() {
+        assert!(is_script_ref("src/02_analyze.do"));
+        assert!(is_script_ref("analyze.do"));
+        assert!(is_script_ref("src\\analyze.do"));
+        assert!(!is_script_ref("analyze"));
+        assert!(!is_script_ref("clean"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #64. `all = ["clean", "src/02_analyze.do"]` now works: entries that don't match a defined task and look like a path (`/`, `\\`, or `.do`) run as scripts. Defined task names take precedence, so existing configs are unaffected; bare unknown names still error. Verified against real Stata (path entry runs, unknown bare name still errors). `make check` passes locally.