### PR TITLE
fix: exit nonzero when a package command does not complete (#94)

### DIFF
--- a/docs/src/commands/add.md
+++ b/docs/src/commands/add.md
@@ -54,7 +54,7 @@ stacy add --dev assert
 | Code | Meaning |
 |------|--------|
 | 0 | Success |
-| 1 | All packages failed to add |
+| 1 | A package failed to add |
 
 See [Exit Codes Reference](../reference/exit-codes.md) for details.
 

--- a/docs/src/commands/deps.md
+++ b/docs/src/commands/deps.md
@@ -17,6 +17,11 @@ dependency graph, detects circular dependencies, and identifies missing files.
 `require` statements (including `cap require` and `capture require`) are
 recognized as package dependencies and shown as leaf nodes in the tree.
 
+A path that holds a Stata macro, such as `do "$root/prep.do"`, only points
+somewhere once Stata expands the macro. stacy reads the script but does not run
+it, so it lists the path as written and marks it as resolved at run time. Such a
+path is not a missing file and does not fail the command.
+
 ## Arguments
 
 | Argument | Description |

--- a/docs/src/commands/deps.md
+++ b/docs/src/commands/deps.md
@@ -48,7 +48,8 @@ stacy deps --flat main.do
 | Code | Meaning |
 |------|--------|
 | 0 | Analysis complete |
-| 3 | Script not found |
+| 1 | Circular dependencies detected |
+| 3 | Script not found, or a dependency is missing |
 
 See [Exit Codes Reference](../reference/exit-codes.md) for details.
 

--- a/docs/src/commands/install.md
+++ b/docs/src/commands/install.md
@@ -53,8 +53,7 @@ stacy install estout
 | Code | Meaning |
 |------|--------|
 | 0 | Success |
-| 1 | Installation failed |
-| 3 | Package not found |
+| 1 | A package failed to install or failed checksum verification |
 
 See [Exit Codes Reference](../reference/exit-codes.md) for details.
 

--- a/docs/src/commands/lock.md
+++ b/docs/src/commands/lock.md
@@ -40,7 +40,7 @@ stacy lock --check
 | Code | Meaning |
 |------|--------|
 | 0 | Success / in sync |
-| 1 | Out of sync (with --check) |
+| 1 | A package could not be resolved, or the lockfile is out of sync (with --check) |
 
 See [Exit Codes Reference](../reference/exit-codes.md) for details.
 

--- a/docs/src/commands/outdated.md
+++ b/docs/src/commands/outdated.md
@@ -26,6 +26,7 @@ stacy outdated
 | Code | Meaning |
 |------|--------|
 | 0 | Success |
+| 1 | A package's latest version could not be checked |
 
 See [Exit Codes Reference](../reference/exit-codes.md) for details.
 

--- a/docs/src/commands/update.md
+++ b/docs/src/commands/update.md
@@ -14,6 +14,9 @@ Checks for newer versions of installed packages and updates them. Updates both
 `stacy.toml` and `stacy.lock` to reflect new versions. Use `--dry-run` to preview
 changes without applying them.
 
+A `local:` package lives in the project, so there is no source to check for a
+newer version. It is reported as skipped and does not fail the command.
+
 ## Arguments
 
 | Argument | Description |

--- a/docs/src/commands/update.md
+++ b/docs/src/commands/update.md
@@ -51,7 +51,7 @@ stacy update --dry-run
 | Code | Meaning |
 |------|--------|
 | 0 | Success |
-| 1 | All updates failed |
+| 1 | A package failed to update, or its latest version could not be checked |
 
 See [Exit Codes Reference](../reference/exit-codes.md) for details.
 

--- a/docs/src/reference/json-output.md
+++ b/docs/src/reference/json-output.md
@@ -179,12 +179,14 @@ stacy env --format json
 
 ```json
 {
+  "status": "success",
   "script": "master.do",
   "dependencies": {
     "path": "master.do",
     "type": null,
     "exists": true,
     "is_circular": false,
+    "is_unresolved": false,
     "line_number": null,
     "children": [
       {
@@ -192,6 +194,7 @@ stacy env --format json
         "type": "do",
         "exists": true,
         "is_circular": false,
+        "is_unresolved": false,
         "line_number": 3,
         "children": []
       },
@@ -200,6 +203,7 @@ stacy env --format json
         "type": "require",
         "exists": true,
         "is_circular": false,
+        "is_unresolved": false,
         "line_number": 5,
         "children": []
       }
@@ -211,11 +215,21 @@ stacy env --format json
     "has_missing": false,
     "circular_paths": [],
     "missing_paths": [],
+    "unresolved_paths": [],
     "circular_count": 0,
-    "missing_count": 0
+    "missing_count": 0,
+    "unresolved_count": 0
   }
 }
 ```
+
+`status` is `success` when the graph resolved and `error` when a dependency is
+missing or circular — branch on it rather than on the summary counts.
+
+`is_unresolved` marks a path that holds a Stata macro, such as
+`do "$root/prep.do"`. stacy reads scripts but does not run them, so it cannot
+say where the path points. Such a path is listed but not looked up, and it does
+not fail the command.
 
 ## jq Examples
 

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -334,8 +334,7 @@ status = { type = "string", json_path = "status", stata_type = "local", descript
 
 [commands.install.exit_codes]
 0 = "Success"
-1 = "Installation failed"
-3 = "Package not found"
+1 = "A package failed to install or failed checksum verification"
 
 [[commands.install.examples]]
 title = "Install from lockfile"
@@ -380,10 +379,12 @@ missing_count = { type = "int", json_path = "summary.missing_paths", stata_type 
 
 # Locals
 script = { type = "path", json_path = "script", stata_type = "local", description = "Path to analyzed script" }
+status = { type = "string", json_path = "status", stata_type = "local", description = "'success' or 'error'" }
 
 [commands.deps.exit_codes]
 0 = "Analysis complete"
-3 = "Script not found"
+1 = "Circular dependencies detected"
+3 = "Script not found, or a dependency is missing"
 
 [[commands.deps.examples]]
 title = "Show dependency tree"
@@ -473,7 +474,7 @@ group = { type = "string", json_path = "summary.group", stata_type = "local", de
 
 [commands.add.exit_codes]
 0 = "Success"
-1 = "All packages failed to add"
+1 = "A package failed to add"
 
 [[commands.add.examples]]
 title = "Add from SSC"
@@ -561,7 +562,7 @@ status = { type = "string", json_path = "status", stata_type = "local", descript
 
 [commands.update.exit_codes]
 0 = "Success"
-1 = "All updates failed"
+1 = "A package failed to update, or its latest version could not be checked"
 
 [[commands.update.examples]]
 title = "Update all packages"
@@ -638,6 +639,7 @@ json = { type = "bool", description = "JSON output (internal)" }
 # Scalars
 outdated_count = { type = "int", json_path = "outdated_count", stata_type = "scalar", description = "Number of outdated packages" }
 total_count = { type = "int", json_path = "total_count", stata_type = "scalar", description = "Total packages checked" }
+failed = { type = "int", json_path = "failed", stata_type = "scalar", description = "Number of packages whose latest version could not be checked" }
 
 # Locals (comma-separated lists)
 status = { type = "string", json_path = "status", stata_type = "local", description = "'success' or 'error'" }
@@ -647,6 +649,7 @@ outdated_latests = { type = "string", json_path = "packages", stata_type = "loca
 
 [commands.outdated.exit_codes]
 0 = "Success"
+1 = "A package's latest version could not be checked"
 
 [[commands.outdated.examples]]
 title = "Check for updates"
@@ -676,6 +679,7 @@ json = { type = "bool", description = "JSON output (internal)" }
 [commands.lock.returns]
 # Scalars
 package_count = { type = "int", json_path = "package_count", stata_type = "scalar", description = "Number of packages in lockfile" }
+failed = { type = "int", json_path = "failed", stata_type = "scalar", description = "Number of packages that could not be resolved" }
 updated = { type = "bool", json_path = "updated", stata_type = "scalar", description = "Whether lockfile was updated (1=yes, 0=no)" }
 in_sync = { type = "bool", json_path = "in_sync", stata_type = "scalar", description = "Whether lockfile is in sync (1=yes, 0=no)" }
 
@@ -684,7 +688,7 @@ status = { type = "string", json_path = "status", stata_type = "local", descript
 
 [commands.lock.exit_codes]
 0 = "Success / in sync"
-1 = "Out of sync (with --check)"
+1 = "A package could not be resolved, or the lockfile is out of sync (with --check)"
 
 [[commands.lock.examples]]
 title = "Generate lockfile"

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -361,6 +361,11 @@ dependency graph, detects circular dependencies, and identifies missing files.
 
 `require` statements (including `cap require` and `capture require`) are
 recognized as package dependencies and shown as leaf nodes in the tree.
+
+A path that holds a Stata macro, such as `do "$root/prep.do"`, only points
+somewhere once Stata expands the macro. stacy reads the script but does not run
+it, so it lists the path as written and marks it as resolved at run time. Such a
+path is not a missing file and does not fail the command.
 """
 see_also = ["run"]
 
@@ -541,6 +546,9 @@ long_description = """
 Checks for newer versions of installed packages and updates them. Updates both
 `stacy.toml` and `stacy.lock` to reflect new versions. Use `--dry-run` to preview
 changes without applying them.
+
+A `local:` package lives in the project, so there is no source to check for a
+newer version. It is reported as skipped and does not fail the command.
 """
 see_also = ["outdated", "install", "lock"]
 
@@ -554,6 +562,7 @@ json = { type = "bool", description = "JSON output (internal)" }
 updated = { type = "int", json_path = "summary.updated", stata_type = "scalar", description = "Number of packages updated" }
 updates_available = { type = "int", json_path = "summary.updates_available", stata_type = "scalar", description = "Number of packages with updates available" }
 failed = { type = "int", json_path = "summary.failed", stata_type = "scalar", description = "Number of packages that failed to update" }
+skipped = { type = "int", json_path = "summary.skipped", stata_type = "scalar", description = "Number of packages with no source to check (local packages)" }
 total = { type = "int", json_path = "summary.total", stata_type = "scalar", description = "Total packages checked" }
 dry_run = { type = "bool", json_path = "dry_run", stata_type = "scalar", description = "Whether this was a dry run (1=yes, 0=no)" }
 

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -281,8 +281,19 @@ pub fn execute(args: &AddArgs) -> Result<()> {
         OutputFormat::Human => print_human_summary(&output),
     }
 
-    if failed_count > 0 && added_count == 0 {
-        std::process::exit(1);
+    // Any package that failed to install is a package the caller asked for and
+    // did not get — a partial batch is a failure, not a success.
+    if failed_count > 0 {
+        let failed_names: Vec<&str> = results
+            .iter()
+            .filter(|r| !r.success)
+            .map(|r| r.name.as_str())
+            .collect();
+        return Err(Error::Config(format!(
+            "{} package(s) failed to add: {}",
+            failed_count,
+            failed_names.join(", ")
+        )));
     }
 
     Ok(())

--- a/src/cli/deps.rs
+++ b/src/cli/deps.rs
@@ -41,12 +41,13 @@ pub fn execute(args: &DepsArgs) -> Result<()> {
             has_missing: true,
             circular_count: 0,
             missing_count: 1,
+            status: "error".to_string(),
         };
 
         match format {
             OutputFormat::Json => {
                 println!(
-                    r#"{{"error": "Script not found: {}"}}"#,
+                    r#"{{"status": "error", "error": "Script not found: {}"}}"#,
                     args.script.display()
                 );
             }
@@ -59,6 +60,10 @@ pub fn execute(args: &DepsArgs) -> Result<()> {
     // Analyze dependencies
     let analysis = analyze_dependencies(&args.script)?;
 
+    // A missing or circular dependency means the graph could not be resolved:
+    // the analysis is incomplete, so it must not report success.
+    let incomplete = analysis.has_missing || analysis.has_circular;
+
     // Build output struct
     let output = DepsOutput {
         script: args.script.clone(),
@@ -67,11 +72,12 @@ pub fn execute(args: &DepsArgs) -> Result<()> {
         has_missing: analysis.has_missing,
         circular_count: analysis.circular_paths.len(),
         missing_count: analysis.missing_paths.len(),
+        status: if incomplete { "error" } else { "success" }.to_string(),
     };
 
     // Output result
     match format {
-        OutputFormat::Json => print_json_output(&analysis.tree, &args.script)?,
+        OutputFormat::Json => print_json_output(&analysis.tree, &args.script, &output.status)?,
         OutputFormat::Stata => println!("{}", output.to_stata()),
         OutputFormat::Human => {
             if args.flat {
@@ -84,10 +90,9 @@ pub fn execute(args: &DepsArgs) -> Result<()> {
             println!();
             print_summary(&analysis.tree);
 
-            // Warnings
             if analysis.has_circular {
                 println!();
-                eprintln!("Warning: Circular dependencies detected:");
+                eprintln!("Error: Circular dependencies detected:");
                 for path in &analysis.circular_paths {
                     eprintln!("  - {}", path.display());
                 }
@@ -95,12 +100,22 @@ pub fn execute(args: &DepsArgs) -> Result<()> {
 
             if analysis.has_missing {
                 println!();
-                eprintln!("Warning: Missing files:");
+                eprintln!("Error: Missing files:");
                 for path in &analysis.missing_paths {
                     eprintln!("  - {}", path.display());
                 }
             }
         }
+    }
+
+    // A missing file is a file error (3), matching a missing script above.
+    // A cycle is not a file error — the files are all there — so it maps to
+    // the generic failure code (1).
+    if analysis.has_missing {
+        std::process::exit(3);
+    }
+    if analysis.has_circular {
+        std::process::exit(1);
     }
 
     Ok(())
@@ -160,10 +175,11 @@ fn print_summary(tree: &DependencyTree) {
     }
 }
 
-fn print_json_output(tree: &DependencyTree, script: &std::path::Path) -> Result<()> {
+fn print_json_output(tree: &DependencyTree, script: &std::path::Path, status: &str) -> Result<()> {
     use serde_json::json;
 
     let output = json!({
+        "status": status,
         "script": script.display().to_string(),
         "dependencies": tree_to_json(tree),
         "summary": {

--- a/src/cli/deps.rs
+++ b/src/cli/deps.rs
@@ -105,6 +105,14 @@ pub fn execute(args: &DepsArgs) -> Result<()> {
                     eprintln!("  - {}", path.display());
                 }
             }
+
+            if !analysis.dynamic_paths.is_empty() {
+                println!();
+                println!("Paths that hold a macro are resolved when the script runs:");
+                for path in &analysis.dynamic_paths {
+                    println!("  - {}", path.display());
+                }
+            }
         }
     }
 
@@ -139,6 +147,8 @@ fn print_flat_output(tree: &DependencyTree) {
         let indent = "  ".repeat(dep.depth + 1);
         let suffix = if dep.is_circular {
             " (circular)"
+        } else if dep.is_dynamic {
+            " (macro path, resolved at run time)"
         } else if !dep.exists {
             " (not found)"
         } else {
@@ -188,8 +198,10 @@ fn print_json_output(tree: &DependencyTree, script: &std::path::Path, status: &s
             "has_missing": tree.has_missing(),
             "circular_paths": tree.circular_paths().iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
             "missing_paths": tree.missing_paths().iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+            "unresolved_paths": tree.dynamic_paths().iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
             "circular_count": tree.circular_paths().len(),
             "missing_count": tree.missing_paths().len(),
+            "unresolved_count": tree.dynamic_paths().len(),
         }
     });
 
@@ -207,6 +219,7 @@ fn tree_to_json(tree: &DependencyTree) -> serde_json::Value {
         "type": tree.dep_type.map(|t| t.to_string()),
         "exists": tree.exists,
         "is_circular": tree.is_circular,
+        "is_unresolved": tree.is_dynamic,
         "line_number": tree.line_number,
         "children": children,
     })

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -216,7 +216,17 @@ fn install_from_lockfile(args: &InstallArgs) -> Result<()> {
         })
         .collect();
 
+    // A skipped package is one the lockfile asks for and stacy could not
+    // install (unreachable source, bad repo, missing local path). The lockfile
+    // was not realised, so the command did not do its job.
+    let skipped_names: Vec<&str> = results
+        .iter()
+        .filter(|r| matches!(r.action, SyncAction::Skipped(_)))
+        .map(|r| r.name.as_str())
+        .collect();
+
     let failed_count = (failed_names.len() + mismatches.len()) as i32;
+    let integrity_failed = failed_count > 0;
 
     let mut problems: Vec<String> = mismatches.iter().map(|m| m.to_string()).collect();
     if !failed_names.is_empty() {
@@ -226,16 +236,18 @@ fn install_from_lockfile(args: &InstallArgs) -> Result<()> {
             failed_names.join(", ")
         ));
     }
+    if !skipped_names.is_empty() {
+        problems.push(format!(
+            "{} package(s) failed to install: {}",
+            skipped_names.len(),
+            skipped_names.join(", ")
+        ));
+    }
 
-    let error_message: Option<String> = if !problems.is_empty() {
-        Some(problems.join("\n\n"))
-    } else if skipped_count > 0 && installed_count == 0 {
-        Some(format!(
-            "{} package(s) skipped, none installed",
-            skipped_count
-        ))
-    } else {
+    let error_message: Option<String> = if problems.is_empty() {
         None
+    } else {
+        Some(problems.join("\n\n"))
     };
 
     let output = InstallOutput {
@@ -260,10 +272,15 @@ fn install_from_lockfile(args: &InstallArgs) -> Result<()> {
         OutputFormat::Human => print_sync_human_output(&results),
     }
 
-    if failed_count > 0 {
-        // Both kinds of failure — a source that disagrees with the pin, and a
-        // cached package that no longer hashes to it — are integrity failures.
-        return Err(Error::Integrity(error_message.unwrap()));
+    if let Some(msg) = error_message {
+        // A source that disagrees with the pin, and a cached package that no
+        // longer hashes to it, are integrity failures. A package stacy simply
+        // could not fetch is not: the lockfile just was not realised.
+        return Err(if integrity_failed {
+            Error::Integrity(msg)
+        } else {
+            Error::Config(msg)
+        });
     }
 
     Ok(())
@@ -409,7 +426,7 @@ fn print_sync_human_output(results: &[SyncedPackage]) {
             }
             SyncAction::Skipped(reason) => {
                 println!(
-                    "  Skipping {} ({}): {}",
+                    "  x {} ({}) failed to install: {}",
                     result.name, result.version, reason
                 );
                 skipped.push(&result.name);
@@ -436,12 +453,23 @@ fn print_sync_human_output(results: &[SyncedPackage]) {
             summary.push(format!("{} already installed", already.len()));
         }
         if !skipped.is_empty() {
-            summary.push(format!("{} skipped", skipped.len()));
+            summary.push(format!("{} failed", skipped.len()));
         }
+<<<<<<< HEAD
         if !mismatched.is_empty() {
             summary.push(format!("{} failed", mismatched.len()));
         }
         println!("Install complete: {}", summary.join(", "));
+||||||| parent of ce331be (fix: exit nonzero when a package command does not complete (#94))
+        println!("Install complete: {}", summary.join(", "));
+=======
+        let headline = if skipped.is_empty() {
+            "Install complete"
+        } else {
+            "Install incomplete"
+        };
+        println!("{}: {}", headline, summary.join(", "));
+>>>>>>> ce331be (fix: exit nonzero when a package command does not complete (#94))
     }
 
     // Checksum verification results

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -455,21 +455,15 @@ fn print_sync_human_output(results: &[SyncedPackage]) {
         if !skipped.is_empty() {
             summary.push(format!("{} failed", skipped.len()));
         }
-<<<<<<< HEAD
         if !mismatched.is_empty() {
             summary.push(format!("{} failed", mismatched.len()));
         }
-        println!("Install complete: {}", summary.join(", "));
-||||||| parent of ce331be (fix: exit nonzero when a package command does not complete (#94))
-        println!("Install complete: {}", summary.join(", "));
-=======
-        let headline = if skipped.is_empty() {
+        let headline = if skipped.is_empty() && mismatched.is_empty() {
             "Install complete"
         } else {
             "Install incomplete"
         };
         println!("{}: {}", headline, summary.join(", "));
->>>>>>> ce331be (fix: exit nonzero when a package command does not complete (#94))
     }
 
     // Checksum verification results

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -84,6 +84,12 @@ pub fn execute(args: &LockArgs) -> Result<()> {
             package_count: lockfile.packages.len(),
             updated: false,
             in_sync,
+            failed: 0,
+            error: if in_sync {
+                None
+            } else {
+                Some("Lockfile is out of sync with stacy.toml".to_string())
+            },
         };
 
         match format {
@@ -131,6 +137,8 @@ pub fn execute(args: &LockArgs) -> Result<()> {
     let mut updated = false;
     let mut added_count = 0;
     let mut removed_count = 0;
+    // Packages in stacy.toml that could not be recorded in the lockfile.
+    let mut failures: Vec<String> = Vec::new();
 
     // Add packages from config that aren't in lockfile
     let github_downloader = GitHubDownloader::new();
@@ -172,8 +180,9 @@ pub fn execute(args: &LockArgs) -> Result<()> {
                     }
                 }
                 Err(e) => {
+                    failures.push(name.to_string());
                     if format == OutputFormat::Human {
-                        eprintln!("  Warning: Could not resolve {}: {}", name, e);
+                        eprintln!("  x could not resolve {}: {}", name, e);
                     }
                 }
             }
@@ -236,15 +245,29 @@ pub fn execute(args: &LockArgs) -> Result<()> {
                         }
                     }
                     Err(e) => {
+                        failures.push(name.to_string());
                         if format == OutputFormat::Human {
-                            eprintln!("  Warning: Could not resolve {}: {}", name, e);
+                            eprintln!("  x could not resolve {}: {}", name, e);
                         }
                     }
                 }
-            } else if format == OutputFormat::Human {
+            } else {
+                failures.push(name.to_string());
+                if format == OutputFormat::Human {
+                    eprintln!(
+                        "  x could not resolve {}: invalid GitHub source '{}'. Use github:user/repo",
+                        name, source_str
+                    );
+                }
+            }
+        } else {
+            // net: and local: packages carry no resolvable version — they are
+            // recorded in the lockfile by `stacy add`, not by `stacy lock`.
+            failures.push(name.to_string());
+            if format == OutputFormat::Human {
                 eprintln!(
-                    "  Warning: Invalid GitHub source for {}: {}",
-                    name, source_str
+                    "  x could not resolve {}: '{}' sources are recorded by `stacy add {} --source {}`",
+                    name, source_str, name, source_str
                 );
             }
         }
@@ -303,11 +326,27 @@ pub fn execute(args: &LockArgs) -> Result<()> {
         save_lockfile(&project.root, &lockfile)?;
     }
 
+    let error_message = if failures.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "{} package(s) could not be resolved: {}",
+            failures.len(),
+            failures.join(", ")
+        ))
+    };
+
     let output = LockOutput {
-        status: "success".to_string(),
+        status: if error_message.is_some() {
+            "error".to_string()
+        } else {
+            "success".to_string()
+        },
         package_count: lockfile.packages.len(),
         updated,
-        in_sync: true,
+        in_sync: failures.is_empty(),
+        failed: failures.len(),
+        error: error_message.clone(),
     };
 
     match format {
@@ -331,13 +370,17 @@ pub fn execute(args: &LockArgs) -> Result<()> {
                     summary.join(", "),
                     lockfile.packages.len()
                 );
-            } else {
+            } else if failures.is_empty() {
                 println!(
                     "Lockfile is up to date ({} packages)",
                     lockfile.packages.len()
                 );
             }
         }
+    }
+
+    if let Some(msg) = error_message {
+        return Err(Error::Config(msg));
     }
 
     Ok(())

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -47,6 +47,8 @@ pub fn execute(args: &OutdatedArgs) -> Result<()> {
             status: "success".to_string(),
             outdated_count: 0,
             total_count: 0,
+            failed: 0,
+            error: None,
             packages: vec![],
         };
 
@@ -67,6 +69,8 @@ pub fn execute(args: &OutdatedArgs) -> Result<()> {
     let github_downloader = GitHubDownloader::new();
     let mut outdated: Vec<OutdatedInfo> = Vec::new();
     let mut checked_count = 0;
+    // Packages whose latest version could not be determined.
+    let mut failures: Vec<String> = Vec::new();
 
     for (name, entry) in &lockfile.packages {
         match &entry.source {
@@ -92,8 +96,9 @@ pub fn execute(args: &OutdatedArgs) -> Result<()> {
                         }
                     }
                     Err(e) => {
+                        failures.push(name.clone());
                         if format == OutputFormat::Human {
-                            eprintln!("  Warning: Could not check {}: {}", name, e);
+                            eprintln!("  x could not check {}: {}", name, e);
                         }
                     }
                 }
@@ -120,13 +125,20 @@ pub fn execute(args: &OutdatedArgs) -> Result<()> {
                             }
                         }
                         Err(e) => {
+                            failures.push(name.clone());
                             if format == OutputFormat::Human {
-                                eprintln!("  Warning: Could not check {}: {}", name, e);
+                                eprintln!("  x could not check {}: {}", name, e);
                             }
                         }
                     }
-                } else if format == OutputFormat::Human {
-                    eprintln!("  Warning: Invalid repo format for {}: {}", name, repo);
+                } else {
+                    failures.push(name.clone());
+                    if format == OutputFormat::Human {
+                        eprintln!(
+                            "  x could not check {}: invalid repo format '{}'",
+                            name, repo
+                        );
+                    }
                 }
             }
             PackageSource::Local { path } => {
@@ -158,10 +170,26 @@ pub fn execute(args: &OutdatedArgs) -> Result<()> {
         })
         .collect();
 
+    let error_message = if failures.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "{} package(s) could not be checked: {}",
+            failures.len(),
+            failures.join(", ")
+        ))
+    };
+
     let output = OutdatedOutput {
-        status: "success".to_string(),
+        status: if error_message.is_some() {
+            "error".to_string()
+        } else {
+            "success".to_string()
+        },
         outdated_count: outdated.len(),
         total_count: checked_count,
+        failed: failures.len(),
+        error: error_message.clone(),
         packages: output_packages,
     };
 
@@ -170,7 +198,10 @@ pub fn execute(args: &OutdatedArgs) -> Result<()> {
         OutputFormat::Stata => println!("{}", output.to_stata()),
         OutputFormat::Human => {
             if outdated.is_empty() {
-                println!("All packages are up to date.");
+                // Only claim everything is current when every check succeeded.
+                if failures.is_empty() {
+                    println!("All packages are up to date.");
+                }
             } else {
                 // Calculate column widths
                 let name_width = outdated.iter().map(|p| p.name.len()).max().unwrap_or(10);
@@ -218,6 +249,10 @@ pub fn execute(args: &OutdatedArgs) -> Result<()> {
                 println!("{} {} updates available.", outdated.len(), pkg_word);
             }
         }
+    }
+
+    if let Some(msg) = error_message {
+        return Err(Error::Config(msg));
     }
 
     Ok(())

--- a/src/cli/output_types.rs
+++ b/src/cli/output_types.rs
@@ -754,6 +754,8 @@ pub struct DepsOutput {
     pub unique_count: i32,
     /// Path to analyzed script
     pub script: PathBuf,
+    /// 'success' or 'error'
+    pub status: String,
 }
 
 impl CommandOutput for DepsOutput {
@@ -764,6 +766,7 @@ impl CommandOutput for DepsOutput {
     fn to_stata(&self) -> String {
         let mut lines = Vec::new();
         lines.push("* stacy deps output".to_string());
+        lines.push(format_stata_local("status", &self.status));
         lines.push(format_stata_local(
             "script",
             &self.script.display().to_string(),
@@ -956,6 +959,11 @@ pub struct OutdatedOutput {
     pub outdated_count: usize,
     /// Total packages checked
     pub total_count: usize,
+    /// Number of packages whose latest version could not be checked
+    pub failed: usize,
+    /// Error summary (present iff status == "error")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
     /// List of outdated packages
     pub packages: Vec<OutdatedPackageInfo>,
 }
@@ -987,6 +995,7 @@ impl CommandOutput for OutdatedOutput {
             self.outdated_count,
         ));
         lines.push(format_stata_scalar_usize("total_count", self.total_count));
+        lines.push(format_stata_scalar_usize("failed", self.failed));
         // Create comma-separated lists
         let names: Vec<_> = self.packages.iter().map(|p| p.name.as_str()).collect();
         let currents: Vec<_> = self.packages.iter().map(|p| p.current.as_str()).collect();
@@ -994,6 +1003,9 @@ impl CommandOutput for OutdatedOutput {
         lines.push(format_stata_local("outdated_names", &names.join(",")));
         lines.push(format_stata_local("outdated_currents", &currents.join(",")));
         lines.push(format_stata_local("outdated_latests", &latests.join(",")));
+        if let Some(msg) = &self.error {
+            lines.push(format_stata_local("error", msg));
+        }
         lines.join("\n")
     }
 }
@@ -1013,6 +1025,11 @@ pub struct LockOutput {
     pub updated: bool,
     /// Whether lockfile is in sync with config (for --check)
     pub in_sync: bool,
+    /// Number of packages that could not be resolved
+    pub failed: usize,
+    /// Error summary (present iff status == "error")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 impl CommandOutput for LockOutput {
@@ -1030,6 +1047,10 @@ impl CommandOutput for LockOutput {
         ));
         lines.push(format_stata_scalar_bool("updated", self.updated));
         lines.push(format_stata_scalar_bool("in_sync", self.in_sync));
+        lines.push(format_stata_scalar_usize("failed", self.failed));
+        if let Some(msg) = &self.error {
+            lines.push(format_stata_local("error", msg));
+        }
         lines.join("\n")
     }
 }
@@ -1309,9 +1330,11 @@ mod tests {
             has_missing: true,
             circular_count: 0,
             missing_count: 2,
+            status: "error".to_string(),
         };
 
         let stata = output.to_stata();
+        assert!(stata.contains("global stacy_status \"error\""));
         assert!(stata.contains("global stacy_script \"/path/to/main.do\""));
         assert!(stata.contains("scalar stacy_unique_count = 5"));
         assert!(stata.contains("scalar stacy_has_circular = 0"));
@@ -1809,6 +1832,8 @@ mod tests {
             status: "success".to_string(),
             outdated_count: 1,
             total_count: 3,
+            failed: 0,
+            error: None,
             packages: vec![OutdatedPackageInfo {
                 name: "estout".to_string(),
                 current: "3.30".to_string(),
@@ -1821,6 +1846,7 @@ mod tests {
         assert!(stata.contains("global stacy_status \"success\""));
         assert!(stata.contains("scalar stacy_outdated_count = 1"));
         assert!(stata.contains("scalar stacy_total_count = 3"));
+        assert!(stata.contains("scalar stacy_failed = 0"));
         assert!(stata.contains("global stacy_outdated_names \"estout\""));
         assert!(stata.contains("global stacy_outdated_currents \"3.30\""));
         assert!(stata.contains("global stacy_outdated_latests \"3.31\""));
@@ -1837,6 +1863,8 @@ mod tests {
             package_count: 5,
             updated: false,
             in_sync: true,
+            failed: 0,
+            error: None,
         };
 
         let stata = output.to_stata();
@@ -1844,6 +1872,25 @@ mod tests {
         assert!(stata.contains("scalar stacy_package_count = 5"));
         assert!(stata.contains("scalar stacy_updated = 0"));
         assert!(stata.contains("scalar stacy_in_sync = 1"));
+        assert!(stata.contains("scalar stacy_failed = 0"));
+    }
+
+    #[test]
+    fn test_lock_output_to_stata_reports_unresolved_packages() {
+        let output = LockOutput {
+            status: "error".to_string(),
+            package_count: 0,
+            updated: false,
+            in_sync: false,
+            failed: 1,
+            error: Some("1 package(s) could not be resolved: badpkg".to_string()),
+        };
+
+        let stata = output.to_stata();
+        assert!(stata.contains("global stacy_status \"error\""));
+        assert!(stata.contains("scalar stacy_failed = 1"));
+        assert!(stata.contains("global stacy_error"));
+        assert!(!stata.contains("global stacy_status \"success\""));
     }
 
     // =========================================================================
@@ -2085,6 +2132,7 @@ mod tests {
                     has_missing: false,
                     circular_count: 0,
                     missing_count: 0,
+                    status: "success".to_string(),
                 }
                 .to_stata(),
             ),
@@ -2128,6 +2176,8 @@ mod tests {
                     status: "success".to_string(),
                     outdated_count: 0,
                     total_count: 0,
+                    failed: 0,
+                    error: None,
                     packages: vec![],
                 }
                 .to_stata(),
@@ -2139,6 +2189,8 @@ mod tests {
                     package_count: 0,
                     updated: false,
                     in_sync: true,
+                    failed: 0,
+                    error: None,
                 }
                 .to_stata(),
             ),

--- a/src/cli/output_types.rs
+++ b/src/cli/output_types.rs
@@ -704,6 +704,8 @@ pub struct UpdateOutput {
     pub dry_run: bool,
     /// Number of packages that failed to update
     pub failed: i32,
+    /// Number of packages skipped (no source to check, e.g. local)
+    pub skipped: i32,
     /// 'success', 'partial', or 'error'
     pub status: String,
     /// Total packages checked
@@ -729,6 +731,7 @@ impl CommandOutput for UpdateOutput {
             self.updates_available as i64,
         ));
         lines.push(format_stata_scalar_int("failed", self.failed as i64));
+        lines.push(format_stata_scalar_int("skipped", self.skipped as i64));
         lines.push(format_stata_scalar_int("total", self.total as i64));
         lines.push(format_stata_scalar_bool("dry_run", self.dry_run));
         lines.join("\n")
@@ -1721,6 +1724,7 @@ mod tests {
         let output = UpdateOutput {
             dry_run: true,
             failed: 0,
+            skipped: 1,
             status: "success".to_string(),
             total: 5,
             updates_available: 2,
@@ -1732,6 +1736,7 @@ mod tests {
         assert!(stata.contains("scalar stacy_updated = 0"));
         assert!(stata.contains("scalar stacy_updates_available = 2"));
         assert!(stata.contains("scalar stacy_failed = 0"));
+        assert!(stata.contains("scalar stacy_skipped = 1"));
         assert!(stata.contains("scalar stacy_total = 5"));
         assert!(stata.contains("scalar stacy_dry_run = 1"));
     }
@@ -2116,6 +2121,7 @@ mod tests {
                 UpdateOutput {
                     dry_run: false,
                     failed: 0,
+                    skipped: 0,
                     status: "success".to_string(),
                     total: 2,
                     updates_available: 1,

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -50,6 +50,15 @@ impl Check {
     }
 }
 
+/// What `update` did with one package
+enum Outcome {
+    /// The source was asked for its latest version, and — outside a dry run —
+    /// the package was installed from it
+    Checked(Check),
+    /// There is no source to ask: the reason is carried for the report
+    Skipped(String),
+}
+
 /// Latest version from a manifest's distribution date, defaulting to today
 /// (the same rule the installers use when a package declares no date).
 fn manifest_version(distribution_date: Option<String>) -> String {
@@ -64,6 +73,7 @@ struct UpdatedPackage {
     new_version: Option<String>,
     updated: bool,
     has_update: bool,
+    skipped: bool,
     error: Option<String>,
 }
 
@@ -129,15 +139,18 @@ pub fn execute(args: &UpdateArgs) -> Result<()> {
         // latest version but installs nothing; anything it cannot check is a
         // failure, not an "up to date".
         let group = entry.group.as_str();
-        let update_result: Result<Check> = match &entry.source {
+        let update_result: Result<Outcome> = match &entry.source {
             PackageSource::SSC { name: _ } => {
                 if args.dry_run {
                     ssc_downloader.get_manifest(pkg_name).map(|m| {
-                        Check::from_version(manifest_version(m.distribution_date), &old_version)
+                        Outcome::Checked(Check::from_version(
+                            manifest_version(m.distribution_date),
+                            &old_version,
+                        ))
                     })
                 } else {
                     install_from_ssc(pkg_name, &project.root, group)
-                        .map(|r| Check::from_version(r.version, &old_version))
+                        .map(|r| Outcome::Checked(Check::from_version(r.version, &old_version)))
                 }
             }
             PackageSource::GitHub { repo, tag, .. } => {
@@ -148,9 +161,11 @@ pub fn execute(args: &UpdateArgs) -> Result<()> {
                         // rather than the recorded distribution date.
                         github_downloader
                             .check_for_updates(parts[0], parts[1], tag)
-                            .map(|info| Check {
-                                new_version: info.latest_tag.unwrap_or_else(|| tag.clone()),
-                                has_update: info.has_update,
+                            .map(|info| {
+                                Outcome::Checked(Check {
+                                    new_version: info.latest_tag.unwrap_or_else(|| tag.clone()),
+                                    has_update: info.has_update,
+                                })
                             })
                     } else {
                         install_package_github(
@@ -161,20 +176,25 @@ pub fn execute(args: &UpdateArgs) -> Result<()> {
                             &project.root,
                             group,
                         )
-                        .map(|r| Check::from_version(r.version, &old_version))
+                        .map(|r| Outcome::Checked(Check::from_version(r.version, &old_version)))
                     }
                 } else {
                     Err(Error::Config(format!("Invalid repo format: {}", repo)))
                 }
             }
-            PackageSource::Local { path } => Err(Error::Config(format!(
-                "Cannot update local package: {}",
-                path
-            ))),
+            // A local package is a directory in the project, not something to
+            // fetch: there is no newer version to find. Skipping it is the
+            // right answer, not a failure — the same call `outdated` makes.
+            PackageSource::Local { path } => {
+                Ok(Outcome::Skipped(format!("local package at {}", path)))
+            }
             PackageSource::Net { url } => {
                 if args.dry_run {
                     net_downloader.get_manifest(pkg_name, url).map(|m| {
-                        Check::from_version(manifest_version(m.distribution_date), &old_version)
+                        Outcome::Checked(Check::from_version(
+                            manifest_version(m.distribution_date),
+                            &old_version,
+                        ))
                     })
                 } else {
                     crate::packages::installer::install_from_net(
@@ -183,17 +203,16 @@ pub fn execute(args: &UpdateArgs) -> Result<()> {
                         &project.root,
                         group,
                     )
-                    .map(|r| Check::from_version(r.version, &old_version))
+                    .map(|r| Outcome::Checked(Check::from_version(r.version, &old_version)))
                 }
             }
         };
 
         match update_result {
-            Ok(check) => {
-                let Check {
-                    new_version,
-                    has_update,
-                } = check;
+            Ok(Outcome::Checked(Check {
+                new_version,
+                has_update,
+            })) => {
                 let updated = !args.dry_run && has_update;
 
                 if format == OutputFormat::Human {
@@ -216,6 +235,22 @@ pub fn execute(args: &UpdateArgs) -> Result<()> {
                     new_version: Some(new_version),
                     updated,
                     has_update,
+                    skipped: false,
+                    error: None,
+                });
+            }
+            Ok(Outcome::Skipped(reason)) => {
+                if format == OutputFormat::Human {
+                    println!("  = {} (skipped: {})", pkg_name, reason);
+                }
+
+                results.push(UpdatedPackage {
+                    name: pkg_name.clone(),
+                    new_version: Some(old_version.clone()),
+                    old_version,
+                    updated: false,
+                    has_update: false,
+                    skipped: true,
                     error: None,
                 });
             }
@@ -229,6 +264,7 @@ pub fn execute(args: &UpdateArgs) -> Result<()> {
                     new_version: None,
                     updated: false,
                     has_update: false,
+                    skipped: false,
                     error: Some(e.to_string()),
                 });
             }
@@ -249,6 +285,7 @@ pub fn execute(args: &UpdateArgs) -> Result<()> {
     let updated_count = results.iter().filter(|r| r.updated).count() as i32;
     let updates_available = results.iter().filter(|r| r.has_update).count() as i32;
     let failed_count = results.iter().filter(|r| r.error.is_some()).count() as i32;
+    let skipped_count = results.iter().filter(|r| r.skipped).count() as i32;
 
     let status = if failed_count > 0 && updated_count == 0 {
         "error"
@@ -263,6 +300,7 @@ pub fn execute(args: &UpdateArgs) -> Result<()> {
         updated: updated_count,
         updates_available,
         failed: failed_count,
+        skipped: skipped_count,
         total: results.len() as i32,
         dry_run: args.dry_run,
     };
@@ -306,6 +344,7 @@ fn print_json_output(results: &[UpdatedPackage], output: &UpdateOutput) {
                 "new_version": r.new_version,
                 "updated": r.updated,
                 "has_update": r.has_update,
+                "skipped": r.skipped,
                 "error": r.error,
             })
         })
@@ -319,6 +358,7 @@ fn print_json_output(results: &[UpdatedPackage], output: &UpdateOutput) {
             "updated": output.updated,
             "updates_available": output.updates_available,
             "failed": output.failed,
+            "skipped": output.skipped,
             "total": output.total,
         }
     });
@@ -343,6 +383,9 @@ fn print_human_summary(output: &UpdateOutput, dry_run: bool) {
         let mut summary = Vec::new();
         if output.updated > 0 {
             summary.push(format!("{} updated", output.updated));
+        }
+        if output.skipped > 0 {
+            summary.push(format!("{} skipped", output.skipped));
         }
         if output.failed > 0 {
             summary.push(format!("{} failed", output.failed));

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -5,8 +5,11 @@
 use crate::cli::output_format::OutputFormat;
 use crate::cli::output_types::{CommandOutput, UpdateOutput};
 use crate::error::{Error, Result};
+use crate::packages::github::GitHubDownloader;
 use crate::packages::installer::{install_from_ssc, install_package_github};
 use crate::packages::lockfile::{load_lockfile, save_lockfile};
+use crate::packages::net::NetDownloader;
+use crate::packages::ssc::SscDownloader;
 use crate::project::config::load_config;
 use crate::project::{PackageSource, Project};
 use clap::Args;
@@ -29,6 +32,28 @@ pub struct UpdateArgs {
     /// Output format: human (default), json, or stata
     #[arg(long, value_enum, default_value = "human")]
     pub format: OutputFormat,
+}
+
+/// Outcome of a version check (dry run) or an install (real update)
+struct Check {
+    new_version: String,
+    has_update: bool,
+}
+
+impl Check {
+    fn from_version(new_version: String, old_version: &str) -> Self {
+        let has_update = new_version != old_version;
+        Self {
+            new_version,
+            has_update,
+        }
+    }
+}
+
+/// Latest version from a manifest's distribution date, defaulting to today
+/// (the same rule the installers use when a package declares no date).
+fn manifest_version(distribution_date: Option<String>) -> String {
+    distribution_date.unwrap_or_else(crate::utils::date::today_yyyymmdd)
 }
 
 /// Result of checking/updating a single package
@@ -92,28 +117,41 @@ pub fn execute(args: &UpdateArgs) -> Result<()> {
     }
 
     let mut results: Vec<UpdatedPackage> = Vec::new();
+    let ssc_downloader = SscDownloader::new();
+    let github_downloader = GitHubDownloader::new();
+    let net_downloader = NetDownloader::new();
 
     for pkg_name in &packages_to_update {
         let entry = lockfile.packages.get(pkg_name).unwrap();
         let old_version = entry.version.clone();
 
-        // Try to update the package
+        // Try to update the package. A dry run queries the source for the
+        // latest version but installs nothing; anything it cannot check is a
+        // failure, not an "up to date".
         let group = entry.group.as_str();
-        let update_result = match &entry.source {
+        let update_result: Result<Check> = match &entry.source {
             PackageSource::SSC { name: _ } => {
                 if args.dry_run {
-                    // For dry run, we'd need to check the latest version without installing
-                    // For now, we'll just report that an update check was done
-                    Ok(None)
+                    ssc_downloader.get_manifest(pkg_name).map(|m| {
+                        Check::from_version(manifest_version(m.distribution_date), &old_version)
+                    })
                 } else {
-                    install_from_ssc(pkg_name, &project.root, group).map(|r| Some(r.version))
+                    install_from_ssc(pkg_name, &project.root, group)
+                        .map(|r| Check::from_version(r.version, &old_version))
                 }
             }
             PackageSource::GitHub { repo, tag, .. } => {
                 let parts: Vec<&str> = repo.split('/').collect();
                 if parts.len() == 2 {
                     if args.dry_run {
-                        Ok(None)
+                        // GitHub packages are locked by tag, so compare tags
+                        // rather than the recorded distribution date.
+                        github_downloader
+                            .check_for_updates(parts[0], parts[1], tag)
+                            .map(|info| Check {
+                                new_version: info.latest_tag.unwrap_or_else(|| tag.clone()),
+                                has_update: info.has_update,
+                            })
                     } else {
                         install_package_github(
                             pkg_name,
@@ -123,7 +161,7 @@ pub fn execute(args: &UpdateArgs) -> Result<()> {
                             &project.root,
                             group,
                         )
-                        .map(|r| Some(r.version))
+                        .map(|r| Check::from_version(r.version, &old_version))
                     }
                 } else {
                     Err(Error::Config(format!("Invalid repo format: {}", repo)))
@@ -135,7 +173,9 @@ pub fn execute(args: &UpdateArgs) -> Result<()> {
             ))),
             PackageSource::Net { url } => {
                 if args.dry_run {
-                    Ok(None)
+                    net_downloader.get_manifest(pkg_name, url).map(|m| {
+                        Check::from_version(manifest_version(m.distribution_date), &old_version)
+                    })
                 } else {
                     crate::packages::installer::install_from_net(
                         pkg_name,
@@ -143,15 +183,17 @@ pub fn execute(args: &UpdateArgs) -> Result<()> {
                         &project.root,
                         group,
                     )
-                    .map(|r| Some(r.version))
+                    .map(|r| Check::from_version(r.version, &old_version))
                 }
             }
         };
 
         match update_result {
-            Ok(new_version_opt) => {
-                let new_version = new_version_opt.unwrap_or_else(|| old_version.clone());
-                let has_update = new_version != old_version;
+            Ok(check) => {
+                let Check {
+                    new_version,
+                    has_update,
+                } = check;
                 let updated = !args.dry_run && has_update;
 
                 if format == OutputFormat::Human {
@@ -232,8 +274,21 @@ pub fn execute(args: &UpdateArgs) -> Result<()> {
         OutputFormat::Human => print_human_summary(&output, args.dry_run),
     }
 
-    if failed_count > 0 && updated_count == 0 {
-        std::process::exit(1);
+    // A package that could not be updated (or, in a dry run, could not be
+    // checked) leaves the request unfinished, even if others succeeded.
+    if failed_count > 0 {
+        let failed_names: Vec<&str> = results
+            .iter()
+            .filter(|r| r.error.is_some())
+            .map(|r| r.name.as_str())
+            .collect();
+        let verb = if args.dry_run { "checked" } else { "updated" };
+        return Err(Error::Config(format!(
+            "{} package(s) could not be {}: {}",
+            failed_count,
+            verb,
+            failed_names.join(", ")
+        )));
     }
 
     Ok(())
@@ -280,7 +335,8 @@ fn print_human_summary(output: &UpdateOutput, dry_run: bool) {
                 "Would update {} package(s). Run without --dry-run to apply.",
                 output.updates_available
             );
-        } else {
+        } else if output.failed == 0 {
+            // Only claim everything is current when every check succeeded.
             println!("All packages are up to date.");
         }
     } else {

--- a/src/deps/parser.rs
+++ b/src/deps/parser.rs
@@ -75,6 +75,18 @@ static INCLUDE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
 static REQUIRE_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"(?i)^\s*(?:cap(?:ture)?\s+)?require\s+(\w+)"#).unwrap());
 
+/// Matches an unexpanded Stata macro: `$name`, `${name}` (global) or `` `name' `` (local).
+static MACRO_PATTERN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\$\{?\w|`\w").unwrap());
+
+/// Whether a path still contains a Stata macro.
+///
+/// stacy reads scripts, it does not run them, so it cannot know what a macro
+/// holds. `do "$root/prep.do"` names a file whose location is only decided at
+/// run time: the path is unresolved, not missing.
+pub fn is_dynamic_path(path: &Path) -> bool {
+    MACRO_PATTERN.is_match(&path.to_string_lossy())
+}
+
 /// Parse a Stata script file for dependencies
 ///
 /// # Arguments
@@ -374,6 +386,32 @@ regress y x
         let content = r#"require using "requirements.txt""#;
         let deps = parse_dependencies_from_content(content).unwrap();
         assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn test_is_dynamic_path_global_macro() {
+        assert!(is_dynamic_path(Path::new("$root/prep.do")));
+        assert!(is_dynamic_path(Path::new("${root}/prep.do")));
+    }
+
+    #[test]
+    fn test_is_dynamic_path_local_macro() {
+        assert!(is_dynamic_path(Path::new("`sub'/prep.do")));
+    }
+
+    #[test]
+    fn test_is_dynamic_path_plain_path() {
+        assert!(!is_dynamic_path(Path::new("utils/helper.do")));
+        assert!(!is_dynamic_path(Path::new("/abs/path/helper.do")));
+    }
+
+    #[test]
+    fn test_parse_do_with_macro_path() {
+        let content = r#"do "$root/prep.do""#;
+        let deps = parse_dependencies_from_content(content).unwrap();
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].path, PathBuf::from("$root/prep.do"));
+        assert!(is_dynamic_path(&deps[0].path));
     }
 
     #[test]

--- a/src/deps/tree.rs
+++ b/src/deps/tree.rs
@@ -3,7 +3,7 @@
 //! Recursively analyzes Stata scripts to build a complete dependency tree,
 //! detecting circular dependencies and missing files.
 
-use super::parser::{parse_dependencies, DependencyType};
+use super::parser::{is_dynamic_path, parse_dependencies, DependencyType};
 use crate::error::Result;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -21,6 +21,9 @@ pub struct DependencyTree {
     pub is_circular: bool,
     /// Whether the file exists
     pub exists: bool,
+    /// Whether the path holds a Stata macro, so it can only be resolved at run
+    /// time. Such a node is unresolved, not missing.
+    pub is_dynamic: bool,
     /// Line number in parent (None for root)
     pub line_number: Option<usize>,
 }
@@ -34,6 +37,7 @@ impl DependencyTree {
             children: Vec::new(),
             is_circular: false,
             exists: true,
+            is_dynamic: false,
             line_number: None,
         }
     }
@@ -61,7 +65,12 @@ impl DependencyTree {
 
     /// Check if tree has any missing files
     pub fn has_missing(&self) -> bool {
-        !self.exists || self.children.iter().any(|c| c.has_missing())
+        (!self.exists && !self.is_dynamic) || self.children.iter().any(|c| c.has_missing())
+    }
+
+    /// Check if tree has any paths that only resolve at run time
+    pub fn has_dynamic(&self) -> bool {
+        self.is_dynamic || self.children.iter().any(|c| c.has_dynamic())
     }
 
     /// Get all circular dependency paths
@@ -88,11 +97,27 @@ impl DependencyTree {
     }
 
     fn collect_missing<'a>(&'a self, paths: &mut Vec<&'a Path>) {
-        if !self.exists && !self.is_circular {
+        if !self.exists && !self.is_circular && !self.is_dynamic {
             paths.push(&self.path);
         }
         for child in &self.children {
             child.collect_missing(paths);
+        }
+    }
+
+    /// Get all paths that hold a Stata macro
+    pub fn dynamic_paths(&self) -> Vec<&Path> {
+        let mut paths = Vec::new();
+        self.collect_dynamic(&mut paths);
+        paths
+    }
+
+    fn collect_dynamic<'a>(&'a self, paths: &mut Vec<&'a Path>) {
+        if self.is_dynamic {
+            paths.push(&self.path);
+        }
+        for child in &self.children {
+            child.collect_dynamic(paths);
         }
     }
 
@@ -116,6 +141,8 @@ impl DependencyTree {
         let path_display = self.path.display().to_string();
         let suffix = if self.is_circular {
             " (circular)"
+        } else if self.is_dynamic {
+            " (macro path, resolved at run time)"
         } else if !self.exists {
             " (not found)"
         } else {
@@ -158,6 +185,7 @@ impl DependencyTree {
                 depth,
                 is_circular: child.is_circular,
                 exists: child.exists,
+                is_dynamic: child.is_dynamic,
             });
             if !child.is_circular {
                 child.flatten_recursive(deps, depth + 1);
@@ -174,6 +202,7 @@ pub struct FlatDependency {
     pub depth: usize,
     pub is_circular: bool,
     pub exists: bool,
+    pub is_dynamic: bool,
 }
 
 /// Build a complete dependency tree for a script
@@ -221,6 +250,7 @@ fn build_tree_recursive(
             children: Vec::new(),
             is_circular: true,
             exists: script.exists(),
+            is_dynamic: false,
             line_number,
         });
     }
@@ -233,6 +263,7 @@ fn build_tree_recursive(
             children: Vec::new(),
             is_circular: false,
             exists: false,
+            is_dynamic: false,
             line_number,
         });
     }
@@ -257,10 +288,27 @@ fn build_tree_recursive(
                 children: Vec::new(),
                 is_circular: false,
                 exists: true, // Package existence is not a file check
+                is_dynamic: false,
                 line_number: Some(dep.line_number),
             });
             continue;
         }
+
+        // A path built from a macro only exists once Stata expands it. Record
+        // it as written and stop: there is nothing to look up or recurse into.
+        if is_dynamic_path(&dep.path) {
+            children.push(DependencyTree {
+                path: dep.path.clone(),
+                dep_type: Some(dep.dep_type),
+                children: Vec::new(),
+                is_circular: false,
+                exists: false,
+                is_dynamic: true,
+                line_number: Some(dep.line_number),
+            });
+            continue;
+        }
+
         let resolved_path = dep.resolve(base_dir);
         let child = build_tree_recursive(
             &resolved_path,
@@ -280,6 +328,7 @@ fn build_tree_recursive(
         children,
         is_circular: false,
         exists: true,
+        is_dynamic: false,
         line_number,
     })
 }
@@ -293,6 +342,8 @@ pub struct DependencyAnalysis {
     pub has_missing: bool,
     pub circular_paths: Vec<PathBuf>,
     pub missing_paths: Vec<PathBuf>,
+    /// Paths that hold a Stata macro and only resolve when the script runs
+    pub dynamic_paths: Vec<PathBuf>,
 }
 
 pub fn analyze_dependencies(script: &Path) -> Result<DependencyAnalysis> {
@@ -308,6 +359,11 @@ pub fn analyze_dependencies(script: &Path) -> Result<DependencyAnalysis> {
         .iter()
         .map(|p| p.to_path_buf())
         .collect();
+    let dynamic_paths: Vec<PathBuf> = tree
+        .dynamic_paths()
+        .iter()
+        .map(|p| p.to_path_buf())
+        .collect();
 
     Ok(DependencyAnalysis {
         unique_count: tree.unique_count(),
@@ -315,6 +371,7 @@ pub fn analyze_dependencies(script: &Path) -> Result<DependencyAnalysis> {
         has_missing: tree.has_missing(),
         circular_paths,
         missing_paths,
+        dynamic_paths,
         tree,
     })
 }
@@ -388,6 +445,34 @@ mod tests {
         let tree = build_tree(&main).unwrap();
         assert!(tree.has_missing());
         assert_eq!(tree.missing_paths().len(), 1);
+    }
+
+    #[test]
+    fn test_macro_path_is_dynamic_not_missing() {
+        let temp = TempDir::new().unwrap();
+        let main = create_test_file(temp.path(), "main.do", "do \"$root/prep.do\"");
+
+        let tree = build_tree(&main).unwrap();
+        assert!(!tree.has_missing());
+        assert!(tree.missing_paths().is_empty());
+        assert!(tree.has_dynamic());
+        assert_eq!(tree.dynamic_paths(), vec![Path::new("$root/prep.do")]);
+        assert!(tree.children[0].children.is_empty());
+    }
+
+    #[test]
+    fn test_macro_path_alongside_missing_file() {
+        let temp = TempDir::new().unwrap();
+        let main = create_test_file(
+            temp.path(),
+            "main.do",
+            "do \"`sub'/prep.do\"\ndo \"gone.do\"\n",
+        );
+
+        let tree = build_tree(&main).unwrap();
+        assert!(tree.has_missing());
+        assert_eq!(tree.missing_paths().len(), 1);
+        assert_eq!(tree.dynamic_paths().len(), 1);
     }
 
     #[test]

--- a/src/packages/net.rs
+++ b/src/packages/net.rs
@@ -96,6 +96,21 @@ impl NetDownloader {
         })
     }
 
+    /// Get a package manifest without downloading its files
+    ///
+    /// Fetches and parses `{base_url}/{name}.pkg` only.
+    pub fn get_manifest(&self, name: &str, base_url: &str) -> Result<PackageManifest> {
+        let name = name.to_lowercase();
+        let base_url = if base_url.ends_with('/') {
+            base_url.to_string()
+        } else {
+            format!("{}/", base_url)
+        };
+
+        let pkg_content = self.download_text(&format!("{}{}.pkg", base_url, name))?;
+        parse_pkg_file(&pkg_content, &name)
+    }
+
     fn download_text(&self, url: &str) -> Result<String> {
         self.client.download_text(url)
     }

--- a/stata/stacy_deps.ado
+++ b/stata/stacy_deps.ado
@@ -20,6 +20,7 @@
         r(missing_count       ) - Number of missing files (scalar)
         r(unique_count        ) - Number of unique dependencies (scalar)
         r(script              ) - Path to analyzed script (local)
+        r(status              ) - 'success' or 'error' (local)
 */
 
 program define stacy_deps, rclass
@@ -75,6 +76,10 @@ program define stacy_deps, rclass
 
     if `"${stacy_script}"' != "" {
         return local script `"${stacy_script}"'
+    }
+
+    if `"${stacy_status}"' != "" {
+        return local status `"${stacy_status}"'
     }
 
     * Return failure if command failed

--- a/stata/stacy_deps.sthlp
+++ b/stata/stacy_deps.sthlp
@@ -55,6 +55,7 @@
 
 {p2col 5 25 29 2: Macros}{p_end}
 {synopt:{cmd:r(script)}}Path to analyzed script{p_end}
+{synopt:{cmd:r(status)}}'success' or 'error'{p_end}
 
 
 {marker examples}{...}

--- a/stata/stacy_lock.ado
+++ b/stata/stacy_lock.ado
@@ -15,6 +15,7 @@
         REFRESH              - Recompute checksums from the packages installed in the global cache
 
     Returns:
+        r(failed              ) - Number of packages that could not be resolved (scalar)
         r(in_sync             ) - Whether lockfile is in sync (1=yes, 0=no) (scalar)
         r(package_count       ) - Number of packages in lockfile (scalar)
         r(updated             ) - Whether lockfile was updated (1=yes, 0=no) (scalar)
@@ -41,6 +42,11 @@ program define stacy_lock, rclass
     local exec_rc = r(exit_code)
 
     * Map parsed values to r() returns
+    capture confirm scalar stacy_failed
+    if _rc == 0 {
+        return scalar failed = scalar(stacy_failed)
+    }
+
     capture confirm scalar stacy_in_sync
     if _rc == 0 {
         return scalar in_sync = scalar(stacy_in_sync)

--- a/stata/stacy_lock.sthlp
+++ b/stata/stacy_lock.sthlp
@@ -51,6 +51,7 @@
 
 {synoptset 25 tabbed}{...}
 {p2col 5 25 29 2: Scalars}{p_end}
+{synopt:{cmd:r(failed)}}Number of packages that could not be resolved{p_end}
 {synopt:{cmd:r(in_sync)}}Whether lockfile is in sync (1=yes, 0=no){p_end}
 {synopt:{cmd:r(package_count)}}Number of packages in lockfile{p_end}
 {synopt:{cmd:r(updated)}}Whether lockfile was updated (1=yes, 0=no){p_end}

--- a/stata/stacy_outdated.ado
+++ b/stata/stacy_outdated.ado
@@ -11,6 +11,7 @@
         stacy_outdated 
 
     Returns:
+        r(failed              ) - Number of packages whose latest version could not be checked (scalar)
         r(outdated_count      ) - Number of outdated packages (scalar)
         r(total_count         ) - Total packages checked (scalar)
         r(outdated_currents   ) - Comma-separated current versions (local)
@@ -31,6 +32,11 @@ program define stacy_outdated, rclass
     local exec_rc = r(exit_code)
 
     * Map parsed values to r() returns
+    capture confirm scalar stacy_failed
+    if _rc == 0 {
+        return scalar failed = scalar(stacy_failed)
+    }
+
     capture confirm scalar stacy_outdated_count
     if _rc == 0 {
         return scalar outdated_count = scalar(stacy_outdated_count)

--- a/stata/stacy_outdated.sthlp
+++ b/stata/stacy_outdated.sthlp
@@ -32,6 +32,7 @@
 
 {synoptset 25 tabbed}{...}
 {p2col 5 25 29 2: Scalars}{p_end}
+{synopt:{cmd:r(failed)}}Number of packages whose latest version could not be checked{p_end}
 {synopt:{cmd:r(outdated_count)}}Number of outdated packages{p_end}
 {synopt:{cmd:r(total_count)}}Total packages checked{p_end}
 

--- a/stata/stacy_update.ado
+++ b/stata/stacy_update.ado
@@ -16,6 +16,7 @@
     Returns:
         r(dry_run             ) - Whether this was a dry run (1=yes, 0=no) (scalar)
         r(failed              ) - Number of packages that failed to update (scalar)
+        r(skipped             ) - Number of packages with no source to check (local packages) (scalar)
         r(total               ) - Total packages checked (scalar)
         r(updated             ) - Number of packages updated (scalar)
         r(updates_available   ) - Number of packages with updates available (scalar)
@@ -50,6 +51,11 @@ program define stacy_update, rclass
     capture confirm scalar stacy_failed
     if _rc == 0 {
         return scalar failed = scalar(stacy_failed)
+    }
+
+    capture confirm scalar stacy_skipped
+    if _rc == 0 {
+        return scalar skipped = scalar(stacy_skipped)
     }
 
     capture confirm scalar stacy_total

--- a/stata/stacy_update.sthlp
+++ b/stata/stacy_update.sthlp
@@ -49,6 +49,7 @@
 {p2col 5 25 29 2: Scalars}{p_end}
 {synopt:{cmd:r(dry_run)}}Whether this was a dry run (1=yes, 0=no){p_end}
 {synopt:{cmd:r(failed)}}Number of packages that failed to update{p_end}
+{synopt:{cmd:r(skipped)}}Number of packages with no source to check (local packages){p_end}
 {synopt:{cmd:r(total)}}Total packages checked{p_end}
 {synopt:{cmd:r(updated)}}Number of packages updated{p_end}
 {synopt:{cmd:r(updates_available)}}Number of packages with updates available{p_end}

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -12,6 +12,23 @@ fn stacy() -> Command {
     cargo_bin_cmd!("stacy")
 }
 
+/// Put a package in an isolated global cache so `install` sees it as already
+/// installed and never reaches for a package source.
+fn cache_package(cache_root: &std::path::Path, name: &str, version: &str) {
+    let packages = if cfg!(windows) {
+        cache_root.join("stacy").join("cache").join("packages")
+    } else {
+        cache_root.join("stacy").join("packages")
+    };
+    let dir = packages.join(name).join(version);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join(format!("{}.ado", name)),
+        format!("program define {}\nend\n", name),
+    )
+    .unwrap();
+}
+
 #[test]
 fn test_help() {
     stacy()
@@ -175,11 +192,13 @@ fn test_deps_detects_circular() {
     fs::write(temp.path().join("a.do"), "do \"b.do\"").unwrap();
     fs::write(temp.path().join("b.do"), "do \"a.do\"").unwrap();
 
+    // The graph could not be resolved, so the analysis fails (#94)
     stacy()
         .arg("deps")
         .arg(temp.path().join("a.do"))
         .assert()
-        .success()
+        .failure()
+        .code(1)
         .stdout(predicate::str::contains("circular"));
 }
 
@@ -1468,9 +1487,16 @@ name = "devpkg"
     )
     .unwrap();
 
+    // Both packages are already in the cache, so install resolves them locally
+    let cache = TempDir::new().unwrap();
+    cache_package(cache.path(), "prodpkg", "1.0.0");
+    cache_package(cache.path(), "devpkg", "1.0.0");
+
     // Should accept the flag and mention the groups
     stacy()
         .current_dir(temp.path())
+        .env("XDG_CACHE_HOME", cache.path())
+        .env("LOCALAPPDATA", cache.path())
         .arg("install")
         .arg("--with")
         .arg("dev")

--- a/tests/package_command_failures.rs
+++ b/tests/package_command_failures.rs
@@ -1,0 +1,574 @@
+//! Regression tests for #94: a package command whose work did not complete
+//! must exit non-zero and must not report `status: "success"`.
+//!
+//! Every case here is hermetic. Failures come from sources that cannot resolve
+//! without a network (an invalid GitHub source, a closed loopback port), and
+//! successes come from a stub HTTP server bound to 127.0.0.1. No test needs SSC
+//! or github.com to be reachable.
+
+use assert_cmd::{cargo_bin_cmd, Command};
+use predicates::prelude::*;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::thread;
+use tempfile::TempDir;
+
+fn stacy() -> Command {
+    cargo_bin_cmd!("stacy")
+}
+
+/// A port nothing listens on: connections are refused immediately, so any
+/// download against it fails without touching the network.
+const CLOSED_URL: &str = "http://127.0.0.1:1/";
+
+// ============================================================================
+// Stub package server
+// ============================================================================
+
+/// Serve a fixed set of paths over HTTP on 127.0.0.1. Unknown paths get a 404,
+/// which is how a package "does not exist" at a `net:` source.
+fn start_stub_server(routes: HashMap<String, Vec<u8>>) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let Ok(peek) = stream.try_clone() else {
+                continue;
+            };
+            let mut reader = BufReader::new(peek);
+
+            let mut request_line = String::new();
+            if reader.read_line(&mut request_line).is_err() {
+                continue;
+            }
+            let path = request_line
+                .split_whitespace()
+                .nth(1)
+                .unwrap_or("/")
+                .trim_start_matches('/')
+                .to_string();
+
+            // Drain the request headers.
+            loop {
+                let mut line = String::new();
+                match reader.read_line(&mut line) {
+                    Ok(0) => break,
+                    Ok(_) if line.trim().is_empty() => break,
+                    Ok(_) => continue,
+                    Err(_) => break,
+                }
+            }
+
+            let response = match routes.get(&path) {
+                Some(body) => {
+                    let mut head = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    )
+                    .into_bytes();
+                    head.extend_from_slice(body);
+                    head
+                }
+                None => b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    .to_vec(),
+            };
+
+            let _ = stream.write_all(&response);
+            let _ = stream.flush();
+        }
+    });
+
+    port
+}
+
+/// Serve one package (`<name>.pkg` plus its ado file) at the given date.
+fn serve_package(name: &str, date: &str) -> String {
+    let mut routes = HashMap::new();
+    routes.insert(
+        format!("{}.pkg", name),
+        format!(
+            "d '{}': stub package\nd Distribution-Date: {}\nf {}.ado\n",
+            name.to_uppercase(),
+            date,
+            name
+        )
+        .into_bytes(),
+    );
+    routes.insert(
+        format!("{}.ado", name),
+        format!("program define {}\nend\n", name).into_bytes(),
+    );
+
+    let port = start_stub_server(routes);
+    format!("http://127.0.0.1:{}/", port)
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Project + isolated package cache, so nothing reaches the user's real cache.
+struct Project {
+    dir: TempDir,
+    cache: TempDir,
+}
+
+impl Project {
+    fn new(stacy_toml: &str) -> Self {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("stacy.toml"), stacy_toml).unwrap();
+        Self {
+            dir,
+            cache: TempDir::new().unwrap(),
+        }
+    }
+
+    fn with_lockfile(self, stacy_lock: &str) -> Self {
+        std::fs::write(self.dir.path().join("stacy.lock"), stacy_lock).unwrap();
+        self
+    }
+
+    fn run(&self, args: &[&str]) -> Command {
+        let mut cmd = stacy();
+        cmd.current_dir(self.dir.path())
+            .env("XDG_CACHE_HOME", self.cache.path())
+            .env("LOCALAPPDATA", self.cache.path())
+            .args(args);
+        cmd
+    }
+}
+
+/// Run a command with `--format json`, assert the exit code, return the JSON.
+fn json_after_exit(project: &Project, args: &[&str], expected_code: i32) -> Value {
+    let mut argv = args.to_vec();
+    argv.extend_from_slice(&["--format", "json"]);
+
+    let output = project.run(&argv).output().unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(expected_code),
+        "expected exit {} from `stacy {}`, got {:?}\nstdout: {}\nstderr: {}",
+        expected_code,
+        args.join(" "),
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("stdout is not JSON ({e}): {stdout}"))
+}
+
+fn assert_not_success(json: &Value) {
+    let status = json["status"].as_str().unwrap_or("<missing>");
+    assert_ne!(
+        status, "success",
+        "machine-readable status must not be success: {json}"
+    );
+}
+
+// ============================================================================
+// install
+// ============================================================================
+
+/// A lockfile package that cannot be fetched leaves the environment
+/// incomplete: `install` must fail, not report "N skipped" and exit 0.
+#[test]
+fn test_install_fails_when_package_cannot_be_installed() {
+    let project = Project::new("[project]\nname = \"t\"\n").with_lockfile(&format!(
+        r#"version = "1"
+
+[packages.stubpkg]
+version = "20200101"
+group = "production"
+
+[packages.stubpkg.source]
+type = "Net"
+url = "{CLOSED_URL}"
+"#
+    ));
+
+    let json = json_after_exit(&project, &["install"], 1);
+    assert_not_success(&json);
+    assert_eq!(json["summary"]["installed"], 0);
+    assert_eq!(json["summary"]["skipped"], 1);
+}
+
+/// The human surface must say so too — #94 saw failures that only JSON knew about.
+#[test]
+fn test_install_failure_is_reported_in_human_output() {
+    let project = Project::new("[project]\nname = \"t\"\n").with_lockfile(&format!(
+        r#"version = "1"
+
+[packages.stubpkg]
+version = "20200101"
+group = "production"
+
+[packages.stubpkg.source]
+type = "Net"
+url = "{CLOSED_URL}"
+"#
+    ));
+
+    project
+        .run(&["install"])
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(predicate::str::contains("failed to install"))
+        .stdout(predicate::str::contains("Install complete").not())
+        .stderr(predicate::str::contains("Error:"));
+}
+
+/// `--frozen` is the CI path: a skipped package there is fatal.
+#[test]
+fn test_install_frozen_fails_when_package_cannot_be_installed() {
+    let project = Project::new(
+        r#"[project]
+name = "t"
+
+[packages.dependencies]
+stubpkg = "ssc"
+"#,
+    )
+    .with_lockfile(&format!(
+        r#"version = "1"
+
+[packages.stubpkg]
+version = "20200101"
+group = "production"
+
+[packages.stubpkg.source]
+type = "Net"
+url = "{CLOSED_URL}"
+"#
+    ));
+
+    let json = json_after_exit(&project, &["install", "--frozen"], 1);
+    assert_not_success(&json);
+}
+
+// ============================================================================
+// lock
+// ============================================================================
+
+/// An unresolvable package means the lockfile does not describe stacy.toml.
+#[test]
+fn test_lock_fails_on_unresolvable_package() {
+    let project = Project::new(
+        r#"[project]
+name = "t"
+
+[packages.dependencies]
+badpkg = "github:notauserreposlash"
+"#,
+    );
+
+    let json = json_after_exit(&project, &["lock"], 1);
+    assert_not_success(&json);
+    assert_eq!(json["package_count"], 0);
+    assert_eq!(json["failed"], 1);
+    assert_eq!(json["in_sync"], false);
+    assert!(!project.dir.path().join("stacy.lock").exists());
+}
+
+#[test]
+fn test_lock_unresolvable_package_reported_in_human_output() {
+    let project = Project::new(
+        r#"[project]
+name = "t"
+
+[packages.dependencies]
+badpkg = "github:notauserreposlash"
+"#,
+    );
+
+    project
+        .run(&["lock"])
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(predicate::str::contains("up to date").not())
+        .stderr(predicate::str::contains("could not resolve badpkg"))
+        .stderr(predicate::str::contains("Error:"));
+}
+
+/// `net:` and `local:` packages carry no resolvable version. Recording nothing
+/// and claiming success hid them from `install`; now lock says it cannot do it.
+#[test]
+fn test_lock_fails_on_source_it_cannot_resolve() {
+    let project = Project::new(
+        r#"[project]
+name = "t"
+
+[packages.dependencies]
+mypkg = "local:./lib/mypkg/"
+"#,
+    );
+
+    let json = json_after_exit(&project, &["lock"], 1);
+    assert_not_success(&json);
+    assert_eq!(json["failed"], 1);
+}
+
+// ============================================================================
+// outdated
+// ============================================================================
+
+/// A failed version check is not evidence that everything is current.
+#[test]
+fn test_outdated_fails_when_a_check_fails() {
+    let project = Project::new("[project]\nname = \"t\"\n").with_lockfile(
+        r#"version = "1"
+
+[packages.badpkg]
+version = "1.0.0"
+group = "production"
+
+[packages.badpkg.source]
+type = "GitHub"
+repo = "notauserreposlash"
+tag = "v1.0.0"
+"#,
+    );
+
+    let json = json_after_exit(&project, &["outdated"], 1);
+    assert_not_success(&json);
+    assert_eq!(json["failed"], 1);
+    assert_eq!(json["outdated_count"], 0);
+}
+
+#[test]
+fn test_outdated_does_not_claim_up_to_date_when_a_check_fails() {
+    let project = Project::new("[project]\nname = \"t\"\n").with_lockfile(
+        r#"version = "1"
+
+[packages.badpkg]
+version = "1.0.0"
+group = "production"
+
+[packages.badpkg.source]
+type = "GitHub"
+repo = "notauserreposlash"
+tag = "v1.0.0"
+"#,
+    );
+
+    project
+        .run(&["outdated"])
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(predicate::str::contains("All packages are up to date").not())
+        .stderr(predicate::str::contains("could not check badpkg"));
+}
+
+// ============================================================================
+// add
+// ============================================================================
+
+/// A partial batch is a failure: the caller asked for two packages and got one.
+#[test]
+fn test_add_partial_batch_fails() {
+    let url = serve_package("goodpkg", "20260101");
+    let project = Project::new("[project]\nname = \"t\"\n");
+
+    let json = json_after_exit(
+        &project,
+        &[
+            "add",
+            "goodpkg",
+            "missingpkg",
+            "--source",
+            &format!("net:{}", url),
+        ],
+        1,
+    );
+
+    assert_not_success(&json);
+    assert_eq!(json["summary"]["added"], 1);
+    assert_eq!(json["summary"]["failed"], 1);
+
+    // The package that did install is still recorded — progress is kept.
+    let config = std::fs::read_to_string(project.dir.path().join("stacy.toml")).unwrap();
+    assert!(config.contains("goodpkg"), "config: {config}");
+}
+
+// ============================================================================
+// update
+// ============================================================================
+
+/// A partial update is a failure, even though another package updated fine.
+#[test]
+fn test_update_partial_batch_fails() {
+    let url = serve_package("goodpkg", "20260101");
+    let project = Project::new("[project]\nname = \"t\"\n").with_lockfile(&format!(
+        r#"version = "1"
+
+[packages.goodpkg]
+version = "20200101"
+group = "production"
+
+[packages.goodpkg.source]
+type = "Net"
+url = "{url}"
+
+[packages.badpkg]
+version = "20200101"
+group = "production"
+
+[packages.badpkg.source]
+type = "Net"
+url = "{CLOSED_URL}"
+"#
+    ));
+
+    let json = json_after_exit(&project, &["update"], 1);
+    assert_not_success(&json);
+    assert_eq!(json["summary"]["updated"], 1);
+    assert_eq!(json["summary"]["failed"], 1);
+}
+
+/// `--dry-run` used to skip the version check entirely and always answer
+/// "up to date". It must really ask the source.
+#[test]
+fn test_update_dry_run_reports_a_real_update() {
+    let url = serve_package("goodpkg", "20260101");
+    let project = Project::new("[project]\nname = \"t\"\n").with_lockfile(&format!(
+        r#"version = "1"
+
+[packages.goodpkg]
+version = "20200101"
+group = "production"
+
+[packages.goodpkg.source]
+type = "Net"
+url = "{url}"
+"#
+    ));
+
+    let json = json_after_exit(&project, &["update", "--dry-run"], 0);
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["summary"]["updates_available"], 1);
+    assert_eq!(json["summary"]["updated"], 0);
+    assert_eq!(json["packages"][0]["new_version"], "20260101");
+
+    // A dry run installs nothing: the lockfile keeps the old version.
+    let lock = std::fs::read_to_string(project.dir.path().join("stacy.lock")).unwrap();
+    assert!(lock.contains("20200101"), "lockfile: {lock}");
+}
+
+/// A check that could not run is not an "up to date".
+#[test]
+fn test_update_dry_run_fails_when_a_check_fails() {
+    let project = Project::new("[project]\nname = \"t\"\n").with_lockfile(&format!(
+        r#"version = "1"
+
+[packages.badpkg]
+version = "20200101"
+group = "production"
+
+[packages.badpkg.source]
+type = "Net"
+url = "{CLOSED_URL}"
+"#
+    ));
+
+    let json = json_after_exit(&project, &["update", "--dry-run"], 1);
+    assert_not_success(&json);
+    assert_eq!(json["summary"]["failed"], 1);
+
+    project
+        .run(&["update", "--dry-run"])
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(predicate::str::contains("All packages are up to date").not());
+}
+
+// ============================================================================
+// deps
+// ============================================================================
+
+/// A cycle means the graph could not be resolved.
+#[test]
+fn test_deps_circular_fails() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(temp.path().join("a.do"), "do \"b.do\"").unwrap();
+    std::fs::write(temp.path().join("b.do"), "do \"a.do\"").unwrap();
+
+    let output = stacy()
+        .arg("deps")
+        .arg(temp.path().join("a.do"))
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_not_success(&json);
+    assert_eq!(json["summary"]["has_circular"], true);
+}
+
+/// A dependency that does not exist is a file error, like a missing script.
+#[test]
+fn test_deps_missing_dependency_fails() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(temp.path().join("main.do"), "do \"gone.do\"").unwrap();
+
+    let output = stacy()
+        .arg("deps")
+        .arg(temp.path().join("main.do"))
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_not_success(&json);
+    assert_eq!(json["summary"]["has_missing"], true);
+}
+
+/// The Stata surface branches on `$stacy_status`, so it must not say success.
+#[test]
+fn test_deps_missing_dependency_stata_status_is_error() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(temp.path().join("main.do"), "do \"gone.do\"").unwrap();
+
+    let output = stacy()
+        .arg("deps")
+        .arg(temp.path().join("main.do"))
+        .arg("--format")
+        .arg("stata")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("global stacy_status \"error\""),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn test_deps_clean_graph_still_succeeds() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(temp.path().join("main.do"), "do \"helper.do\"").unwrap();
+    std::fs::write(temp.path().join("helper.do"), "display 1").unwrap();
+
+    stacy()
+        .arg("deps")
+        .arg(temp.path().join("main.do"))
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"status\": \"success\""));
+}

--- a/tests/package_command_failures.rs
+++ b/tests/package_command_failures.rs
@@ -490,6 +490,62 @@ url = "{CLOSED_URL}"
         .stdout(predicate::str::contains("All packages are up to date").not());
 }
 
+/// A `local:` package is not fetched from anywhere, so `update` has nothing to
+/// do for it. Skipping it is not a failure — the command must still exit 0 when
+/// every other package updated.
+#[test]
+fn test_update_skips_local_package_without_failing() {
+    let url = serve_package("goodpkg", "20260101");
+    let project = Project::new("[project]\nname = \"t\"\n").with_lockfile(&format!(
+        r#"version = "1"
+
+[packages.goodpkg]
+version = "20200101"
+group = "production"
+
+[packages.goodpkg.source]
+type = "Net"
+url = "{url}"
+
+[packages.mylocal]
+version = "20200101"
+group = "production"
+
+[packages.mylocal.source]
+type = "Local"
+path = "./lib/mylocal/"
+"#
+    ));
+
+    let json = json_after_exit(&project, &["update"], 0);
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["summary"]["updated"], 1);
+    assert_eq!(json["summary"]["failed"], 0);
+    assert_eq!(json["summary"]["skipped"], 1);
+}
+
+/// The same holds for a dry run, and for a local package named on its own.
+#[test]
+fn test_update_local_package_alone_succeeds() {
+    let project = Project::new("[project]\nname = \"t\"\n").with_lockfile(
+        r#"version = "1"
+
+[packages.mylocal]
+version = "20200101"
+group = "production"
+
+[packages.mylocal.source]
+type = "Local"
+path = "./lib/mylocal/"
+"#,
+    );
+
+    let json = json_after_exit(&project, &["update", "mylocal", "--dry-run"], 0);
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["summary"]["failed"], 0);
+    assert_eq!(json["summary"]["skipped"], 1);
+}
+
 // ============================================================================
 // deps
 // ============================================================================
@@ -571,4 +627,77 @@ fn test_deps_clean_graph_still_succeeds() {
         .assert()
         .success()
         .stdout(predicate::str::contains("\"status\": \"success\""));
+}
+
+/// A path built from a macro (`do "$root/prep.do"`) only exists once Stata has
+/// run the script. stacy reads the script, it does not run it, so the path is
+/// unresolved — not missing. It must not fail the command.
+#[test]
+fn test_deps_macro_path_is_unresolved_not_missing() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join("main.do"),
+        "global root \"/data\"\nlocal sub \"steps\"\ndo \"$root/prep.do\"\ndo \"`sub'/clean.do\"\ndo \"helper.do\"\n",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join("helper.do"), "display 1").unwrap();
+
+    let output = stacy()
+        .arg("deps")
+        .arg(temp.path().join("main.do"))
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["summary"]["has_missing"], false);
+    assert_eq!(json["summary"]["missing_count"], 0);
+    assert_eq!(json["summary"]["unresolved_count"], 2);
+}
+
+/// A macro path is reported, but as a note, not an error.
+#[test]
+fn test_deps_macro_path_is_reported_in_human_output() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(temp.path().join("main.do"), "do \"$root/prep.do\"\n").unwrap();
+
+    stacy()
+        .arg("deps")
+        .arg(temp.path().join("main.do"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("$root/prep.do"))
+        .stderr(predicate::str::contains("Error").not());
+}
+
+/// A real missing file next to a macro path is still an error.
+#[test]
+fn test_deps_missing_file_still_fails_alongside_macro_path() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join("main.do"),
+        "do \"$root/prep.do\"\ndo \"gone.do\"\n",
+    )
+    .unwrap();
+
+    let output = stacy()
+        .arg("deps")
+        .arg(temp.path().join("main.do"))
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_not_success(&json);
+    assert_eq!(json["summary"]["missing_count"], 1);
 }


### PR DESCRIPTION
A resolve, install or version-check failure was treated as a warning: `install`, `lock`, `outdated`, `add`, `update` and `deps` exited 0, and some still reported `status: "success"` in `--format json`/`stata`, so scripts and CI could not see the failure.

Now a command whose work did not complete exits nonzero and reports a non-success status on every surface. Package failures exit 1; a missing file in `deps` exits 3, matching the existing missing-script code. `install` treats a package it could not install as an error rather than a skip (including under `--frozen`), `lock` reports packages it cannot resolve instead of silently writing nothing, `add` and `update` fail on a partial batch, and `update --dry-run` now actually queries the source rather than reporting everything as up to date.

New integration tests cover the exit code and the JSON status for each command; they use a loopback stub server and a closed port, so none of them need SSC or GitHub to be reachable.

Closes #94