### PR TITLE
fix: dedupe .pkg manifest entries; add stacy lock --refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `stacy lock --refresh`: recompute lockfile checksums from the installed cache.
+
+### Fixed
+
+- Packages whose `.pkg` manifest lists a file twice (e.g. reghdfe) no longer fail checksum verification (#68). Run `stacy lock --refresh` to repair lockfile entries recorded by older versions.
+
 ## [1.3.0] - 2026-07-09
 
 ### Changed
 
-- `stacy run` streams program output to stdout live in piped mode, matching `Rscript`/`python`, instead of printing it after execution (#24). Output content is unchanged (boilerplate-stripped); stacy's status and error messages stay on stderr. Note: on failure, partial output now appears on stdout before the failure is reported.
-- The batch log file is now internal: removed on success, kept on failure (path shown in the failure output). Machine-readable formats (`--format json|stata`) keep the log since their output references it. Use `--log <path>` for a durable log artifact.
-- `--parallel` prints each script's output as a grouped block on completion (`==> script.do <==` headers on stdout, status lines on stderr) instead of discarding it.
-- Raw `-v` streaming runs to process exit instead of stopping a few lines after the end-of-do-file marker.
-- `stacy task` output streams live as well (tasks run with the same piped-mode default).
+- `stacy run` streams program output to stdout live in piped mode, like `Rscript` (#24). Same content as before, just live; status and errors stay on stderr. `stacy task` streams too.
+- The log file is now internal: removed on success, kept on failure. Machine-readable formats keep it. Use `--log <path>` for a durable artifact.
+- `--parallel` prints each script's output as a grouped block on completion instead of discarding it.
 
 ### Added
 
@@ -27,13 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Sequential/parallel task arrays now accept script paths (`all = ["clean", "src/02_analyze.do"]`), as the docs showed (#64). Defined task names take precedence.
-- Post-install dependency hints now comma-separate package names (`appears to need ftools, require`) instead of running them together (#63).
-- Failure context no longer loads the entire log into memory to number its last 20 lines (#66).
-- Log streaming (`-v`, `-vv`, TTY default) no longer hangs forever when Stata is killed (`--timeout` watchdog, external SIGKILL) or fails to launch without creating a log (#24).
-- `stacy run foo.do | head` no longer panics when the downstream pipe closes.
-- Log streaming now recovers from a truncated/recreated log file and no longer emits partially-written lines.
-- `--trace` no longer leaks its temporary traced script and log file on exit.
+- Task arrays accept script paths: `all = ["clean", "src/02_analyze.do"]` (#64).
+- Post-install hints comma-separate package names (#63).
+- Failure context no longer loads the entire log into memory (#66).
+- Log streaming no longer hangs when Stata is killed or fails to launch, recovers from truncated logs, and survives closed pipes (`| head`).
+- `--trace` no longer leaks its temp script and log.
 
 ## [1.2.1] - 2026-05-06
 

--- a/docs/src/commands/lock.md
+++ b/docs/src/commands/lock.md
@@ -19,6 +19,7 @@ to verify the lockfile is up-to-date.
 | Option | Description |
 |--------|-------------|
 | `--check` | Verify lockfile matches stacy.toml without updating |
+| `--refresh` | Recompute checksums from the packages installed in the global cache |
 
 ## Examples
 

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -644,6 +644,7 @@ see_also = ["install", "update", "../configuration/lockfile.md"]
 
 [commands.lock.args]
 check = { type = "bool", description = "Verify lockfile matches stacy.toml without updating", stata_option = "CHECK" }
+refresh = { type = "bool", description = "Recompute checksums from the packages installed in the global cache", stata_option = "REFRESH" }
 json = { type = "bool", description = "JSON output (internal)" }
 
 [commands.lock.returns]

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -8,7 +8,6 @@ use crate::error::{Error, Result};
 use crate::packages::global_cache;
 use crate::packages::installer::{install_package, install_package_github, is_package_installed};
 use crate::packages::lockfile::{check_version_mismatch, load_lockfile, verify_lockfile_sync};
-use crate::packages::ssc::{calculate_combined_checksum, calculate_sha256};
 use crate::project::config::load_config;
 use crate::project::{PackageSource, Project};
 use clap::Args;
@@ -446,23 +445,8 @@ fn verify_package_checksum(name: &str, entry: &crate::project::PackageEntry) -> 
         return Some(false);
     }
 
-    // Collect SHA256 of every file in cache dir
-    let mut checksums = Vec::new();
-    let entries = std::fs::read_dir(&cache_dir).ok()?;
-    for dir_entry in entries {
-        let dir_entry = dir_entry.ok()?;
-        if dir_entry.path().is_file() {
-            let content = std::fs::read(dir_entry.path()).ok()?;
-            checksums.push(calculate_sha256(&content));
-        }
-    }
-
-    if checksums.is_empty() {
-        return Some(false);
-    }
-
-    // calculate_combined_checksum sorts internally (H2 fix)
-    let actual = calculate_combined_checksum(&checksums);
+    // Same hash `stacy add` records at download time
+    let actual = global_cache::hash_package_dir(&cache_dir)?;
     Some(actual == expected)
 }
 
@@ -581,6 +565,7 @@ fn print_sync_human_output(results: &[SyncedPackage]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::packages::ssc::{calculate_combined_checksum, calculate_sha256};
     use serial_test::serial;
     use tempfile::TempDir;
 

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -19,11 +19,17 @@ use clap::Args;
 #[command(after_help = "\
 Examples:
   stacy lock                              Generate/update lockfile
-  stacy lock --check                      Verify lockfile is in sync")]
+  stacy lock --check                      Verify lockfile is in sync
+  stacy lock --refresh                    Recompute checksums from installed packages")]
 pub struct LockArgs {
     /// Verify lockfile matches stacy.toml without updating (exit 1 if out of sync)
-    #[arg(long)]
+    #[arg(long, conflicts_with = "refresh")]
     pub check: bool,
+
+    /// Recompute checksums from the packages installed in the global cache
+    /// (repairs entries recorded by older stacy versions, see #68)
+    #[arg(long)]
+    pub refresh: bool,
 
     /// Output format: human (default), json, or stata
     #[arg(long, value_enum, default_value = "human")]
@@ -264,6 +270,34 @@ pub fn execute(args: &LockArgs) -> Result<()> {
         }
     }
 
+    // Refresh mode: recompute checksums from the global cache so the
+    // lockfile matches what `stacy install` verifies against. Repairs
+    // entries recorded before duplicate manifest entries were deduped (#68).
+    let mut refreshed_count = 0;
+    if args.refresh {
+        for (name, entry) in lockfile.packages.iter_mut() {
+            let Ok(cache_dir) = crate::packages::global_cache::package_path(name, &entry.version)
+            else {
+                continue;
+            };
+            let Some(actual) = crate::packages::global_cache::hash_package_dir(&cache_dir) else {
+                if format == OutputFormat::Human {
+                    eprintln!("  Warning: {} not in cache, checksum left unchanged", name);
+                }
+                continue;
+            };
+            let new_checksum = format!("sha256:{}", actual);
+            if entry.checksum.as_deref() != Some(new_checksum.as_str()) {
+                entry.checksum = Some(new_checksum);
+                updated = true;
+                refreshed_count += 1;
+                if format == OutputFormat::Human {
+                    println!("  ~ {} (checksum recomputed)", name);
+                }
+            }
+        }
+    }
+
     // Save lockfile if updated
     if updated {
         save_lockfile(&project.root, &lockfile)?;
@@ -288,6 +322,9 @@ pub fn execute(args: &LockArgs) -> Result<()> {
                 }
                 if removed_count > 0 {
                     summary.push(format!("{} removed", removed_count));
+                }
+                if refreshed_count > 0 {
+                    summary.push(format!("{} checksum(s) recomputed", refreshed_count));
                 }
                 println!(
                     "Updated stacy.lock: {} ({} total packages)",

--- a/src/packages/global_cache.rs
+++ b/src/packages/global_cache.rs
@@ -369,8 +369,49 @@ pub fn clean_unused_packages(lockfiles: &[&Lockfile]) -> Result<usize> {
     Ok(removed)
 }
 
+/// Combined checksum of every file in an installed package directory.
+///
+/// This is the same quantity `stacy add` records at download time: per-file
+/// SHA256s combined order-independently. Returns None if the directory can't
+/// be read or contains no files.
+pub fn hash_package_dir(dir: &std::path::Path) -> Option<String> {
+    use crate::packages::ssc::{calculate_combined_checksum, calculate_sha256};
+
+    let mut checksums = Vec::new();
+    for entry in std::fs::read_dir(dir).ok()? {
+        let entry = entry.ok()?;
+        if entry.path().is_file() {
+            let content = std::fs::read(entry.path()).ok()?;
+            checksums.push(calculate_sha256(&content));
+        }
+    }
+    if checksums.is_empty() {
+        return None;
+    }
+    Some(calculate_combined_checksum(&checksums))
+}
+
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn test_hash_package_dir_matches_download_checksum() {
+        use crate::packages::ssc::{calculate_combined_checksum, calculate_sha256};
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("pkg.ado"), b"program define pkg\nend\n").unwrap();
+        std::fs::write(dir.path().join("pkg.sthlp"), b"help text\n").unwrap();
+
+        // What `stacy add` records: per-file hashes, combined
+        let expected = calculate_combined_checksum(&[
+            calculate_sha256(b"program define pkg\nend\n"),
+            calculate_sha256(b"help text\n"),
+        ]);
+        assert_eq!(hash_package_dir(dir.path()), Some(expected));
+
+        // Empty dir -> None
+        let empty = tempfile::TempDir::new().unwrap();
+        assert_eq!(hash_package_dir(empty.path()), None);
+    }
+
     use super::*;
     use serial_test::serial;
     use std::collections::HashMap;

--- a/src/packages/pkg_parser.rs
+++ b/src/packages/pkg_parser.rs
@@ -171,9 +171,12 @@ pub fn parse_pkg_file(content: &str, package_name: &str) -> Result<PackageManife
                 }
             }
             'f' | 'F' => {
-                // File line
+                // File line. Some manifests list the same file twice (e.g.
+                // reghdfe); dedupe here so download, install, and checksum
+                // all see one entry per file — verification hashes the
+                // unique files on disk (#68).
                 let filename = line[1..].trim();
-                if !filename.is_empty() {
+                if !filename.is_empty() && !files.iter().any(|f: &PackageFile| f.name == filename) {
                     let file_type = filename
                         .rsplit('.')
                         .next()
@@ -243,6 +246,23 @@ pub fn parse_pkg_file(content: &str, package_name: &str) -> Result<PackageManife
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn test_duplicate_file_entries_deduped() {
+        // reghdfe's manifest lists some files twice (#68)
+        let pkg = "d 'REGHDFE': module to run linear models\n\
+f reghdfe.ado\n\
+f reghdfe5_parse.ado\n\
+f reghdfe.mata\n\
+f reghdfe5_parse.ado\n\
+f reghdfe.mata\n";
+        let manifest = parse_pkg_file(pkg, "reghdfe").unwrap();
+        let names: Vec<_> = manifest.files.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["reghdfe.ado", "reghdfe5_parse.ado", "reghdfe.mata"]
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/stata/stacy_lock.ado
+++ b/stata/stacy_lock.ado
@@ -12,6 +12,7 @@
 
     Options:
         CHECK                - Verify lockfile matches stacy.toml without updating
+        REFRESH              - Recompute checksums from the packages installed in the global cache
 
     Returns:
         r(in_sync             ) - Whether lockfile is in sync (1=yes, 0=no) (scalar)
@@ -22,13 +23,17 @@
 
 program define stacy_lock, rclass
     version 14.0
-    syntax [, CHECK]
+    syntax [, CHECK REFRESH]
 
     * Build command arguments
     local cmd "lock"
 
     if "`check'" != "" {
         local cmd `"`cmd' --check"'
+    }
+
+    if "`refresh'" != "" {
+        local cmd `"`cmd' --refresh"'
     }
 
     * Execute via _stacy_exec

--- a/stata/stacy_lock.sthlp
+++ b/stata/stacy_lock.sthlp
@@ -22,6 +22,7 @@
 {synoptline}
 {syntab:Main}
 {synopt:{opt:check}}Verify lockfile matches stacy.toml without updating{p_end}
+{synopt:{opt:refresh}}Recompute checksums from the packages installed in the global cache{p_end}
 {synoptline}
 
 
@@ -37,6 +38,9 @@
 
 {phang}
 {opt check} verify lockfile matches stacy.toml without updating.
+
+{phang}
+{opt refresh} recompute checksums from the packages installed in the global cache.
 
 
 {marker returns}{...}


### PR DESCRIPTION
Closes #68.

`add` hashed all manifest entries including duplicates (reghdfe lists `reghdfe5_parse.ado` and `reghdfe.mata` twice → 24 hashes) while `install` verified against the unique files on disk (22) — verification was structurally impossible.

- Dedupe file entries in `parse_pkg_file` (fixes SSC and GitHub paths, and double-downloads)
- Extract `global_cache::hash_package_dir`, shared by install verification and the new repair path
- `stacy lock --refresh`: recompute checksums from the installed cache — repairs lockfiles recorded by older versions without network or version changes

Verified live against SSC reghdfe: add → install verifies 1/1; tampered checksum fails; `lock --refresh` repairs and verification passes. `make check` passes locally.