### PR TITLE
ci: grant actions:write so release can dispatch homebrew update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ env:
 
 permissions:
   contents: write
+  actions: write # dispatch homebrew.yml from the release job
 
 jobs:
   build:


### PR DESCRIPTION
v1.3.0's Release run published fine but failed its last step: `gh workflow run homebrew.yml` → HTTP 403. Same workflow succeeded on v1.2.1, so the default `GITHUB_TOKEN` permissions have tightened since. Grants `actions: write` explicitly. (v1.3.0's homebrew update was dispatched manually.)