### PR TITLE
fix: print the kept log path on failure for single-script and -c runs

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -557,7 +557,12 @@ fn execute_inline(args: &RunArgs) -> Result<()> {
                 if let Some(error) = result.errors.first() {
                     print_error_details(error);
                 }
-                // Log context only when not quiet and log wasn't already streamed
+                // Failure keeps its log — always say where it is (CI/batch too).
+                // Streaming shows the log's content, not the kept file's path.
+                if !result.log_file.as_os_str().is_empty() {
+                    eprintln!("\n   Log: {}", result.log_file.display());
+                }
+                // Short excerpt only when the log wasn't already streamed live.
                 if !verbosity.is_quiet()
                     && !verbosity.should_stream_raw()
                     && !verbosity.should_stream_clean()
@@ -570,8 +575,6 @@ fn execute_inline(args: &RunArgs) -> Result<()> {
                     if let Ok(raw) = crate::executor::log_reader::read_full_log(&result.log_file) {
                         let clean = crate::executor::log_reader::strip_boilerplate(&raw);
                         if !clean.is_empty() {
-                            eprintln!();
-                            eprintln!("   Log:");
                             print_log_context_n(&clean, context_lines);
                         }
                     }
@@ -848,7 +851,12 @@ fn execute_single(script_path: &Path, args: &RunArgs) -> Result<()> {
                 if let Some(error) = result.errors.first() {
                     print_error_details(error);
                 }
-                // Log context only when not quiet and log wasn't already streamed
+                // Failure keeps its log — always say where it is (CI/batch too).
+                // Streaming shows the log's content, not the kept file's path.
+                if !result.log_file.as_os_str().is_empty() {
+                    eprintln!("\n   Log: {}", result.log_file.display());
+                }
+                // Short excerpt only when the log wasn't already streamed live.
                 if !verbosity.is_quiet()
                     && !verbosity.should_stream_raw()
                     && !verbosity.should_stream_clean()
@@ -858,7 +866,6 @@ fn execute_single(script_path: &Path, args: &RunArgs) -> Result<()> {
                     } else {
                         FAILURE_CONTEXT_LINES
                     };
-                    eprintln!("\n   Log: {}", result.log_file.display());
                     if let Ok(raw) = crate::executor::log_reader::read_full_log(&result.log_file) {
                         let clean = crate::executor::log_reader::strip_boilerplate(&raw);
                         if !clean.is_empty() {


### PR DESCRIPTION
Closes #75.

The `Log: <path>` line in the FAIL block was dead code for the two most common failure paths. The single-script (`run.rs:861`) and inline `-c` (`run.rs:574`) blocks gated it behind `!is_quiet() && !should_stream_raw() && !should_stream_clean()`. Since 1.3.0 streams clean output by default in both interactive and piped mode, every verbosity mode tripped a clause, so the path was never shown — only the `--parallel` summary (unguarded) printed it.

Now the `Log:` path prints unconditionally on failure in both paths (guarded only against an empty path, like the parallel summary already does). Streaming shows the log's *content*, not the kept file's *path*, so it isn't redundant. The short log excerpt stays gated as before.

Verified live against real Stata on a failing script — the path now prints in all five modes (single-script interactive/piped/quiet/`-v`, and inline `-c`); previously none of the single-script or `-c` modes did. This also un-blocks the pre-existing `#[ignore]` test `test_run_single_script_failure_shows_log_path`. `make check` passes locally.