### PR TITLE
test: repair the in-Stata wrapper suite and add #84 regression coverage

### DIFF
--- a/tests/stata/fixtures/scripts/noisy.do
+++ b/tests/stata/fixtures/scripts/noisy.do
@@ -1,0 +1,5 @@
+* noisy.do - Prints output that breaks `do` if it leaks into the result channel (#84)
+* Lines starting with "(" are not valid Stata commands; if the CLI streams them
+* into --format stata stdout, _stacy_exec's `do` fails with r(199).
+display "( 42 observations deleted )"
+display "( note: free-form script output )"

--- a/tests/stata/fixtures/stacy.toml
+++ b/tests/stata/fixtures/stacy.toml
@@ -13,4 +13,9 @@ ado_dir = "ado"
 # Define a simple task for testing stacy_task
 [scripts.test-task]
 description = "A simple test task"
-scripts = ["scripts/hello.do"]
+script = "scripts/hello.do"
+
+# Task whose script output would break the result channel if it leaked (#84)
+[scripts.noisy-task]
+description = "Prints output that must not reach --format stata stdout"
+script = "scripts/noisy.do"

--- a/tests/stata/test_wrappers.do
+++ b/tests/stata/test_wrappers.do
@@ -569,8 +569,11 @@ if `rc' == 0 {
     }
 
     capture confirm scalar r(script_count)
-    if _rc == 0 {
+    if _rc == 0 & r(script_count) >= 1 {
         di as result "  [PASS] r(script_count) = " r(script_count)
+    }
+    else {
+        di as error "  [FAIL] r(script_count) missing or 0 - task ran no scripts"
     }
 
     if "`r(task_name)'" == "test-task" {
@@ -890,6 +893,76 @@ else {
 
 * Clean up
 capture erase `"`update_flag'"'
+
+di _n
+
+* =============================================================================
+* Test 29: stacy task with noisy script output (#84 regression)
+* =============================================================================
+* noisy.do prints lines starting with "(" — not valid Stata commands. If the
+* CLI streams script output into --format stata stdout, _stacy_exec's `do`
+* fails with r(199). This is the exact failure mode of #84.
+di as text "TEST 29: stacy task noisy-task (#84 regression)"
+di as text "{hline 40}"
+
+capture noisily stacy task "noisy-task"
+local rc = _rc
+
+if `rc' == 0 {
+    di as result "  [PASS] noisy task executed successfully"
+
+    capture confirm scalar r(success)
+    if _rc == 0 & r(success) == 1 {
+        di as result "  [PASS] r(success) = 1"
+    }
+    else {
+        di as error "  [FAIL] r(success) missing or != 1 after noisy task"
+    }
+
+    capture confirm scalar r(script_count)
+    if _rc == 0 & r(script_count) >= 1 {
+        di as result "  [PASS] r(script_count) = " r(script_count)
+    }
+    else {
+        di as error "  [FAIL] r(script_count) missing or 0 - noisy script never ran"
+    }
+}
+else {
+    di as error "  [FAIL] noisy task failed with rc = `rc' (script output leaked into result channel?)"
+}
+
+di _n
+
+* =============================================================================
+* Test 30: stacy run with noisy script output (#84 regression)
+* =============================================================================
+di as text "TEST 30: stacy run scripts/noisy.do (#84 regression)"
+di as text "{hline 40}"
+
+capture noisily stacy run "scripts/noisy.do"
+local rc = _rc
+
+if `rc' == 0 {
+    di as result "  [PASS] noisy run executed successfully"
+
+    capture confirm scalar r(success)
+    if _rc == 0 & r(success) == 1 {
+        di as result "  [PASS] r(success) = 1"
+    }
+    else {
+        di as error "  [FAIL] r(success) missing or != 1 after noisy run"
+    }
+
+    if "`r(source)'" == "file" {
+        di as result "  [PASS] r(source) = file"
+    }
+    else {
+        di as error "  [FAIL] r(source) missing - noisy script never ran"
+    }
+}
+else {
+    di as error "  [FAIL] noisy run failed with rc = `rc' (script output leaked into result channel?)"
+}
 
 di _n
 

--- a/tests/test_stata_wrappers.rs
+++ b/tests/test_stata_wrappers.rs
@@ -122,24 +122,20 @@ fn test_stata_wrappers_in_project_context() {
     // Get absolute path to stacy binary
     let stacy_path = stacy_binary();
 
-    // Run the test file using stacy run
+    // Run the test file using stacy run. The internal log is removed on
+    // success, so request a durable copy with --log.
+    let log_path = temp.path().join("logs").join("test_wrappers.log");
     let output = Command::new(&stacy_path)
         .current_dir(temp.path())
         .env("STACY_BINARY", &stacy_path)
         .arg("run")
         .arg("test_wrappers.do")
+        .arg("--log")
+        .arg(&log_path)
         .output()
         .expect("Failed to execute stacy run");
 
-    // Read the log file
-    let log_path = temp.path().join("logs").join("test_wrappers.log");
-    let log_content = if log_path.exists() {
-        fs::read_to_string(&log_path).unwrap_or_default()
-    } else {
-        // Try current directory
-        let alt_log = temp.path().join("test_wrappers.log");
-        fs::read_to_string(&alt_log).unwrap_or_default()
-    };
+    let log_content = fs::read_to_string(&log_path).unwrap_or_default();
 
     // Parse results
     let (passed, failed) = parse_test_results(&log_content);


### PR DESCRIPTION
The ignored in-Stata wrapper suite (test_stata_wrappers.rs + test_wrappers.do) had drifted:

- The harness parsed the run log from logs/, but the log is internal since 1.3.0 (removed on success), so the suite found no results and failed on any run. It now passes --log for a durable copy.
- The fixture's test-task used a `scripts` key that TaskDef does not have, so `stacy task` ran zero scripts and the task tests passed vacuously. The fixture now uses the supported `script` form, and the task tests assert `script_count >= 1`. (The silent zero-script success itself is a CLI bug, reported separately.)

New coverage: TEST 29/30 run a task and a script whose output starts with `(` — lines that fail with r(199) if the CLI streams script output into the --format stata result channel that _stacy_exec executes with `do`. This is the #84 failure mode; the task variant confirmed to fail against the pre-#86 executor verbosity.

Full suite run against StataNow 19.5 (macOS): 30/30 pass.