### PR TITLE
feat: parse .pkg Requires: line for deps and minimum Stata version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Post-install dependency hints now also read the `Requires:` line of a package's `.pkg` manifest, catching author-declared SSC dependencies that static `.ado` scanning misses (#78).
+- `stacy add` warns when a package's manifest declares a newer minimum Stata version than the one stacy last detected (#82).
+
 ## [1.3.1] - 2026-07-10
 
 ### Added

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -166,14 +166,42 @@ pub fn execute(args: &AddArgs) -> Result<()> {
                 if format == OutputFormat::Human {
                     println!("  + {} ({})", package_lower, result.version);
 
+                    // Warn if the package declares a newer minimum Stata version
+                    // than the one stacy last detected. Silent when either
+                    // version is unknown (e.g. error codes never extracted).
+                    if let Some(required) = &result.required_stata_version {
+                        if let Ok(Some(db)) = crate::error::error_db::ErrorCodeCache::load() {
+                            if let Some(detected) = db.stata_version.as_deref() {
+                                if let Some(warning) =
+                                    stata_version_warning(&package_lower, required, detected)
+                                {
+                                    println!("    warning: {}", warning);
+                                }
+                            }
+                        }
+                    }
+
                     // Scan installed files for implicit dependencies
                     let installed: HashSet<String> =
                         config.packages.all_package_names().into_iter().collect();
                     if let Ok(cache_dir) =
                         global_cache::package_path(&package_lower, &result.version)
                     {
-                        let missing =
+                        let mut missing =
                             dep_scan::find_missing_deps(&package_lower, &cache_dir, &installed);
+                        // Supplement the .ado scan with deps the author declared
+                        // on the manifest's `Requires:` line — these catch
+                        // dependencies resolved dynamically at runtime that
+                        // static scanning misses.
+                        for dep in &result.declared_deps {
+                            if dep != &package_lower
+                                && !installed.contains(dep)
+                                && !missing.contains(dep)
+                            {
+                                missing.push(dep.clone());
+                            }
+                        }
+                        missing.sort();
                         if !missing.is_empty() {
                             println!(
                                 "    hint: {} appears to need {}. Run: stacy add {}",
@@ -256,6 +284,21 @@ pub fn execute(args: &AddArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Build a warning when a package's declared minimum Stata version is newer
+/// than the detected Stata. Returns `None` when the installed Stata already
+/// satisfies the requirement.
+fn stata_version_warning(package: &str, required: &str, detected: &str) -> Option<String> {
+    // compare_versions(current, latest) is true when latest > current.
+    if crate::update_check::compare_versions(detected, required) {
+        Some(format!(
+            "{} requires Stata {}, but the detected Stata is {}",
+            package, required, detected
+        ))
+    } else {
+        None
+    }
 }
 
 fn parse_source(source: &str) -> Result<ParsedSource> {
@@ -407,6 +450,19 @@ fn print_human_summary(output: &AddOutput) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_stata_version_warning_when_required_is_newer() {
+        let w = stata_version_warning("regsensitivity", "15", "14.2");
+        assert!(w.is_some());
+        assert!(w.unwrap().contains("regsensitivity requires Stata 15"));
+    }
+
+    #[test]
+    fn test_stata_version_no_warning_when_satisfied() {
+        assert!(stata_version_warning("reghdfe", "11.2", "18.0").is_none());
+        assert!(stata_version_warning("reghdfe", "11.2", "11.2").is_none());
+    }
 
     #[test]
     fn test_parse_source_ssc() {

--- a/src/packages/github.rs
+++ b/src/packages/github.rs
@@ -312,6 +312,8 @@ impl GitHubDownloader {
             distribution_date: None,
             files: matched_files,
             description_lines: vec![],
+            requires: vec![],
+            stata_version: None,
         })
     }
 
@@ -587,6 +589,8 @@ mod tests {
                 distribution_date: None,
                 files: vec![],
                 description_lines: vec![],
+                requires: vec![],
+                stata_version: None,
             },
             files: vec![
                 DownloadedFile {

--- a/src/packages/installer.rs
+++ b/src/packages/installer.rs
@@ -30,6 +30,10 @@ pub struct InstallResult {
     pub from_mirror: bool,
     /// Combined checksum of all downloaded files
     pub package_checksum: String,
+    /// Package names declared on the manifest's `Requires:` line
+    pub declared_deps: Vec<String>,
+    /// Minimum Stata version declared on the manifest's `Requires:` line
+    pub required_stata_version: Option<String>,
 }
 
 /// Install a package from SSC
@@ -86,6 +90,8 @@ pub fn install_from_ssc(name: &str, project_root: &Path, group: &str) -> Result<
         was_update,
         from_mirror,
         package_checksum,
+        declared_deps: download.manifest.requires,
+        required_stata_version: download.manifest.stata_version,
     })
 }
 
@@ -174,6 +180,8 @@ pub fn install_package_github(
         was_update,
         from_mirror: false, // GitHub packages don't use SSC mirrors
         package_checksum: download.package_checksum.clone(),
+        declared_deps: download.manifest.requires.clone(),
+        required_stata_version: download.manifest.stata_version.clone(),
     })
 }
 
@@ -233,6 +241,8 @@ pub fn install_from_net(
         was_update,
         from_mirror: false,
         package_checksum: download.package_checksum,
+        declared_deps: download.manifest.requires,
+        required_stata_version: download.manifest.stata_version,
     })
 }
 
@@ -294,6 +304,8 @@ pub fn install_from_local(
         was_update,
         from_mirror: false,
         package_checksum: download.package_checksum,
+        declared_deps: Vec::new(), // local packages have no manifest
+        required_stata_version: None,
     })
 }
 

--- a/src/packages/net.rs
+++ b/src/packages/net.rs
@@ -136,6 +136,8 @@ mod tests {
                 distribution_date: Some("20260101".to_string()),
                 files: vec![],
                 description_lines: vec![],
+                requires: vec![],
+                stata_version: None,
             },
             files: vec![],
             package_checksum: "abc123".to_string(),

--- a/src/packages/pkg_parser.rs
+++ b/src/packages/pkg_parser.rs
@@ -69,6 +69,12 @@ pub struct PackageManifest {
     pub files: Vec<PackageFile>,
     /// Raw description lines
     pub description_lines: Vec<String>,
+    /// SSC package names declared on the `Requires:` line (supplementary
+    /// dependency signal; may be empty)
+    pub requires: Vec<String>,
+    /// Minimum Stata version declared on the `Requires:` line (e.g. "11.2"),
+    /// if stated
+    pub stata_version: Option<String>,
 }
 
 impl PackageManifest {
@@ -117,6 +123,8 @@ pub fn parse_pkg_file(content: &str, package_name: &str) -> Result<PackageManife
     let mut distribution_date = None;
     let mut files = Vec::new();
     let mut description_lines = Vec::new();
+    let mut requires = Vec::new();
+    let mut stata_version = None;
 
     for line in content.lines() {
         let line = line.trim();
@@ -148,6 +156,16 @@ pub fn parse_pkg_file(content: &str, package_name: &str) -> Result<PackageManife
                             .trim()
                             .to_string(),
                     );
+                } else if let Some(req) = rest.strip_prefix("Requires:") {
+                    for dep in parse_requires(req) {
+                        if !requires.contains(&dep) {
+                            requires.push(dep);
+                        }
+                    }
+                    if stata_version.is_none() {
+                        stata_version = parse_stata_version(req);
+                    }
+                    description_lines.push(rest.to_string());
                 } else if !rest.is_empty() {
                     // First non-empty description line is the title
                     if title.is_empty() {
@@ -241,7 +259,85 @@ pub fn parse_pkg_file(content: &str, package_name: &str) -> Result<PackageManife
         distribution_date,
         files,
         description_lines,
+        requires,
+        stata_version,
     })
+}
+
+/// Extract the minimum Stata version from the text following `Requires:`.
+///
+/// Every SSC `Requires:` line opens with `Stata version <X[.Y]>`. We take the
+/// token right after `Stata version` and keep it only if it looks like a
+/// numeric version (`11`, `14.2`), ignoring any trailing prose.
+fn parse_stata_version(text: &str) -> Option<String> {
+    let lower = text.to_lowercase();
+    let after = lower.split("stata version").nth(1)?;
+    let token = after.split_whitespace().next()?;
+    // Keep clean numeric versions like "11" or "14.2".
+    if !token.is_empty()
+        && token.chars().all(|c| c.is_ascii_digit() || c == '.')
+        && token.chars().any(|c| c.is_ascii_digit())
+    {
+        Some(token.to_string())
+    } else {
+        None
+    }
+}
+
+/// Extract SSC package dependencies from the text following `Requires:`.
+///
+/// The line has a semi-structured free-text shape, e.g.
+/// `Stata version 13 and avar, ftools and reghdfe from SSC (q.v.)`. Only the
+/// packages named before `from SSC` are SSC dependencies; version-only lines
+/// (`Stata version 14.2`) have no `from SSC` anchor and yield nothing. We take
+/// the text up to the first `from SSC`, drop parentheticals, split on commas
+/// and whitespace, and keep clean lowercase SSC-style tokens. This is a
+/// high-precision supplement — it intentionally ignores rare conditional
+/// clauses that trail a second `from SSC` rather than risk false positives.
+fn parse_requires(text: &str) -> Vec<String> {
+    let lower = text.to_lowercase();
+    let head = match lower.find("from ssc") {
+        Some(i) => &lower[..i],
+        None => return Vec::new(),
+    };
+
+    // Drop parenthetical clauses like "(version 9.2 for colorpalette9)".
+    let mut cleaned = String::with_capacity(head.len());
+    let mut depth = 0i32;
+    for c in head.chars() {
+        match c {
+            '(' => depth += 1,
+            ')' => depth = (depth - 1).max(0),
+            _ if depth == 0 => cleaned.push(c),
+            _ => {}
+        }
+    }
+
+    // Words that appear in the free text but are never package names.
+    const STOPWORDS: &[&str] = &[
+        "stata", "version", "and", "or", "the", "for", "also", "require", "requires", "older",
+        "newer", "with", "from", "ssc",
+    ];
+
+    let mut deps = Vec::new();
+    for token in cleaned.split(|c: char| c == ',' || c == '&' || c.is_whitespace()) {
+        let token = token.trim();
+        // SSC package names are clean lowercase identifiers.
+        if token.len() < 2
+            || !token.starts_with(|c: char| c.is_ascii_lowercase())
+            || !token
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+            || STOPWORDS.contains(&token)
+        {
+            continue;
+        }
+        let dep = token.to_string();
+        if !deps.contains(&dep) {
+            deps.push(dep);
+        }
+    }
+    deps
 }
 
 #[cfg(test)]
@@ -361,6 +457,93 @@ f two.hlp
         let manifest = parse_pkg_file(content, "example").unwrap();
         let help_files = manifest.help_files();
         assert_eq!(help_files.len(), 2);
+    }
+
+    #[test]
+    fn test_requires_single_dep() {
+        let content = "d 'REGHDFE': linear models\n\
+d Requires: Stata version 11.2 and ftools from SSC (q.v.)\n\
+f reghdfe.ado\n";
+        let manifest = parse_pkg_file(content, "reghdfe").unwrap();
+        assert_eq!(manifest.requires, vec!["ftools"]);
+    }
+
+    #[test]
+    fn test_requires_multiple_deps() {
+        let content = "d 'ESI': event study\n\
+d Requires: Stata version 13 and avar, ftools and reghdfe from SSC (q.v.)\n\
+f esi.ado\n";
+        let manifest = parse_pkg_file(content, "eventstudyinteract").unwrap();
+        assert_eq!(manifest.requires, vec!["avar", "ftools", "reghdfe"]);
+    }
+
+    #[test]
+    fn test_requires_version_only_has_no_deps() {
+        // No `from SSC` anchor => Stata-version-only requirement, no package dep.
+        let content = "d 'ESTOUT': tables\n\
+d Requires: Stata version 8.2\n\
+f estout.ado\n";
+        let manifest = parse_pkg_file(content, "estout").unwrap();
+        assert!(manifest.requires.is_empty());
+    }
+
+    #[test]
+    fn test_requires_strips_parenthetical_version_pin() {
+        let content = "d 'GRSTYLE': schemes\n\
+d Requires: Stata version 14.2 and colrspace from SSC (q.v.); (version 9.2 for colorpalette9)\n\
+f grstyle.ado\n";
+        let manifest = parse_pkg_file(content, "grstyle").unwrap();
+        // colorpalette9 lives in a parenthetical and after `from SSC`; only
+        // colrspace is a real declared dep.
+        assert_eq!(manifest.requires, vec!["colrspace"]);
+    }
+
+    #[test]
+    fn test_requires_ignores_conditional_trailing_clause() {
+        // ftools: a second `from SSC` trails a conditional clause with English
+        // words ("older", "also require"). We keep only the first segment.
+        let content = "d 'FTOOLS': fast tools\n\
+d Requires: Stata version 9.2 and moremata from SSC; Stata 12 or older also require boottest from SSC\n\
+f ftools.ado\n";
+        let manifest = parse_pkg_file(content, "ftools").unwrap();
+        assert_eq!(manifest.requires, vec!["moremata"]);
+    }
+
+    #[test]
+    fn test_no_requires_line() {
+        let content = "d example\nf example.ado\n";
+        let manifest = parse_pkg_file(content, "example").unwrap();
+        assert!(manifest.requires.is_empty());
+        assert!(manifest.stata_version.is_none());
+    }
+
+    #[test]
+    fn test_stata_version_captured() {
+        let content = "d 'REGHDFE': linear models\n\
+d Requires: Stata version 11.2 and ftools from SSC (q.v.)\n\
+f reghdfe.ado\n";
+        let manifest = parse_pkg_file(content, "reghdfe").unwrap();
+        assert_eq!(manifest.stata_version.as_deref(), Some("11.2"));
+    }
+
+    #[test]
+    fn test_stata_version_integer_and_version_only_line() {
+        let content = "d 'ESTOUT': tables\n\
+d Requires: Stata version 8\n\
+f estout.ado\n";
+        let manifest = parse_pkg_file(content, "estout").unwrap();
+        assert_eq!(manifest.stata_version.as_deref(), Some("8"));
+        assert!(manifest.requires.is_empty());
+    }
+
+    #[test]
+    fn test_stata_version_ignores_trailing_prose() {
+        // labutil: "Stata version 7.0 (version 8 for labvalcombine)."
+        let content = "d 'LABUTIL': label utilities\n\
+d Requires: Stata version 7.0 (version 8 for labvalcombine).\n\
+f labutil.ado\n";
+        let manifest = parse_pkg_file(content, "labutil").unwrap();
+        assert_eq!(manifest.stata_version.as_deref(), Some("7.0"));
     }
 
     #[test]

--- a/src/packages/ssc.rs
+++ b/src/packages/ssc.rs
@@ -541,6 +541,8 @@ mod tests {
                 distribution_date: None,
                 files: vec![],
                 description_lines: vec![],
+                requires: vec![],
+                stata_version: None,
             },
             files: vec![
                 DownloadedFile {


### PR DESCRIPTION
Parse the `Requires:` line in SSC `.pkg` manifests and use it as a supplementary dependency signal.

- `pkg_parser` extracts the declared SSC package names into `PackageManifest.requires` and the declared minimum Stata version into `PackageManifest.stata_version`.
- `requires` is threaded through `InstallResult.declared_deps` and merged into the post-install dependency hint in `stacy add`, alongside the existing `.ado` scan.
- `stacy add` warns when a package's declared minimum Stata version is newer than the Stata version stacy last detected. Silent when the detected version is unknown.

Closes #78. Closes #82.