### PR TITLE
fix: parse .pkg manifests with CR-only line endings (#79)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Post-install dependency hints now also read the `Requires:` line of a package's `.pkg` manifest, catching author-declared SSC dependencies that static `.ado` scanning misses (#78).
 - `stacy add` warns when a package's manifest declares a newer minimum Stata version than the one stacy last detected (#82).
 
+### Fixed
+
+- `.pkg` manifests with bare `\r` (classic-Mac) line endings no longer parse as a title with no files (#79).
+
 ## [1.3.1] - 2026-07-10
 
 ### Added

--- a/src/packages/pkg_parser.rs
+++ b/src/packages/pkg_parser.rs
@@ -126,7 +126,9 @@ pub fn parse_pkg_file(content: &str, package_name: &str) -> Result<PackageManife
     let mut requires = Vec::new();
     let mut stata_version = None;
 
-    for line in content.lines() {
+    // Some older SSC manifests use bare `\r` (classic-Mac) line endings, which
+    // `str::lines()` does not split on. Split on any of `\r\n`, `\n`, or `\r`.
+    for line in content.split(['\n', '\r']) {
         let line = line.trim();
 
         // Skip empty lines
@@ -544,6 +546,16 @@ d Requires: Stata version 7.0 (version 8 for labvalcombine).\n\
 f labutil.ado\n";
         let manifest = parse_pkg_file(content, "labutil").unwrap();
         assert_eq!(manifest.stata_version.as_deref(), Some("7.0"));
+    }
+
+    #[test]
+    fn test_parse_pkg_cr_only_line_endings() {
+        // Classic-Mac `.pkg` files use bare `\r`; str::lines() would collapse
+        // these into one line and drop every file entry (#79).
+        let content = "d 'EXAMPLE': a package\rf example.ado\rf example.sthlp\r";
+        let manifest = parse_pkg_file(content, "example").unwrap();
+        assert_eq!(manifest.title, "a package");
+        assert_eq!(manifest.files.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
Some older SSC `.pkg` files use bare `\r` (classic-Mac) line endings. `str::lines()` splits only on `\n`/`\r\n`, so these manifests collapse into one line and every file entry is lost.

Split on any of `\r\n`, `\n`, or `\r` in `pkg_parser`.

Closes #79.