### PR TITLE
stacy test: document working directory and add --directory/--cd (#85)

### DIFF
--- a/docs/src/commands/test.md
+++ b/docs/src/commands/test.md
@@ -10,9 +10,14 @@ stacy test <TEST> [OPTIONS]
 
 ## Description
 
-Discovers and runs test scripts from the `test/` directory. Tests are Stata
-scripts that use assertion commands. Supports filtering, parallel execution,
-and verbose output for debugging failures.
+Discovers and runs test scripts from the `tests/` or `test/` directory. Tests
+are Stata scripts that use assertion commands. Supports filtering, parallel
+execution, and verbose output for debugging failures.
+
+Each test runs with the project root as the working directory, so relative
+paths in tests resolve from the project root regardless of where `stacy test`
+is invoked. Use `--directory <dir>` to run tests in a specific directory, or
+`--cd` to run each test in its own parent directory.
 
 ## Arguments
 
@@ -24,6 +29,8 @@ and verbose output for debugging failures.
 
 | Option | Description |
 |--------|-------------|
+| `--cd` | Run each test in its own parent directory |
+| `-C, --directory` | Run tests in this directory |
 | `-f, --filter` | Filter tests by pattern |
 | `--list` | List tests without running |
 | `--parallel` | Run tests in parallel |
@@ -48,6 +55,12 @@ stacy test test_regression
 
 ```bash
 stacy test -f 'regression*'
+```
+
+### Run each test in its own directory
+
+```bash
+stacy test --cd
 ```
 
 ## Exit Codes

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -780,15 +780,22 @@ description = "Run tests"
 category = "execution"
 stata_command = "stacy_test"
 long_description = """
-Discovers and runs test scripts from the `test/` directory. Tests are Stata
-scripts that use assertion commands. Supports filtering, parallel execution,
-and verbose output for debugging failures.
+Discovers and runs test scripts from the `tests/` or `test/` directory. Tests
+are Stata scripts that use assertion commands. Supports filtering, parallel
+execution, and verbose output for debugging failures.
+
+Each test runs with the project root as the working directory, so relative
+paths in tests resolve from the project root regardless of where `stacy test`
+is invoked. Use `--directory <dir>` to run tests in a specific directory, or
+`--cd` to run each test in its own parent directory.
 """
 see_also = ["run"]
 
 [commands.test.args]
 test = { type = "string", positional = true, description = "Specific test to run" }
 filter = { type = "string", short = "f", description = "Filter tests by pattern", stata_option = "Filter(string)" }
+directory = { type = "path", short = "C", conflicts_with = "cd", description = "Run tests in this directory", stata_option = "Directory(string)" }
+cd = { type = "bool", long = "cd", conflicts_with = "directory", description = "Run each test in its own parent directory", stata_option = "CD" }
 parallel = { type = "bool", description = "Run tests in parallel", stata_option = "PARALLEL" }
 list = { type = "bool", description = "List tests without running", stata_option = "LIST" }
 quiet = { type = "bool", short = "q", description = "Suppress progress output", stata_option = "Quiet" }
@@ -823,6 +830,10 @@ commands = ["stacy test test_regression"]
 [[commands.test.examples]]
 title = "Filter tests"
 commands = ["stacy test -f 'regression*'"]
+
+[[commands.test.examples]]
+title = "Run each test in its own directory"
+commands = ["stacy test --cd"]
 
 
 # =============================================================================

--- a/src/cli/test.rs
+++ b/src/cli/test.rs
@@ -7,21 +7,27 @@ use crate::cli::output_types::{
     CommandOutput, TestInfo, TestListOutput, TestOutput, TestResultOutput,
 };
 use crate::cli::test_output;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::executor::StataExecutor;
 use crate::project::Project;
 use crate::test::discovery::{discover_tests, find_test};
-use crate::test::runner::TestRunner;
+use crate::test::runner::{TestRunner, TestWorkingDir};
 use clap::Args;
+use std::path::PathBuf;
 use std::process;
 
 #[derive(Args)]
 #[command(after_help = "\
+Tests run with the project root as the working directory, so relative paths
+in tests resolve from the project root. Use -C/--directory or --cd to change.
+
 Examples:
   stacy test                              Run all tests
   stacy test test_regression              Run a specific test
   stacy test -f \"clean*\"                  Filter tests by pattern
-  stacy test --list                       List tests without running")]
+  stacy test --list                       List tests without running
+  stacy test -C data/                     Run tests in data/ directory
+  stacy test --cd                         Run each test in its own directory")]
 pub struct TestArgs {
     /// Specific test to run (name or path)
     #[arg(value_name = "TEST")]
@@ -30,6 +36,19 @@ pub struct TestArgs {
     /// Filter tests by pattern (can be used multiple times)
     #[arg(long, short = 'f', value_name = "PATTERN")]
     pub filter: Vec<String>,
+
+    /// Run tests in this directory instead of the project root
+    #[arg(
+        short = 'C',
+        long = "directory",
+        conflicts_with = "cd",
+        value_name = "DIR"
+    )]
+    pub directory: Option<PathBuf>,
+
+    /// Run each test in its own parent directory instead of the project root
+    #[arg(long, conflicts_with = "directory")]
+    pub cd: bool,
 
     /// Run tests in parallel
     #[arg(long)]
@@ -52,8 +71,34 @@ pub struct TestArgs {
     pub verbose: bool,
 }
 
+/// Resolve the working-directory mode from the --cd / -C flags.
+/// A -C directory is validated and made absolute up front.
+fn resolve_working_dir_mode(args: &TestArgs) -> Result<TestWorkingDir> {
+    if args.cd {
+        return Ok(TestWorkingDir::TestDir);
+    }
+    if let Some(ref dir) = args.directory {
+        let abs_dir = if dir.is_absolute() {
+            dir.clone()
+        } else {
+            std::env::current_dir()?.join(dir)
+        };
+        if !abs_dir.is_dir() {
+            return Err(Error::Config(format!(
+                "Directory not found: {}",
+                dir.display()
+            )));
+        }
+        return Ok(TestWorkingDir::Fixed(abs_dir));
+    }
+    Ok(TestWorkingDir::ProjectRoot)
+}
+
 pub fn execute(args: &TestArgs) -> Result<()> {
     let format = args.format;
+
+    // Resolve working directory from --cd or -C flags (validates -C early)
+    let working_dir = resolve_working_dir_mode(args)?;
 
     // Find project (optional for test command)
     let project = Project::find()?;
@@ -69,7 +114,7 @@ pub fn execute(args: &TestArgs) -> Result<()> {
     // Handle specific test
     if let Some(ref test_name) = args.test {
         if let Some(test) = find_test(&project_root, test_name)? {
-            return run_single_test(args, &project_root, &test, &local_ado_paths);
+            return run_single_test(args, &project_root, &test, &local_ado_paths, working_dir);
         } else {
             let msg = format!("Test '{}' not found", test_name);
             if format.is_machine_readable() {
@@ -130,7 +175,7 @@ pub fn execute(args: &TestArgs) -> Result<()> {
     }
 
     // Run tests
-    run_tests(args, &project_root, &tests, &local_ado_paths)
+    run_tests(args, &project_root, &tests, &local_ado_paths, working_dir)
 }
 
 fn run_single_test(
@@ -138,6 +183,7 @@ fn run_single_test(
     project_root: &std::path::Path,
     test: &crate::test::discovery::TestFile,
     local_ado_paths: &[std::path::PathBuf],
+    working_dir: TestWorkingDir,
 ) -> Result<()> {
     let format = args.format;
 
@@ -147,7 +193,7 @@ fn run_single_test(
         .with_local_ado_paths(local_ado_paths.to_vec());
 
     // Create test runner
-    let runner = TestRunner::new(&executor, project_root);
+    let runner = TestRunner::new(&executor, project_root).with_working_dir(working_dir);
 
     // Run the test
     if !args.quiet && format == OutputFormat::Human {
@@ -193,6 +239,7 @@ fn run_tests(
     project_root: &std::path::Path,
     tests: &[crate::test::discovery::TestFile],
     local_ado_paths: &[std::path::PathBuf],
+    working_dir: TestWorkingDir,
 ) -> Result<()> {
     let format = args.format;
 
@@ -202,7 +249,9 @@ fn run_tests(
         .with_local_ado_paths(local_ado_paths.to_vec());
 
     // Create test runner
-    let runner = TestRunner::new(&executor, project_root).with_parallel(args.parallel);
+    let runner = TestRunner::new(&executor, project_root)
+        .with_parallel(args.parallel)
+        .with_working_dir(working_dir);
 
     // Print header
     if !args.quiet && format == OutputFormat::Human {

--- a/src/test/runner.rs
+++ b/src/test/runner.rs
@@ -25,9 +25,33 @@ fn format_stata_error(err: &StataError) -> String {
         }
     }
 }
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+/// Working directory for test execution
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum TestWorkingDir {
+    /// Project root (default)
+    #[default]
+    ProjectRoot,
+    /// A fixed directory (from -C/--directory)
+    Fixed(PathBuf),
+    /// Each test's own parent directory (from --cd)
+    TestDir,
+}
+
+/// Resolve the effective working directory for a single test
+fn resolve_working_dir(mode: &TestWorkingDir, project_root: &Path, test_path: &Path) -> PathBuf {
+    match mode {
+        TestWorkingDir::ProjectRoot => project_root.to_path_buf(),
+        TestWorkingDir::Fixed(dir) => dir.clone(),
+        TestWorkingDir::TestDir => test_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| project_root.to_path_buf()),
+    }
+}
 
 /// Result of running a single test
 #[derive(Debug, Clone)]
@@ -110,6 +134,8 @@ pub struct TestRunner<'a> {
     project_root: &'a Path,
     /// Run tests in parallel
     parallel: bool,
+    /// Working directory mode for test execution
+    working_dir: TestWorkingDir,
 }
 
 impl<'a> TestRunner<'a> {
@@ -119,6 +145,7 @@ impl<'a> TestRunner<'a> {
             stata,
             project_root,
             parallel: false,
+            working_dir: TestWorkingDir::default(),
         }
     }
 
@@ -128,11 +155,20 @@ impl<'a> TestRunner<'a> {
         self
     }
 
+    /// Set the working directory mode for test execution
+    pub fn with_working_dir(mut self, working_dir: TestWorkingDir) -> Self {
+        self.working_dir = working_dir;
+        self
+    }
+
     /// Run a single test
     pub fn run_test(&self, test: &TestFile) -> Result<TestResult> {
         let start = Instant::now();
 
-        let result = self.stata.run(&test.path, Some(self.project_root))?;
+        let working_dir = resolve_working_dir(&self.working_dir, self.project_root, &test.path);
+        let result = self
+            .stata
+            .run_in_dir(&test.path, Some(self.project_root), &working_dir)?;
         let duration = start.elapsed();
 
         let error_message = if !result.success {
@@ -225,6 +261,36 @@ impl<'a> TestRunner<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_resolve_working_dir_project_root() {
+        let dir = resolve_working_dir(
+            &TestWorkingDir::ProjectRoot,
+            Path::new("/project"),
+            Path::new("/project/tests/test_foo.do"),
+        );
+        assert_eq!(dir, PathBuf::from("/project"));
+    }
+
+    #[test]
+    fn test_resolve_working_dir_fixed() {
+        let dir = resolve_working_dir(
+            &TestWorkingDir::Fixed(PathBuf::from("/project/data")),
+            Path::new("/project"),
+            Path::new("/project/tests/test_foo.do"),
+        );
+        assert_eq!(dir, PathBuf::from("/project/data"));
+    }
+
+    #[test]
+    fn test_resolve_working_dir_test_dir() {
+        let dir = resolve_working_dir(
+            &TestWorkingDir::TestDir,
+            Path::new("/project"),
+            Path::new("/project/tests/nested/test_foo.do"),
+        );
+        assert_eq!(dir, PathBuf::from("/project/tests/nested"));
+    }
 
     #[test]
     fn test_suite_result_new() {

--- a/stata/stacy_test.ado
+++ b/stata/stacy_test.ado
@@ -11,6 +11,8 @@
         stacy_test [test] [, options]
 
     Options:
+        CD                   - Run each test in its own parent directory
+        Directory(string)    - Run tests in this directory
         Filter(string)       - Filter tests by pattern
         LIST                 - List tests without running
         PARALLEL             - Run tests in parallel
@@ -29,13 +31,21 @@
 
 program define stacy_test, rclass
     version 14.0
-    syntax [anything(name=test)] [, Filter(string) LIST PARALLEL Quiet Verbose]
+    syntax [anything(name=test)] [, CD Directory(string) Filter(string) LIST PARALLEL Quiet Verbose]
 
     * Build command arguments
     local cmd "test"
 
     if `"`test'"' != "" {
         local cmd `"`cmd' "`test'""'
+    }
+
+    if "`cd'" != "" {
+        local cmd `"`cmd' --cd"'
+    }
+
+    if `"`directory'"' != "" {
+        local cmd `"`cmd' --directory "`directory'""'
     }
 
     if `"`filter'"' != "" {

--- a/stata/stacy_test.sthlp
+++ b/stata/stacy_test.sthlp
@@ -21,6 +21,8 @@
 {synopthdr}
 {synoptline}
 {syntab:Main}
+{synopt:{opt:cd}}Run each test in its own parent directory{p_end}
+{synopt:{opt:directory(string)}}Run tests in this directory{p_end}
 {synopt:{opt:filter(string)}}Filter tests by pattern{p_end}
 {synopt:{opt:list}}List tests without running{p_end}
 {synopt:{opt:parallel}}Run tests in parallel{p_end}
@@ -38,6 +40,12 @@
 
 {marker options}{...}
 {title:Options}
+
+{phang}
+{opt cd} run each test in its own parent directory.
+
+{phang}
+{opt directory} run tests in this directory.
 
 {phang}
 {opt filter} filter tests by pattern.

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -2102,6 +2102,132 @@ fn test_test_parallel_execution() {
 }
 
 // ============================================================================
+// Test command working directory tests
+// ============================================================================
+
+#[test]
+fn test_test_help_documents_working_directory() {
+    stacy()
+        .arg("test")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "project root as the working directory",
+        ))
+        .stdout(predicate::str::contains("--cd"))
+        .stdout(predicate::str::contains("-C, --directory"));
+}
+
+#[test]
+fn test_test_cd_conflicts_with_directory() {
+    stacy()
+        .arg("test")
+        .arg("--cd")
+        .arg("-C")
+        .arg(".")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_test_directory_validates_directory_exists() {
+    let temp = TempDir::new().unwrap();
+    fs::create_dir_all(temp.path().join("tests")).unwrap();
+    fs::write(temp.path().join("tests/test_a.do"), "display 1").unwrap();
+
+    stacy()
+        .current_dir(temp.path())
+        .arg("test")
+        .arg("-C")
+        .arg("/nonexistent/directory/path")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Directory not found"));
+}
+
+#[test]
+#[ignore]
+fn test_test_runs_from_project_root_by_default() {
+    // A test writing to a relative path lands in the project root,
+    // even when stacy is invoked from a subdirectory
+    let temp = TempDir::new().unwrap();
+    fs::write(temp.path().join("stacy.toml"), "[project]\n").unwrap();
+    fs::create_dir_all(temp.path().join("tests")).unwrap();
+    fs::write(
+        temp.path().join("tests/test_wd.do"),
+        "file open fh using \"output.txt\", write replace\nfile write fh \"root\"\nfile close fh",
+    )
+    .unwrap();
+
+    stacy()
+        .current_dir(temp.path().join("tests"))
+        .arg("test")
+        .assert()
+        .success();
+
+    assert!(
+        temp.path().join("output.txt").exists(),
+        "output.txt should be created in the project root"
+    );
+}
+
+#[test]
+#[ignore]
+fn test_test_cd_runs_in_test_directory() {
+    // With --cd, relative paths resolve from the test's own directory
+    let temp = TempDir::new().unwrap();
+    fs::write(temp.path().join("stacy.toml"), "[project]\n").unwrap();
+    fs::create_dir_all(temp.path().join("tests")).unwrap();
+    fs::write(
+        temp.path().join("tests/test_wd.do"),
+        "file open fh using \"output.txt\", write replace\nfile write fh \"cd\"\nfile close fh",
+    )
+    .unwrap();
+
+    stacy()
+        .current_dir(temp.path())
+        .arg("test")
+        .arg("--cd")
+        .assert()
+        .success();
+
+    assert!(
+        temp.path().join("tests/output.txt").exists(),
+        "output.txt should be created in the test's directory"
+    );
+}
+
+#[test]
+#[ignore]
+fn test_test_directory_runs_in_given_directory() {
+    // With -C, relative paths resolve from the given directory
+    let temp = TempDir::new().unwrap();
+    fs::write(temp.path().join("stacy.toml"), "[project]\n").unwrap();
+    fs::create_dir_all(temp.path().join("tests")).unwrap();
+    fs::create_dir_all(temp.path().join("workdir")).unwrap();
+    fs::write(
+        temp.path().join("tests/test_wd.do"),
+        "file open fh using \"output.txt\", write replace\nfile write fh \"dir\"\nfile close fh",
+    )
+    .unwrap();
+
+    stacy()
+        .current_dir(temp.path())
+        .arg("test")
+        .arg("-C")
+        .arg("workdir")
+        .assert()
+        .success();
+
+    assert!(
+        temp.path().join("workdir/output.txt").exists(),
+        "output.txt should be created in the -C directory"
+    );
+}
+
+// ============================================================================
 // Run command working directory tests
 // ============================================================================
 


### PR DESCRIPTION
Closes #85.

- `stacy test` now runs each test with the project root as the working directory explicitly (previously the inherited cwd), so relative paths in tests resolve the same way regardless of where the command is invoked.
- Adds `-C`/`--directory` (run tests in a given directory) and `--cd` (run each test in its own parent directory), mutually exclusive, matching `stacy run`.
- Documents the working directory in `--help`, the generated `stacy_test.sthlp` help file, and the docs page.
- Both flags are threaded through the `stacy_test.ado` wrapper (regenerated via `cargo xtask codegen`).

Tests: unit tests for working-directory resolution, CLI tests for help text, flag conflict, and `-C` validation, plus `#[ignore]` Stata-backed tests covering all three modes.