### PR TITLE
fix: error on tasks that define no work (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A task that defines no work — a table without `script` or `parallel` (e.g. a typo'd key, which TOML parsing silently drops) or an empty array — now fails with a config error instead of succeeding as a no-op (#92).
+
 ## [1.4.0] - 2026-07-13
 
 ### Added

--- a/src/task/executor.rs
+++ b/src/task/executor.rs
@@ -142,8 +142,12 @@ impl<'a> TaskExecutor<'a> {
                 } else if let Some(ref script) = complex.script {
                     self.execute_script(name, script)
                 } else {
-                    // Empty task
-                    Ok(TaskResult::empty(name))
+                    // Rejected at TaskGraph construction; guard against
+                    // graphs built another way (#92).
+                    Err(Error::Config(format!(
+                        "Task '{}' defines no work: use 'script', 'parallel', or a non-empty array of tasks",
+                        name
+                    )))
                 }
             }
         }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -23,6 +23,7 @@ impl TaskGraph {
         };
 
         // Validate on construction
+        graph.validate_definitions()?;
         graph.validate_references()?;
         graph.validate_no_cycles()?;
 
@@ -54,6 +55,32 @@ impl TaskGraph {
     /// Check if the graph is empty
     pub fn is_empty(&self) -> bool {
         self.tasks.is_empty()
+    }
+
+    /// Validate that every task defines some work.
+    ///
+    /// A table form without `script` or `parallel` (e.g. a typo'd key —
+    /// serde ignores unknown keys) or an empty array would otherwise run
+    /// zero scripts and report success (#92).
+    fn validate_definitions(&self) -> Result<()> {
+        for (name, task) in &self.tasks {
+            let no_work = match task {
+                TaskDef::Simple(_) => false,
+                TaskDef::Sequential(tasks) => tasks.is_empty(),
+                TaskDef::Complex(complex) => match (&complex.parallel, &complex.script) {
+                    (Some(parallel), _) => parallel.is_empty(),
+                    (None, Some(_)) => false,
+                    (None, None) => true,
+                },
+            };
+            if no_work {
+                return Err(Error::Config(format!(
+                    "Task '{}' defines no work: use 'script', 'parallel', or a non-empty array of tasks",
+                    name
+                )));
+            }
+        }
+        Ok(())
     }
 
     /// Validate that all task references exist
@@ -318,6 +345,52 @@ mod tests {
 
         let graph = TaskGraph::from_config(&scripts).unwrap();
         assert_eq!(graph.len(), 3);
+    }
+
+    #[test]
+    fn test_table_task_without_work_errors() {
+        // Table form with neither `script` nor `parallel` — e.g. a typo'd
+        // key that serde silently drops — must not become a no-op (#92)
+        let scripts = make_scripts(vec![(
+            "build",
+            TaskDef::Complex(ComplexTask {
+                parallel: None,
+                script: None,
+                args: None,
+                description: Some("Build everything".to_string()),
+            }),
+        )]);
+
+        let result = TaskGraph::from_config(&scripts);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("'build' defines no work"));
+    }
+
+    #[test]
+    fn test_empty_sequential_task_errors() {
+        let scripts = make_scripts(vec![("all", TaskDef::Sequential(vec![]))]);
+
+        let result = TaskGraph::from_config(&scripts);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("defines no work"));
+    }
+
+    #[test]
+    fn test_empty_parallel_task_errors() {
+        let scripts = make_scripts(vec![(
+            "outputs",
+            TaskDef::Complex(ComplexTask {
+                parallel: Some(vec![]),
+                script: None,
+                args: None,
+                description: None,
+            }),
+        )]);
+
+        let result = TaskGraph::from_config(&scripts);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("defines no work"));
     }
 
     #[test]

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -1636,6 +1636,32 @@ fn test_task_frozen_flag_exists() {
 }
 
 #[test]
+fn test_task_table_without_work_fails() {
+    // A table-form task whose work key is typo'd (serde drops unknown keys)
+    // must error, not succeed as a no-op (#92)
+    let temp = TempDir::new().unwrap();
+    fs::write(
+        temp.path().join("stacy.toml"),
+        r#"[project]
+name = "test"
+
+[scripts.build]
+description = "Build everything"
+scripts = ["src/01_clean.do"]
+"#,
+    )
+    .unwrap();
+
+    stacy()
+        .current_dir(temp.path())
+        .arg("task")
+        .arg("build")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("defines no work"));
+}
+
+#[test]
 fn test_task_frozen_in_sync() {
     let temp = TempDir::new().unwrap();
     fs::write(


### PR DESCRIPTION
Closes #92.

A table-form task without `script` or `parallel` — typically a typo'd key, which TOML parsing silently drops — deserialized as a task with no work attached, ran zero scripts, and reported success in every output format. Empty arrays (`all = []`, `parallel = []`) behaved the same way.

TaskGraph construction now rejects such definitions with a config error naming the task (`Task 'build' defines no work: use 'script', 'parallel', or a non-empty array of tasks`), so both `stacy task <name>` and `stacy task --list` fail loudly. The executor's empty-task fallback now errors too instead of returning an empty success.

Tests: unit tests for the three no-work shapes, plus a CLI test asserting the typo'd-key config fails with the message.