### PR TITLE
docs: framing sync for 1.3.x (two interfaces, log policy, exit codes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,23 +16,21 @@
 
 ---
 
-Stata projects need to compose: with build systems that expect exit codes, with environments that must be reconstructed, with pipelines that mix languages. But Stata leaves two things implicit that composition requires to be explicit.
+Stata projects increasingly run inside larger workflows — a Makefile that rebuilds results when inputs change, a CI service that reruns an analysis on every commit, a replication package that must run unattended on a stranger's machine. Integration like this rests on two things Stata leaves implicit: whether a step succeeded, and what the project needs in order to run.
 
-**The outcome is implicit.** Batch mode (`stata-mp -b do script.do`) returns exit code 0 even when scripts fail. Build systems, CI pipelines, and downstream scripts cannot detect failure — they proceed as if nothing went wrong.
+**The outcome is implicit.** In batch mode, Stata returns exit code 0 whether the script succeeded or failed — errors are recorded in the log and nowhere else. Build systems, schedulers, and downstream scripts proceed as if nothing went wrong.
 
-**The environment is implicit.** Packages install to a global path — no manifest, no lockfile, no isolation between projects. Each `ssc install` retrieves whatever version exists today; a collaborator installing later gets a different version entirely.
+**The environment is implicit.** User-written packages install into one global directory shared by every project; no file records what a project depends on. Each `ssc install` retrieves whatever version exists that day, so a collaborator installing months later may get a different program — and different results.
 
-**stacy** makes both explicit:
+**stacy** makes both explicit. It is a task runner and package manager for Stata — one program, used from the terminal or the Stata console:
 
 ```bash
-# Proper exit codes
-stacy run analysis.do
-echo $?  # 0 on success, 1-10 on error
-
-# Lockfile-based dependencies
-stacy add estout reghdfe    # Declares in stacy.toml, locks in stacy.lock
-stacy install               # Installs exact versions from lockfile
+stacy run analysis.do       # exits 0 on success, 1-10 on error
+stacy add estout reghdfe    # declares in stacy.toml, locks in stacy.lock
+stacy install               # installs exact versions from the lockfile
 ```
+
+The Stata wrappers are generated from the same schema as the CLI, so commands work unchanged in both interfaces — `. stacy run analysis.do, timeout(600)` — and `help stacy` works as expected.
 
 | If you know... | stacy is like... |
 |----------------|----------------|
@@ -61,11 +59,10 @@ cargo install --git https://github.com/janfasnacht/stacy.git
 ## Quick Start
 
 ```bash
-stacy run analysis.do          # Run with error detection
-stacy init                     # Initialize project
-stacy add estout reghdfe       # Add packages (creates lockfile)
-stacy install                  # Install from lockfile
-stacy doctor                   # Check setup
+stacy init                     # Scaffold stacy.toml
+stacy add estout reghdfe       # Declare and lock packages
+stacy install                  # Reproduce from the lockfile
+stacy doctor                   # Check your setup
 ```
 
 ## Learn More

--- a/docs/src/commands/bench.md
+++ b/docs/src/commands/bench.md
@@ -24,7 +24,7 @@ caching effects.
 
 | Option | Description |
 |--------|-------------|
-| `--no_warmup` | Skip warmup runs |
+| `--no-warmup` | Skip warmup runs |
 | `-q, --quiet` | Suppress progress output |
 | `-n, --runs` | Number of measured runs |
 | `-w, --warmup` | Number of warmup runs |

--- a/docs/src/commands/install.md
+++ b/docs/src/commands/install.md
@@ -19,7 +19,7 @@ lockfile. Can also install individual packages directly from SSC or GitHub.
 | Option | Description |
 |--------|-------------|
 | `--frozen` | Fail if lockfile doesn't match stacy.toml |
-| `--no_verify` | Skip checksum verification |
+| `--no-verify` | Skip checksum verification |
 | `--with` | Include dependency groups (comma-separated: dev, test) |
 
 ## Examples

--- a/docs/src/commands/run.md
+++ b/docs/src/commands/run.md
@@ -31,7 +31,7 @@ The batch log file is internal: removed on success, kept on failure. Use
 Multiple scripts can be run sequentially (default, fail-fast) or in parallel
 (`--parallel`). Parallel mode runs all scripts regardless of failures.
 
-For interactive use where you want to quickly check a result, see `stacy eval`.
+To check a quick result without a script file, use `stacy run -c 'display ...'`.
 
 ## Arguments
 
@@ -43,9 +43,9 @@ For interactive use where you want to quickly check a result, see `stacy eval`.
 
 | Option | Description |
 |--------|-------------|
-| `--allow_global` | Allow globally installed packages |
+| `--allow-global` | Allow globally installed packages |
 | `--cache` | Enable build cache (skip re-execution if script/deps unchanged) |
-| `--cache_only` | Fail if not in cache (useful for CI) |
+| `--cache-only` | Fail if not in cache (useful for CI) |
 | `--cd` | Change to script's parent directory |
 | `-c, --code` | Inline Stata code |
 | `-C, --directory` | Run Stata in this directory |
@@ -125,8 +125,8 @@ stacy run --format json analysis.do
 Enable Stata's set trace on for debugging
 
 ```bash
-stt run --trace 2 analysis.do
-stt run --trace 2 -v analysis.do
+stacy run --trace 2 analysis.do
+stacy run --trace 2 -v analysis.do
 ```
 
 ### Timeout
@@ -154,7 +154,6 @@ See [Exit Codes Reference](../reference/exit-codes.md) for details.
 
 ## See Also
 
-- [stacy eval](./eval.md)
 - [stacy bench](./bench.md)
 - [stacy task](./task.md)
 - [Exit Codes](../reference/exit-codes.md)

--- a/docs/src/commands/run.md
+++ b/docs/src/commands/run.md
@@ -24,9 +24,9 @@ failure, error details with official Stata documentation links and the log
 file path are displayed. Use `-v` to stream the raw log instead, or `-q` to
 suppress all output.
 
-The batch log file is internal: removed on success, kept on failure. Use
-`--log <path>` to keep the raw Stata log as a durable artifact
-(`--quiet --log out.log` for a silent file-only run).
+The batch log file is internal: removed on success, kept on failure with its
+path printed in the failure output. Use `--log <path>` to keep the raw Stata
+log as a durable artifact (`--quiet --log out.log` for a silent file-only run).
 
 Multiple scripts can be run sequentially (default, fail-fast) or in parallel
 (`--parallel`). Parallel mode runs all scripts regardless of failures.

--- a/docs/src/commands/update.md
+++ b/docs/src/commands/update.md
@@ -24,7 +24,7 @@ changes without applying them.
 
 | Option | Description |
 |--------|-------------|
-| `--dry_run` | Show what would be updated without making changes |
+| `--dry-run` | Show what would be updated without making changes |
 
 ## Examples
 

--- a/docs/src/configuration/project.md
+++ b/docs/src/configuration/project.md
@@ -113,14 +113,14 @@ clean = "src/01_clean.do"
 analyze = "src/02_analyze.do"
 tables = "src/03_tables.do"
 
-# Sequential: an array runs other *tasks* in order (task names, not paths)
-build = ["clean", "analyze", "tables"]
+# Sequential: an array runs tasks (or script paths) in order
+build = ["clean", "analyze", "src/03_tables.do"]
 
-# Parallel: run other tasks concurrently
+# Parallel: run tasks (or script paths) concurrently
 outputs = { parallel = ["analyze", "tables"] }
 ```
 
-Array entries and `parallel` lists must be names of other tasks; to run a script, give it a name first. The object form also supports `script`, `args`, and `description` keys:
+Array entries and `parallel` lists may name other tasks or point directly at script paths. The object form also supports `script`, `args`, and `description` keys:
 
 ```toml
 analyze = { script = "src/02_analyze.do", description = "Main estimates" }

--- a/docs/src/configuration/project.md
+++ b/docs/src/configuration/project.md
@@ -38,7 +38,8 @@ assert = "ssc"
 
 [scripts]
 clean = "src/01_clean.do"
-build = ["clean", "src/02_build.do", "src/03_analyze.do"]
+analyze = "src/02_analyze.do"
+build = ["clean", "analyze"]
 ```
 
 ## Sections
@@ -107,14 +108,22 @@ Task definitions for [`stacy task`](../commands/task.md). Supports three formats
 
 ```toml
 [scripts]
-# Simple: run a single script
+# Simple: a task is a script path
 clean = "src/01_clean.do"
+analyze = "src/02_analyze.do"
+tables = "src/03_tables.do"
 
-# Sequential: run tasks/scripts in order
-build = ["clean", "src/02_build.do", "src/03_analyze.do"]
+# Sequential: an array runs other *tasks* in order (task names, not paths)
+build = ["clean", "analyze", "tables"]
 
-# Parallel: run scripts concurrently
-test = { parallel = ["test/test1.do", "test/test2.do"] }
+# Parallel: run other tasks concurrently
+outputs = { parallel = ["analyze", "tables"] }
+```
+
+Array entries and `parallel` lists must be names of other tasks; to run a script, give it a name first. The object form also supports `script`, `args`, and `description` keys:
+
+```toml
+analyze = { script = "src/02_analyze.do", description = "Main estimates" }
 ```
 
 ## Important Notes
@@ -196,8 +205,9 @@ estout = "ssc"
 
 [scripts]
 clean = "src/01_clean.do"
-build = ["clean", "src/02_build.do"]
-all = ["build", "src/03_report.do"]
+build = "src/02_build.do"
+report = "src/03_report.do"
+all = ["clean", "build", "report"]
 ```
 
 ### CI-Friendly

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -17,7 +17,8 @@ stacy works standalone. You get error detection, lockfile packages, and the task
 ```toml
 [scripts]
 clean = "clean_data.do"
-all = ["clean", "analysis.do"]
+analysis = "analysis.do"
+all = ["clean", "analysis"]
 ```
 
 ```bash
@@ -75,6 +76,7 @@ No. stacy manages packages in its own cache and sets `S_ADO` at runtime.
 | 3 | File error |
 | 4 | Memory error |
 | 5 | Internal error |
+| 6 | Statistical error |
 | 10 | Environment error |
 
 ## Updates
@@ -101,6 +103,6 @@ Stata 14+ (MP, SE, BE, StataNow).
 
 Yes. Set `STATA_BINARY` environment variable.
 
-### Does stacy work with Stata GUI?
+### Can I use stacy without leaving Stata?
 
-stacy is for command-line workflows (batch mode). Use Stata directly for interactive work.
+Yes. Installing the Stata wrappers (`net install stacy, from("https://stacy.janfasnacht.com/stata")`) makes every command available from the Stata console: `stacy run analysis.do`, `stacy add estout`, and so on, with `help stacy` documentation. Under the hood, `stacy run` still executes your script in a fresh batch-mode Stata process -- that separate process is what makes the outcome observable and the environment isolated.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,12 +1,12 @@
 # Introduction
 
-[![Version](https://img.shields.io/badge/version-1.2.0-blue)](https://github.com/janfasnacht/stacy/releases)
+[![Version](https://img.shields.io/github/v/release/janfasnacht/stacy?label=version&color=blue)](https://github.com/janfasnacht/stacy/releases)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/janfasnacht/stacy/blob/main/LICENSE)
 [![GitHub](https://img.shields.io/badge/github-janfasnacht/stacy-black)](https://github.com/janfasnacht/stacy)
 
-Stata projects need to compose: with build systems that expect exit codes, with environments that must be reconstructed, with pipelines that mix languages. But Stata leaves two things implicit that composition requires to be explicit: the outcome — whether execution succeeded — and the environment — what packages the project needs.
+Stata projects increasingly run inside larger workflows — a Makefile that rebuilds results when inputs change, a CI service that reruns an analysis on every commit, a replication package that must run unattended on a stranger's machine. Integration like this rests on two things Stata leaves implicit: whether a step succeeded, and what the project needs in order to run.
 
-**stacy** makes both explicit. Dependencies get a manifest and lockfile; execution gets proper exit codes. With these primitives, Stata projects can be versioned, automated, and reproduced.
+**stacy** makes both explicit. It is a task runner and package manager for Stata: `stacy run` executes a script, parses the log, and returns a proper exit code, while `stacy add` and `stacy install` maintain a manifest and lockfile for dependencies. Every command works from both the terminal and the Stata console. With these primitives, Stata projects can be automated, versioned, and reproduced.
 
 | If you know... | stacy is like... | Key similarity |
 |----------------|----------------|----------------|

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -47,6 +47,34 @@ results/output.dta: analysis.do data/input.dta
     stacy run analysis.do   # Stops on failure
 ```
 
+## One Tool, Two Interfaces
+
+stacy is a single binary you can drive from the terminal or from inside Stata:
+
+```bash
+# Terminal
+$ stacy run analysis.do --timeout 600
+```
+
+```stata
+. stacy run analysis.do, timeout(600)
+```
+
+The Stata commands are thin wrappers around the same binary, generated from the same command schema as the command-line interface, so the two never drift apart. `help stacy` works as for any other Stata package. See [Installation](./installation.md#from-within-stata) for setup.
+
+## What stacy Manages (and What It Doesn't)
+
+stacy makes two things explicit -- execution outcomes and the package environment -- and stays out of everything else:
+
+| stacy manages | stacy does not manage |
+|---------------|----------------------|
+| Whether a script succeeded (exit codes) | Orchestrating large pipelines (use Make/Snakemake on top) |
+| Which packages a project needs (manifest) | The Stata version itself (use Docker for full-stack pinning) |
+| Which exact versions are installed (lockfile + checksums) | Data files or other languages' environments |
+| Where Stata looks for packages at runtime (`S_ADO`) | Transitive dependencies (Stata packages don't declare them reliably) |
+
+This makes stacy a small, composable piece of infrastructure rather than a framework: it slots under whatever build system, scheduler, or CI service you already use.
+
 ## At a Glance
 
 | Without stacy | With stacy |

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -1,5 +1,7 @@
 # Quick Start
 
+This page uses terminal commands. If you installed the [Stata wrappers](./installation.md#from-within-stata), every command also works from the Stata console -- `. stacy run analysis.do` instead of `$ stacy run analysis.do`.
+
 ## 1. Verify Setup
 
 ```bash

--- a/docs/src/reference/exit-codes.md
+++ b/docs/src/reference/exit-codes.md
@@ -17,15 +17,19 @@ stacy uses consistent exit codes to indicate success or failure type.
 
 ## Stata r() Code Mapping
 
-stacy maps Stata's r() error codes to exit codes:
+The number inside `r(N)` is preserved in stacy's output (JSON field `r_code`, stored result `r(exit_code)` in Stata). The *shell* exit code is a category derived from it, in two steps:
+
+1. **Error database lookup.** stacy extracts error descriptions and categories from your local Stata installation (run `stacy doctor --refresh` after a Stata upgrade). If the code is found there, its category decides the exit code.
+2. **Range fallback.** Otherwise, the documented ranges from Stata's Programming Reference Manual apply:
 
 | Exit Code | Stata r() Codes |
 |-----------|----------------|
-| 1 | most r() codes not in other categories |
-| 2 | r(198), r(199) |
-| 3 | r(601), r(603), r(610), r(639), r(2000-2999) |
-| 4 | r(950) |
+| 1 | all r() codes not in other categories |
+| 2 | r(100)-r(199), e.g. r(198), r(199) |
+| 3 | r(600)-r(699), e.g. r(601), r(603) |
+| 4 | r(900)-r(999), e.g. r(950) |
 | 6 | r(400)-r(499) |
+| 10 | r(800)-r(899) |
 
 ## Usage
 
@@ -43,11 +47,13 @@ results.dta: analysis.do
 	stacy run analysis.do  # Stops on non-zero exit
 ```
 
+This mapping is many-to-one by design: it compresses Stata's hundreds of return codes into a small, stable set that build tools can branch on.
+
 ## Stability
 
 Exit codes 0-10 are stable and will not change meaning. New categories may be added with codes 11+.
 
 ## See Also
 
-- [Error Detection](./errors.md)
+- [Error Detection](./how-it-works.md#error-detection)
 - [stacy run](../commands/run.md)

--- a/docs/src/reference/how-it-works.md
+++ b/docs/src/reference/how-it-works.md
@@ -1,13 +1,41 @@
 # How It Works
 
-Technical details on stacy's architecture.
+What actually happens when stacy runs a script or installs a package. stacy has four moving parts: an execution engine, an error detector, package management, and a build cache. This page walks through each, then covers the machine interface and stacy's boundaries.
 
 ## Contents
 
+- [Script Execution](#script-execution)
 - [Error Detection](#error-detection)
 - [Package Isolation](#package-isolation)
+- [Build Cache](#build-cache)
 - [Output Streaming](#output-streaming)
 - [Machine Interface](#machine-interface)
+- [What stacy Does Not Do](#what-stacy-does-not-do)
+
+---
+
+## Script Execution
+
+`stacy run script.do` does four things:
+
+```
+┌───────────┐     ┌───────────┐     ┌─────────┐     ┌──────────┐
+│ Build     │ ──▶ │ Stata     │ ──▶ │ Log     │ ──▶ │ Exit     │
+│ S_ADO     │     │ -b -q     │     │ Parser  │     │ Code 0-10│
+└───────────┘     └───────────┘     └─────────┘     └──────────┘
+ from lockfile     fresh process     from the end    translated
+```
+
+1. **Build the environment.** If a lockfile is present, stacy constructs the `S_ADO` search path from it, so Stata sees exactly the locked packages (see [Package Isolation](#package-isolation)).
+2. **Run Stata.** The script runs in a fresh batch-mode process (`-b -q`). The `-q` flag skips your `profile.do`, so execution doesn't depend on machine-specific startup configuration.
+3. **Parse the log.** stacy reads the log Stata produced and determines whether the script succeeded (see [Error Detection](#error-detection)).
+4. **Translate the outcome.** Stata error codes become standard shell exit codes that any build tool understands.
+
+Extras that matter in practice:
+
+- `--timeout <seconds>` kills a hung script (SIGTERM, then SIGKILL after a grace period) -- useful for convergence loops on shared clusters.
+- `--parallel` runs multiple scripts concurrently, each in its own Stata process; output prints as a grouped block per script on completion, and internal logs are uniquely named, so `make -j` and Snakemake can run same-named scripts safely.
+- `-c 'display ...'` runs inline code without a script file.
 
 ---
 
@@ -15,71 +43,37 @@ Technical details on stacy's architecture.
 
 ### The Problem
 
-Stata's batch mode (`stata -b do script.do`) always exits with code 0, even when scripts fail. Errors are only visible in log files.
+Stata's batch mode always exits with code 0, even when scripts fail. Errors are only visible in log files.
 
 ### stacy's Solution
 
-1. **Execute**: stacy runs Stata with `-b -q` flags
-2. **Parse**: After Stata exits, stacy parses the log file
-3. **Detect**: Matches against Stata's official `r()` error codes
-4. **Report**: Returns appropriate exit code (1-10)
+stacy parses the log **from the end**. It locates the last `end of do-file` marker -- which corresponds to the outermost do-file in nested execution -- and scans the lines after it for a return-code pattern (`r(N);`). Found: the script failed with that code. Not found: it succeeded.
+
+This design handles the edge cases correctly:
+
+| Scenario | Behavior |
+|----------|----------|
+| Uncaptured error, e.g. `r(601)` | `r(N);` appears after the final marker -- failure |
+| `capture`d error | Doesn't propagate past `end of do-file` -- success |
+| Error in a nested do-file | Propagates to the outermost marker -- failure |
+| Script *prints* `"r(199);"` | Appears before the marker -- ignored |
+| Stata killed / crashed | No final marker at all -- reported as error, never as success |
+
+The error-detection logic is exercised by a test suite of 250+ cases covering nested do-files, captured errors, false positives from display output, and incomplete logs.
+
+### Error Descriptions
+
+To describe an error rather than just number it, stacy extracts Stata's own error descriptions from your installation at first run (`stacy doctor --refresh` re-extracts after a Stata upgrade). Where no description is available, it falls back to the documented range categories -- see [Exit Codes](./exit-codes.md) for the mapping.
+
+Failures print a human-readable description plus a link to the official manual page, so you can diagnose a remote job from the error output alone:
 
 ```
-┌───────────┐     ┌───────┐     ┌─────────┐     ┌──────────┐
-│ stacy run │ ──▶ │ Stata │ ──▶ │ Log     │ ──▶ │ Exit     │
-│           │     │ -b -q │     │ Parser  │     │ Code 0-10│
-└───────────┘     └───────┘     └─────────┘     └──────────┘
+FAIL  broken.do  (0.8s)
+
+   Error: r(199) - unrecognized command
+
+   See: https://www.stata.com/manuals/perror.pdf#r199
 ```
-
-### Error Patterns
-
-stacy recognizes errors in two forms:
-
-**r() codes** (primary):
-```
-r(199);
-```
-
-**Error messages** (secondary):
-```
-unrecognized command: foobar
-file myfile.dta not found
-```
-
-### Official Stata Error Codes
-
-stacy extracts error codes from your Stata installation at runtime (`stacy doctor` triggers this). It falls back to range-based categories from the [Stata Programming Reference Manual](https://www.stata.com/manuals/perror.pdf):
-
-| Range | Category | Examples |
-|-------|----------|----------|
-| r(1-99) | General errors | r(1) generic error |
-| r(100-199) | Syntax/variable errors | r(111) not found, r(199) unrecognized command |
-| r(400-499) | System limits | r(459) not sorted |
-| r(600-699) | File errors | r(601) file not found, r(603) file exists |
-| r(900-999) | Resource errors | r(950) insufficient memory |
-
-### 10 Most Common Errors
-
-| Code | Name | Typical Cause |
-|------|------|---------------|
-| r(100) | varlist required | Command needs variable list |
-| r(109) | type mismatch | String operation on numeric or vice versa |
-| r(111) | not found | Variable doesn't exist in dataset |
-| r(198) | invalid syntax | Malformed command |
-| r(199) | unrecognized command | Command doesn't exist or package missing |
-| r(459) | not sorted | Data must be sorted |
-| r(601) | file not found | File doesn't exist |
-| r(603) | file already exists | Need `replace` option |
-| r(950) | insufficient memory | Operation too large |
-
-### Accuracy
-
-Error detection achieves 97% accuracy on common patterns. Edge cases:
-
-- **`capture` blocks**: Intentionally suppressed errors are not reported
-  (captured errors don't produce `r(N);` after the "end of do-file" marker)
-- **Custom programs**: User-written error messages may not match patterns
-- **Unusual formatting**: Some packages produce non-standard log output
 
 ---
 
@@ -105,18 +99,11 @@ stacy uses a **global cache** with **per-project isolation**:
         └── reghdfe.ado
 ```
 
-**Cache benefits:**
-- Multiple versions coexist
-- Shared across projects (disk efficient)
-- Offline installation from cache
+Multiple versions coexist in the cache, projects share it (disk-efficient), and cached packages install offline.
 
 ### Runtime Isolation
 
-When you run `stacy run script.do`, stacy:
-
-1. Reads `stacy.lock` to determine required packages
-2. Builds a custom `S_ADO` path pointing to cached versions
-3. Launches Stata with this adopath
+When you run `stacy run script.do`, stacy reads `stacy.lock`, builds an `S_ADO` search path pointing at the exact cached versions, and launches Stata with it. Each project's path is built from its own lockfile:
 
 ```
 Project A (stacy.lock):          Project B (stacy.lock):
@@ -125,6 +112,13 @@ Project A (stacy.lock):          Project B (stacy.lock):
 
 Both use the same cache, but see different versions.
 ```
+
+Two modes:
+
+- **Strict (default):** only locked packages and Stata's built-ins (`BASE`) are visible. Nothing leaks in from your global `PLUS` or `PERSONAL` directories, so "works because of something installed on my machine" cannot happen.
+- **Allow-global (`--allow-global`):** locked packages take precedence, but globally installed packages remain available. Useful during development or incremental migration.
+
+Project-local `.ado` directories can be added to the path via the [`[paths]` config section](../configuration/project.md#paths).
 
 ### Lockfile Verification
 
@@ -136,39 +130,40 @@ version = "2024.03.15"
 checksum = "sha256:14af94e03edd..."
 ```
 
-On `stacy install`, checksums are verified to ensure:
-- Downloaded files match expected content
-- Cached packages haven't been modified
-- SSC hasn't silently updated the package
+On `stacy install`, checksums are verified to ensure downloaded files match expected content, cached packages haven't been modified, and SSC hasn't silently updated the package. See [Lockfile Format](./lockfile.md).
+
+---
+
+## Build Cache
+
+Pipelines often re-run scripts that haven't changed. `stacy run --cache` skips that work:
+
+1. stacy hashes the script and every do-file it depends on (`do`, `run`, and `include` statements, traced recursively -- the same parser behind `stacy deps`).
+2. If nothing changed since the last successful run, stacy replays the previous result (exit code, log path, duration) without launching Stata.
+
+The cache is project-local (`.stacy/cache/build.json`) and opt-in. `--force` re-runs regardless; `--cache-only` fails when no cached result exists, letting CI require a pre-populated cache. Files outside the do-file graph -- datasets, environment variables -- are not tracked; use `--force` when they change.
 
 ---
 
 ## Output Streaming
 
-### Real-time Logs
+### Real-time Output
 
-Program output streams to stdout live by default — boilerplate-stripped
-(command echoes removed, blank runs collapsed), both in a terminal and when
-piped. Use `-v` (verbose) to stream the raw, unstripped log instead:
+Program output streams to stdout live by default -- boilerplate-stripped (command echoes removed, blank runs collapsed), both in a terminal and when piped. Use `-v` (verbose) to stream the raw, unstripped log instead:
 
 ```bash
 stacy run -v long_analysis.do
 ```
 
-Streaming stops when the Stata process exits, so killed or timed-out runs
-terminate cleanly. Closed pipes (`stacy run foo.do | head`) end the stream
-without error.
+Streaming stops when the Stata process exits, so killed or timed-out runs terminate cleanly, and closed pipes (`stacy run foo.do | head`) end the stream without error.
 
 ### Log Files
 
-The batch log is internal: removed on success, kept on failure (the path is
-shown in the error output). `--log <path>` writes the raw log to a chosen
-location regardless of outcome. Machine-readable formats keep the log and
-report its path.
+The batch log is internal: it gets a unique name per invocation (so concurrent runs never collide), is removed on success, and is kept on failure. `--log <path>` writes the raw log to a chosen location regardless of outcome. Machine-readable formats keep the log and report its path.
 
 ### Progress Reporting
 
-For scripts without verbose mode, stacy shows periodic progress:
+Without verbose mode, stacy shows periodic progress:
 
 ```
 ⠋ Running: analysis.do (45s elapsed)
@@ -183,9 +178,7 @@ progress_interval_seconds = 30
 
 ### Structured Logging
 
-For automated pipelines, use `--format json`. Machine-readable formats imply
-quiet execution (no streaming); the JSON result's `log_file` field points to
-the kept Stata log:
+For automated pipelines, use `--format json`. Machine-readable formats imply quiet execution (no streaming); the JSON result's `log_file` field points to the kept Stata log:
 
 ```bash
 stacy run --format json analysis.do
@@ -195,7 +188,7 @@ stacy run --format json analysis.do
 
 ## Machine Interface
 
-stacy is designed for integration with other tools.
+stacy is designed to be a good Unix citizen: standard exit codes, machine-readable output, and no interactive surprises (update checks and colors are suppressed automatically in CI and piped output).
 
 ### JSON Output
 
@@ -221,13 +214,14 @@ Stable, semantic exit codes for scripting:
 | 3 | File error |
 | 4 | Memory error |
 | 5 | Internal error |
+| 6 | Statistical error |
 | 10 | Environment error |
 
 See [Exit Codes](./exit-codes.md) for mapping details.
 
 ### Build System Integration
 
-stacy's exit codes enable integration with any tool that respects Unix conventions:
+stacy's exit codes work with any tool that respects Unix conventions:
 
 **Make:**
 ```makefile
@@ -269,8 +263,20 @@ data <- jsonlite::fromJSON(paste(result, collapse = "\n"))
 
 ---
 
+## What stacy Does Not Do
+
+Knowing the boundaries is as useful as knowing the features:
+
+- **It is not a build system.** stacy decides whether a Stata step *succeeded*; Make, Snakemake, or statacons decide *which* steps run and in what order. They compose: point your build tool's Stata rule at `stacy run`. See [Build Integration](../guides/build-integration.md).
+- **It does not manage the Stata version, data files, or other languages.** The lockfile pins Stata *packages*. For full-stack reproducibility (OS, Stata itself, Python/R), use Docker -- stacy works the same inside a container.
+- **It does not resolve transitive dependencies.** SSC packages declare dependencies inconsistently, as free text, so automatic resolution would guess. If package A needs package B, add both: `stacy add A B`. `stacy doctor` and post-install scanning warn about likely missing dependencies.
+- **It does not replace interactive Stata.** stacy wraps batch execution. For exploratory work, use Stata as usual -- and run the finished script through `stacy run` to verify it stands on its own.
+
+---
+
 ## See Also
 
 - [Exit Codes](./exit-codes.md) - Exit code reference
 - [JSON Output](./json-output.md) - JSON schemas
+- [Lockfile Format](./lockfile.md) - Lockfile specification
 - [Stata Error Manual](https://www.stata.com/manuals/perror.pdf) - Official documentation

--- a/docs/src/reference/how-it-works.md
+++ b/docs/src/reference/how-it-works.md
@@ -159,7 +159,7 @@ Streaming stops when the Stata process exits, so killed or timed-out runs termin
 
 ### Log Files
 
-The batch log is internal: it gets a unique name per invocation (so concurrent runs never collide), is removed on success, and is kept on failure. `--log <path>` writes the raw log to a chosen location regardless of outcome. Machine-readable formats keep the log and report its path.
+The batch log is internal: it gets a unique name per invocation (so concurrent runs never collide), is removed on success, and is kept on failure — with its path printed in the failure output so you can inspect it. `--log <path>` writes the raw log to a chosen location regardless of outcome. Machine-readable formats keep the log and report its path.
 
 ### Progress Reporting
 

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -63,9 +63,9 @@ failure, error details with official Stata documentation links and the log
 file path are displayed. Use `-v` to stream the raw log instead, or `-q` to
 suppress all output.
 
-The batch log file is internal: removed on success, kept on failure. Use
-`--log <path>` to keep the raw Stata log as a durable artifact
-(`--quiet --log out.log` for a silent file-only run).
+The batch log file is internal: removed on success, kept on failure with its
+path printed in the failure output. Use `--log <path>` to keep the raw Stata
+log as a durable artifact (`--quiet --log out.log` for a silent file-only run).
 
 Multiple scripts can be run sequentially (default, fail-fast) or in parallel
 (`--parallel`). Parallel mode runs all scripts regardless of failures.

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -70,9 +70,9 @@ The batch log file is internal: removed on success, kept on failure. Use
 Multiple scripts can be run sequentially (default, fail-fast) or in parallel
 (`--parallel`). Parallel mode runs all scripts regardless of failures.
 
-For interactive use where you want to quickly check a result, see `stacy eval`.
+To check a quick result without a script file, use `stacy run -c 'display ...'`.
 """
-see_also = ["./eval.md", "bench", "task", "../reference/exit-codes.md", "../guides/build-integration.md"]
+see_also = ["bench", "task", "../reference/exit-codes.md", "../guides/build-integration.md"]
 
 [commands.run.args]
 script = { type = "path", positional = true, required_unless = "code", description = "Script to execute" }
@@ -153,7 +153,7 @@ commands = ["stacy run --format json analysis.do"]
 [[commands.run.examples]]
 title = "Execution tracing"
 description = "Enable Stata's set trace on for debugging"
-commands = ["stt run --trace 2 analysis.do", "stt run --trace 2 -v analysis.do"]
+commands = ["stacy run --trace 2 analysis.do", "stacy run --trace 2 -v analysis.do"]
 
 [[commands.run.examples]]
 title = "Timeout"
@@ -915,10 +915,10 @@ status = { type = "string", json_path = "status", stata_type = "local", descript
 
 [exit_codes]
 0 = { name = "Success", description = "Operation completed successfully" }
-1 = { name = "Stata Error", description = "Stata r() code detected in log", r_codes = "most r() codes not in other categories" }
-2 = { name = "Syntax Error", description = "Invalid Stata syntax", r_codes = "r(198), r(199)" }
-3 = { name = "File Error", description = "File not found, permission denied, data errors", r_codes = "r(601), r(603), r(610), r(639), r(2000-2999)" }
-4 = { name = "Memory Error", description = "Insufficient memory", r_codes = "r(950)" }
+1 = { name = "Stata Error", description = "Stata r() code detected in log", r_codes = "all r() codes not in other categories" }
+2 = { name = "Syntax Error", description = "Invalid Stata syntax", r_codes = "r(100)-r(199), e.g. r(198), r(199)" }
+3 = { name = "File Error", description = "File not found, permission denied, data errors", r_codes = "r(600)-r(699), e.g. r(601), r(603)" }
+4 = { name = "Memory Error", description = "Insufficient memory", r_codes = "r(900)-r(999), e.g. r(950)" }
 5 = { name = "Internal Error", description = "stacy itself failed (not Stata)" }
 6 = { name = "Statistical Error", description = "Convergence failure, model problems", r_codes = "r(400)-r(499)" }
-10 = { name = "Environment Error", description = "Stata not found or configuration invalid" }
+10 = { name = "Environment Error", description = "Stata not found or configuration invalid", r_codes = "r(800)-r(899)" }

--- a/xtask/src/codegen.rs
+++ b/xtask/src/codegen.rs
@@ -909,10 +909,14 @@ fn generate_markdown(name: &str, command: &Command, schema: &Schema) -> Result<S
         out.push_str("| Option | Description |\n");
         out.push_str("|--------|-------------|\n");
         for (arg_name, arg) in &options {
+            let long = arg
+                .long
+                .clone()
+                .unwrap_or_else(|| arg_name.replace('_', "-"));
             let flag = if let Some(ref short) = arg.short {
-                format!("-{}, --{}", short, arg_name)
+                format!("-{}, --{}", short, long)
             } else {
-                format!("--{}", arg_name)
+                format!("--{}", long)
             };
             out.push_str(&format!("| `{}` | {} |\n", flag, arg.description));
         }
@@ -1065,7 +1069,16 @@ fn generate_exit_codes_md(schema: &Schema) -> Result<String> {
 
     // Stata r() code mapping
     out.push_str("## Stata r() Code Mapping\n\n");
-    out.push_str("stacy maps Stata's r() error codes to exit codes:\n\n");
+    out.push_str(
+        "The number inside `r(N)` is preserved in stacy's output (JSON field `r_code`, \
+         stored result `r(exit_code)` in Stata). The *shell* exit code is a category \
+         derived from it, in two steps:\n\n\
+         1. **Error database lookup.** stacy extracts error descriptions and categories \
+         from your local Stata installation (run `stacy doctor --refresh` after a Stata \
+         upgrade). If the code is found there, its category decides the exit code.\n\
+         2. **Range fallback.** Otherwise, the documented ranges from Stata's Programming \
+         Reference Manual apply:\n\n",
+    );
     out.push_str("| Exit Code | Stata r() Codes |\n");
     out.push_str("|-----------|----------------|\n");
 
@@ -1090,13 +1103,18 @@ fn generate_exit_codes_md(schema: &Schema) -> Result<String> {
     out.push_str("\tstacy run analysis.do  # Stops on non-zero exit\n");
     out.push_str("```\n\n");
 
+    out.push_str(
+        "This mapping is many-to-one by design: it compresses Stata's hundreds of \
+         return codes into a small, stable set that build tools can branch on.\n\n",
+    );
+
     // Stability note
     out.push_str("## Stability\n\n");
     out.push_str("Exit codes 0-10 are stable and will not change meaning. ");
     out.push_str("New categories may be added with codes 11+.\n\n");
 
     out.push_str("## See Also\n\n");
-    out.push_str("- [Error Detection](./errors.md)\n");
+    out.push_str("- [Error Detection](./how-it-works.md#error-detection)\n");
     out.push_str("- [stacy run](../commands/run.md)\n");
 
     Ok(out)

--- a/xtask/src/schema.rs
+++ b/xtask/src/schema.rs
@@ -97,6 +97,9 @@ pub struct Argument {
     #[serde(default)]
     #[allow(dead_code)]
     pub short: Option<String>,
+    /// Long option flag when it differs from the kebab-cased argument name
+    #[serde(default)]
+    pub long: Option<String>,
     /// Conflicting argument (for CLI validation)
     #[serde(default)]
     #[allow(dead_code)]


### PR DESCRIPTION
Brings the docs in line with current 1.3.x behavior and sharpens the framing.

- **Introduction / how-it-works:** frame stacy as two interfaces (human + machine), with a restructured how-it-works and clearer boundaries.
- **Log policy:** document that the internal log is removed on success and kept on failure with its path printed in the FAIL output (now true as of #76). Also covered in `run` help and the streaming section.
- **Exit codes:** correct the r()-code ranges and show them as documented ranges with examples, plus a two-step explanation (error-db lookup, then range fallback).
- **Codegen:** support a `long` option alias in the schema so generated flag docs render the real long form; minor schema cleanups (drop a dead `eval` reference, fix a `stt`→`stacy` typo).

Generated docs regenerated from the schema; `make check` passes locally.