### PR TITLE
fix: stacy task fails when run from the Stata console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `.pkg` manifests with bare `\r` (classic-Mac) line endings no longer parse as a title with no files (#79).
 - `stacy task` from the Stata console no longer fails with `r(199)`: machine-readable formats no longer stream script output to stdout (#84).
+- Line breaks in `--format stata` string values are replaced with spaces.
 
 ## [1.3.1] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `.pkg` manifests with bare `\r` (classic-Mac) line endings no longer parse as a title with no files (#79).
+- `stacy task` from the Stata console no longer fails with `r(199)`: machine-readable formats no longer stream script output to stdout (#84).
 
 ## [1.3.1] - 2026-07-10
 

--- a/src/cli/output_format.rs
+++ b/src/cli/output_format.rs
@@ -52,8 +52,9 @@ pub fn resolve_verbosity(quiet: bool, verbose: u8, format: OutputFormat) -> Verb
 ///
 /// In Stata, double-quoted strings ("...") do not expand macros,
 /// so only embedded double quotes need escaping (replaced with single quotes).
+/// Line breaks become spaces — a raw newline would split the assignment.
 pub fn escape_stata_string(s: &str) -> String {
-    s.replace('"', "'")
+    s.replace('"', "'").replace(['\n', '\r'], " ")
 }
 
 /// Format a boolean as a Stata scalar assignment
@@ -183,6 +184,13 @@ mod tests {
         assert!(!OutputFormat::Human.is_machine_readable());
         assert!(OutputFormat::Json.is_machine_readable());
         assert!(OutputFormat::Stata.is_machine_readable());
+    }
+
+    #[test]
+    fn test_escape_stata_string_replaces_line_breaks() {
+        assert_eq!(escape_stata_string("line1\nline2"), "line1 line2");
+        assert_eq!(escape_stata_string("line1\r\nline2"), "line1  line2");
+        assert_eq!(escape_stata_string("line1\rline2"), "line1 line2");
     }
 
     #[test]

--- a/src/cli/output_format.rs
+++ b/src/cli/output_format.rs
@@ -3,7 +3,9 @@
 //! Provides the `OutputFormat` enum and utilities for formatting command output
 //! in human-readable, JSON, or Stata-native formats.
 
+use crate::executor::verbosity::Verbosity;
 use clap::ValueEnum;
+use std::io::IsTerminal;
 
 /// Output format for CLI commands
 ///
@@ -25,6 +27,24 @@ impl OutputFormat {
     /// Returns true if this format should suppress human-friendly messages
     pub fn is_machine_readable(&self) -> bool {
         matches!(self, OutputFormat::Json | OutputFormat::Stata)
+    }
+}
+
+/// Resolve executor verbosity from CLI flags with TTY-awareness
+///
+/// Machine-readable formats force `Quiet`: stdout is the payload channel
+/// (executed with `do` by the console wrappers), so nothing may be streamed
+/// to it (#84). Commands that run Stata derive their verbosity here.
+pub fn resolve_verbosity(quiet: bool, verbose: u8, format: OutputFormat) -> Verbosity {
+    if quiet || format.is_machine_readable() {
+        Verbosity::Quiet
+    } else {
+        match verbose {
+            0 if std::io::stdout().is_terminal() => Verbosity::DefaultInteractive,
+            0 => Verbosity::PipedDefault,
+            1 => Verbosity::Verbose,
+            _ => Verbosity::VeryVerbose,
+        }
     }
 }
 
@@ -163,5 +183,39 @@ mod tests {
         assert!(!OutputFormat::Human.is_machine_readable());
         assert!(OutputFormat::Json.is_machine_readable());
         assert!(OutputFormat::Stata.is_machine_readable());
+    }
+
+    #[test]
+    fn test_resolve_verbosity_machine_readable_is_quiet() {
+        for verbose in 0..=2 {
+            assert_eq!(
+                resolve_verbosity(false, verbose, OutputFormat::Stata),
+                Verbosity::Quiet
+            );
+            assert_eq!(
+                resolve_verbosity(false, verbose, OutputFormat::Json),
+                Verbosity::Quiet
+            );
+        }
+    }
+
+    #[test]
+    fn test_resolve_verbosity_quiet_flag_wins() {
+        assert_eq!(
+            resolve_verbosity(true, 2, OutputFormat::Human),
+            Verbosity::Quiet
+        );
+    }
+
+    #[test]
+    fn test_resolve_verbosity_human_verbose_levels() {
+        assert_eq!(
+            resolve_verbosity(false, 1, OutputFormat::Human),
+            Verbosity::Verbose
+        );
+        assert_eq!(
+            resolve_verbosity(false, 2, OutputFormat::Human),
+            Verbosity::VeryVerbose
+        );
     }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,7 +1,7 @@
 use crate::cache::detect::{check_cache_with_working_dir, hash_working_dir, CacheStatus};
 use crate::cache::hash::{hash_dependency_tree, hash_lockfile};
 use crate::cache::{BuildCache, CacheEntry, CachedError, CachedResult};
-use crate::cli::output_format::OutputFormat;
+use crate::cli::output_format::{resolve_verbosity, OutputFormat};
 use crate::cli::output_types::{
     CacheHitOutput, CommandOutput, ParallelRunOutput, RunOutput, ScriptRunResult,
 };
@@ -139,26 +139,6 @@ pub enum CodeSource {
     File,
     /// Inline code from -c/--code flag
     Inline,
-}
-
-/// Resolve verbosity from CLI flags with TTY-awareness
-fn resolve_verbosity(
-    quiet: bool,
-    verbose: u8,
-    format: OutputFormat,
-) -> crate::executor::verbosity::Verbosity {
-    use crate::executor::verbosity::Verbosity;
-
-    if quiet || format.is_machine_readable() {
-        Verbosity::Quiet
-    } else {
-        match verbose {
-            0 if std::io::stdout().is_terminal() => Verbosity::DefaultInteractive,
-            0 => Verbosity::PipedDefault,
-            1 => Verbosity::Verbose,
-            _ => Verbosity::VeryVerbose,
-        }
-    }
 }
 
 #[derive(Args, Clone)]

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -2,7 +2,7 @@
 //!
 //! Run defined tasks from stacy.toml's `[scripts]` section.
 
-use crate::cli::output_format::OutputFormat;
+use crate::cli::output_format::{resolve_verbosity, OutputFormat};
 use crate::cli::output_types::{
     CommandOutput, ScriptResultOutput, TaskInfo, TaskListOutput, TaskOutput,
 };
@@ -169,10 +169,9 @@ pub fn execute(args: &TaskArgs) -> Result<()> {
     // Parse arguments
     let task_args = parse_task_args(&args.args)?;
 
-    // Create Stata executor
-    let executor =
-        StataExecutor::try_new(None, crate::executor::verbosity::Verbosity::PipedDefault)?
-            .with_local_ado_paths(project.resolve_local_ado_paths());
+    // Create Stata executor (machine-readable formats suppress streaming, #84)
+    let executor = StataExecutor::try_new(None, resolve_verbosity(false, 0, format))?
+        .with_local_ado_paths(project.resolve_local_ado_paths());
 
     // Create task executor
     let task_executor = TaskExecutor::new(&graph, &executor, &project.root).with_args(task_args);

--- a/tests/test_format_stream_isolation.rs
+++ b/tests/test_format_stream_isolation.rs
@@ -1,0 +1,146 @@
+//! Regression tests for #84: machine-readable stdout carries only the payload.
+//!
+//! The console wrappers execute `--format stata` stdout with `do`, so script
+//! output streamed to stdout during the run breaks it. Runs `stacy task`
+//! against a fake Stata binary that writes a noisy log.
+
+#![cfg(unix)]
+
+use assert_cmd::{cargo_bin_cmd, Command};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+/// A line Stata would reject if executed as a command (#84 failed on `(`).
+const NOISE: &str = "( 42 observations deleted )";
+
+fn stacy() -> Command {
+    cargo_bin_cmd!("stacy")
+}
+
+/// Fake Stata binary: mimics `stata -b -q do wrapper.do` by writing
+/// `<wrapper stem>.log` into its cwd (noisy output + completion trailer).
+fn write_fake_stata(dir: &Path) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let path = dir.join("fake-stata");
+    let body = format!(
+        "#!/bin/sh\n\
+         for arg in \"$@\"; do last=\"$arg\"; done\n\
+         stem=$(basename \"$last\" .do)\n\
+         printf '%s\\n' '{NOISE}' 'more script output' '' 'end of do-file' > \"$stem.log\"\n"
+    );
+    fs::write(&path, body).unwrap();
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).unwrap();
+    path
+}
+
+/// Project with a script task and a composite task, as in #84.
+fn setup_project(temp: &TempDir) {
+    fs::write(
+        temp.path().join("stacy.toml"),
+        r#"[project]
+name = "test"
+
+[scripts]
+clean = "src/01_clean.do"
+all = ["clean"]
+"#,
+    )
+    .unwrap();
+    fs::create_dir(temp.path().join("src")).unwrap();
+    fs::write(temp.path().join("src/01_clean.do"), "display 1\n").unwrap();
+}
+
+#[test]
+fn test_task_format_stata_stdout_is_only_payload() {
+    let temp = TempDir::new().unwrap();
+    setup_project(&temp);
+    let fake = write_fake_stata(temp.path());
+
+    let output = stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["task", "all", "--format", "stata"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "task failed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains(NOISE),
+        "script output leaked into --format stata stdout:\n{}",
+        stdout
+    );
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        assert!(
+            line.starts_with('*')
+                || line.starts_with("scalar stacy_")
+                || line.starts_with("global stacy_"),
+            "line not executable as Stata assignment: '{}'",
+            line
+        );
+    }
+    assert!(stdout.contains("scalar stacy_success = 1"));
+    assert!(stdout.contains("scalar stacy_script_count = 1"));
+}
+
+#[test]
+fn test_task_format_json_stdout_is_parseable() {
+    let temp = TempDir::new().unwrap();
+    setup_project(&temp);
+    let fake = write_fake_stata(temp.path());
+
+    let output = stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["task", "all", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "task failed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("--format json stdout not parseable ({}):\n{}", e, stdout));
+    assert_eq!(parsed["success"], serde_json::Value::Bool(true));
+}
+
+#[test]
+fn test_task_format_human_still_streams_script_output() {
+    let temp = TempDir::new().unwrap();
+    setup_project(&temp);
+    let fake = write_fake_stata(temp.path());
+
+    let output = stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["task", "all"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "task failed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Piped human mode still live-streams the script's log to stdout.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(NOISE),
+        "human mode should stream script output; stdout:\n{}",
+        stdout
+    );
+}


### PR DESCRIPTION
Fixes #84.

`stacy task` constructed its executor with `PipedDefault` verbosity regardless of `--format`, so the do-files' log output was live-streamed to stdout. The console wrapper executes `--format stata` stdout with `do`, so that output ran as Stata commands and failed with `r(199)`.

- Move `resolve_verbosity` from `run.rs` to `output_format.rs` and use it in `task.rs`; machine-readable formats force `Quiet`. Audited the other commands: `run`, `test`, and `bench` already suppress streaming, and no command writes anything else to stdout in machine-readable modes.
- `escape_stata_string` now replaces line breaks with spaces so a multi-line value cannot split a `global` assignment across lines.
- Regression tests run `stacy task` against a fake Stata binary that writes a noisy log: `--format stata` stdout must contain only executable assignments, `--format json` must parse, and human mode must still stream.