### PR TITLE
fix: config, env and log-path correctness

### DIFF
--- a/docs/src/commands/run.md
+++ b/docs/src/commands/run.md
@@ -28,7 +28,9 @@ The batch log file is internal: removed on success, kept on failure with its
 path printed in the failure output. Inside a project, kept logs go to `[run]
 log_dir` from `stacy.toml` (`logs/` by default); outside one they stay next to
 the run. The same rule applies to the scripts run by `stacy task`, `stacy test`
-and `stacy bench`. Use `--log <path>` to keep the raw Stata log as a durable
+and `stacy bench`, and to every output format — `--format json` and `--format
+stata` report an empty log_file for a run that succeeded, because there is no
+log to point at. Use `--log <path>` to keep the raw Stata log as a durable
 artifact — it wins over `log_dir` and is written whether the run passed or
 failed (`--quiet --log out.log` for a silent file-only run).
 

--- a/docs/src/commands/run.md
+++ b/docs/src/commands/run.md
@@ -25,8 +25,12 @@ file path are displayed. Use `-v` to stream the raw log instead, or `-q` to
 suppress all output.
 
 The batch log file is internal: removed on success, kept on failure with its
-path printed in the failure output. Use `--log <path>` to keep the raw Stata
-log as a durable artifact (`--quiet --log out.log` for a silent file-only run).
+path printed in the failure output. Inside a project, kept logs go to `[run]
+log_dir` from `stacy.toml` (`logs/` by default); outside one they stay next to
+the run. The same rule applies to the scripts run by `stacy task`, `stacy test`
+and `stacy bench`. Use `--log <path>` to keep the raw Stata log as a durable
+artifact — it wins over `log_dir` and is written whether the run passed or
+failed (`--quiet --log out.log` for a silent file-only run).
 
 Multiple scripts can be run sequentially (default, fail-fast) or in parallel
 (`--parallel`). Parallel mode runs all scripts regardless of failures.

--- a/docs/src/configuration/project.md
+++ b/docs/src/configuration/project.md
@@ -61,10 +61,16 @@ Settings for [`stacy run`](../commands/run.md) command.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `log_dir` | string | `"logs"` | Directory for log files |
+| `log_dir` | string | `"logs"` | Directory for kept log files, relative to the project root |
 | `show_progress` | bool | `true` | Show progress during execution |
 | `progress_interval_seconds` | int | `10` | Progress update interval |
 | `max_log_size_mb` | int | `50` | Log size warning threshold |
+
+Batch logs are internal: a script that succeeds leaves none behind. A script that
+fails keeps its log, and `log_dir` is where it goes — for `stacy run` as well as
+the scripts run by `stacy task`, `stacy test` and `stacy bench`. The directory is
+created when the first log needs it. `stacy run --log <path>` overrides `log_dir`
+for that run.
 
 ### [paths]
 

--- a/docs/src/configuration/project.md
+++ b/docs/src/configuration/project.md
@@ -136,8 +136,10 @@ analyze = { script = "src/02_analyze.do", description = "Main estimates" }
 
 ### Unknown Keys Are Rejected
 
-Every key outside `[scripts]` (where the keys are your task names) must be one
-stacy knows. A key it does not know is an error, not a shrug:
+Task names under `[scripts]` are yours to pick. Every other key must be one stacy
+knows — including the keys inside a package table (`source`, `version`) and a task
+table (`script`, `args`, `parallel`, `description`). A key it does not know is an
+error, not a shrug:
 
 ```
 $ stacy lock
@@ -150,7 +152,9 @@ hint: declare these under [packages.dependencies]
 ```
 
 Dependencies declared under the wrong key used to be dropped without a word, and
-`stacy lock` then reported success on zero packages.
+`stacy lock` then reported success on zero packages. The same went for a typo
+inside a package table: `{ source = "ssc", verison = "1.0.0" }` parsed, lost the
+version pin, and resolved the latest release instead.
 
 ### Stata Binary
 

--- a/docs/src/configuration/project.md
+++ b/docs/src/configuration/project.md
@@ -134,6 +134,24 @@ analyze = { script = "src/02_analyze.do", description = "Main estimates" }
 
 ## Important Notes
 
+### Unknown Keys Are Rejected
+
+Every key outside `[scripts]` (where the keys are your task names) must be one
+stacy knows. A key it does not know is an error, not a shrug:
+
+```
+$ stacy lock
+Error: Failed to parse stacy.toml: TOML parse error at line 4, column 1
+  |
+4 | [dependencies]
+  | ^^^^^^^^^^^^^^
+unknown field `dependencies`, expected one of `project`, `run`, `paths`, `packages`, `scripts`
+hint: declare these under [packages.dependencies]
+```
+
+Dependencies declared under the wrong key used to be dropped without a word, and
+`stacy lock` then reported success on zero packages.
+
 ### Stata Binary
 
 stacy auto-detects Stata in common locations. If detection fails, configure manually:

--- a/docs/src/reference/how-it-works.md
+++ b/docs/src/reference/how-it-works.md
@@ -178,10 +178,11 @@ progress_interval_seconds = 30
 
 ### Structured Logging
 
-For automated pipelines, use `--format json`. Machine-readable formats imply quiet execution (no streaming); the JSON result's `log_file` field points to the kept Stata log:
+For automated pipelines, use `--format json`. Machine-readable formats imply quiet execution (no streaming). The batch log follows the same rule as in human mode — removed on success, kept on failure — so `log_file` names the kept log of a failed run and is empty for one that passed. Add `--log <path>` to keep the raw log either way:
 
 ```bash
 stacy run --format json analysis.do
+stacy run --format json --log run.log analysis.do
 ```
 
 ---

--- a/docs/src/reference/json-output.md
+++ b/docs/src/reference/json-output.md
@@ -23,7 +23,7 @@ stacy env --format json
   "script": "analysis.do",
   "duration_secs": 12.45,
   "exit_code": 0,
-  "log_file": "/path/to/wd/analysis_12345_1715000000123_0.log"
+  "log_file": ""
 }
 ```
 
@@ -53,7 +53,7 @@ stacy env --format json
 | `script` | string | Path to script that was run |
 | `duration_secs` | float | Execution time in seconds |
 | `exit_code` | int | stacy exit code (0-10) |
-| `log_file` | string | Absolute path to Stata log file. Each invocation gets a unique stem (`<script>_<pid>_<nanos>_<n>.log`) so concurrent runs from a shared cwd never collide. |
+| `log_file` | string | Absolute path to the kept Stata log, empty when the run succeeded (a successful run's log is removed). Each invocation gets a unique stem (`<script>_<pid>_<nanos>_<n>.log`) so concurrent runs from a shared cwd never collide. Pass `--log <path>` to keep the log of a passing run; `log_file` then reports that path. |
 | `errors` | array | Error details (only on failure) |
 | `errors[].type` | string | Error type (`StataCode`, `Syntax`, `File`) |
 | `errors[].r_code` | int | Stata r() code if applicable |

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -218,6 +218,8 @@ json = { type = "bool", description = "JSON output (internal)" }
 has_config = { type = "bool", json_path = "project.has_config", stata_type = "scalar", description = "stacy.toml exists (1=yes, 0=no)" }
 show_progress = { type = "bool", json_path = "settings.show_progress", stata_type = "scalar", description = "Progress shown (1=yes, 0=no)" }
 adopath_count = { type = "int", json_path = "adopath", stata_type = "scalar", array_handling = "count", description = "Number of adopath entries" }
+package_count = { type = "int", json_path = "project.package_count", stata_type = "scalar", description = "Locked packages present in the cache" }
+missing_package_count = { type = "int", json_path = "project.missing_package_count", stata_type = "scalar", description = "Locked packages absent from the cache" }
 
 # Locals
 stata_binary = { type = "path", json_path = "stata.binary", stata_type = "local", description = "Path to Stata binary" }

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -67,7 +67,9 @@ The batch log file is internal: removed on success, kept on failure with its
 path printed in the failure output. Inside a project, kept logs go to `[run]
 log_dir` from `stacy.toml` (`logs/` by default); outside one they stay next to
 the run. The same rule applies to the scripts run by `stacy task`, `stacy test`
-and `stacy bench`. Use `--log <path>` to keep the raw Stata log as a durable
+and `stacy bench`, and to every output format — `--format json` and `--format
+stata` report an empty log_file for a run that succeeded, because there is no
+log to point at. Use `--log <path>` to keep the raw Stata log as a durable
 artifact — it wins over `log_dir` and is written whether the run passed or
 failed (`--quiet --log out.log` for a silent file-only run).
 
@@ -108,7 +110,7 @@ error_count = { type = "int", json_path = "errors", stata_type = "scalar", array
 # Locals (string values)
 source = { type = "string", json_path = "source", stata_type = "local", description = "'file' or 'inline'" }
 script = { type = "path", json_path = "script", stata_type = "local", description = "Path to script" }
-log_file = { type = "path", json_path = "log_file", stata_type = "local", description = "Path to log file" }
+log_file = { type = "path", json_path = "log_file", stata_type = "local", description = "Path to the kept log file (empty when the run succeeded)" }
 
 [commands.run.exit_codes]
 0 = "Success"

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -64,8 +64,12 @@ file path are displayed. Use `-v` to stream the raw log instead, or `-q` to
 suppress all output.
 
 The batch log file is internal: removed on success, kept on failure with its
-path printed in the failure output. Use `--log <path>` to keep the raw Stata
-log as a durable artifact (`--quiet --log out.log` for a silent file-only run).
+path printed in the failure output. Inside a project, kept logs go to `[run]
+log_dir` from `stacy.toml` (`logs/` by default); outside one they stay next to
+the run. The same rule applies to the scripts run by `stacy task`, `stacy test`
+and `stacy bench`. Use `--log <path>` to keep the raw Stata log as a durable
+artifact — it wins over `log_dir` and is written whether the run passed or
+failed (`--quiet --log out.log` for a silent file-only run).
 
 Multiple scripts can be run sequentially (default, fail-fast) or in parallel
 (`--parallel`). Parallel mode runs all scripts regardless of failures.

--- a/src/cli/bench.rs
+++ b/src/cli/bench.rs
@@ -179,7 +179,9 @@ pub fn execute(args: &BenchArgs) -> Result<()> {
             if !result.success {
                 if format == OutputFormat::Human {
                     eprintln!("\nError: Script failed during warmup run {}", i + 1);
-                    eprintln!("Log: {}", log_file.display());
+                    if let Some(log) = &log_file {
+                        eprintln!("Log: {}", log.display());
+                    }
                 }
                 process::exit(result.exit_code);
             }
@@ -210,7 +212,9 @@ pub fn execute(args: &BenchArgs) -> Result<()> {
         if !result.success {
             if format == OutputFormat::Human {
                 eprintln!("\nError: Script failed on run {}", i + 1);
-                eprintln!("Log: {}", log_file.display());
+                if let Some(log) = &log_file {
+                    eprintln!("Log: {}", log.display());
+                }
             }
             process::exit(result.exit_code);
         }

--- a/src/cli/bench.rs
+++ b/src/cli/bench.rs
@@ -5,6 +5,7 @@
 use crate::cli::output_format::OutputFormat;
 use crate::cli::output_types::{BenchOutput, CommandOutput};
 use crate::error::Result;
+use crate::executor::log_policy::LogPolicy;
 use crate::executor::{verbosity::Verbosity, StataExecutor};
 use crate::project::Project;
 use clap::Args;
@@ -140,6 +141,10 @@ pub fn execute(args: &BenchArgs) -> Result<()> {
     let executor =
         StataExecutor::try_new(engine_ref, Verbosity::Quiet)?.with_local_ado_paths(local_ado_paths);
 
+    // Benchmarks run the script many times; their logs are internal. Removed on
+    // success, kept on failure so the run can be diagnosed (#98).
+    let policy = LogPolicy::for_project(project.as_ref());
+
     // Print header
     if !args.quiet && format == OutputFormat::Human {
         println!("Benchmarking: {}", args.script.display());
@@ -169,10 +174,12 @@ pub fn execute(args: &BenchArgs) -> Result<()> {
 
         for i in 0..warmup_count {
             let result = executor.run(&args.script, project_root)?;
+            let log_file = policy.finalize(&result.log_file, result.success);
 
             if !result.success {
                 if format == OutputFormat::Human {
                     eprintln!("\nError: Script failed during warmup run {}", i + 1);
+                    eprintln!("Log: {}", log_file.display());
                 }
                 process::exit(result.exit_code);
             }
@@ -198,10 +205,12 @@ pub fn execute(args: &BenchArgs) -> Result<()> {
 
     for i in 0..args.runs {
         let result = executor.run(&args.script, project_root)?;
+        let log_file = policy.finalize(&result.log_file, result.success);
 
         if !result.success {
             if format == OutputFormat::Human {
                 eprintln!("\nError: Script failed on run {}", i + 1);
+                eprintln!("Log: {}", log_file.display());
             }
             process::exit(result.exit_code);
         }

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -31,6 +31,9 @@ struct AdopathEntry {
     path: String,
     source: &'static str,  // "local", "package", or "builtin"
     label: Option<String>, // package name for package entries
+    /// For package entries: the package is present in the global cache.
+    /// Always true for local and builtin entries.
+    installed: bool,
 }
 
 /// Gathered environment information
@@ -44,7 +47,10 @@ struct EnvironmentInfo {
     log_dir: PathBuf,
     show_progress: bool,
     adopath: Vec<AdopathEntry>,
+    /// Locked packages found in the global cache.
     package_count: usize,
+    /// Locked packages absent from the global cache.
+    missing_package_count: usize,
 }
 
 pub fn execute(args: &EnvArgs) -> Result<()> {
@@ -56,6 +62,8 @@ pub fn execute(args: &EnvArgs) -> Result<()> {
         has_config: info.has_config,
         show_progress: info.show_progress,
         adopath_count: info.adopath.len(),
+        package_count: info.package_count,
+        missing_package_count: info.missing_package_count,
         cache_dir: info.cache_dir.clone(),
         log_dir: info.log_dir.clone(),
         project_root: info.project_root.clone(),
@@ -92,7 +100,7 @@ fn gather_environment_info() -> Result<EnvironmentInfo> {
 
     // Build adopath list from lockfile + local ado paths
     let local_ado_paths = resolve_local_ado_paths_for_env(&project);
-    let (adopath, package_count) =
+    let (adopath, package_count, missing_package_count) =
         build_adopath_from_lockfile(&project.as_ref().map(|p| p.root.clone()), &local_ado_paths);
 
     // Check for config file
@@ -110,6 +118,7 @@ fn gather_environment_info() -> Result<EnvironmentInfo> {
         show_progress,
         adopath,
         package_count,
+        missing_package_count,
     })
 }
 
@@ -145,12 +154,19 @@ fn resolve_local_ado_paths_for_env(project: &Option<Project>) -> Vec<PathBuf> {
     }
 }
 
+/// Build the adopath list and count locked packages by cache status.
+///
+/// Returns `(entries, installed, missing)`. A lockfile entry is only counted as
+/// installed when its directory is actually present in the global cache —
+/// `package_path` merely constructs a path, so a cold cache used to report every
+/// declared package as installed (#99).
 fn build_adopath_from_lockfile(
     project_root: &Option<PathBuf>,
     local_ado_paths: &[PathBuf],
-) -> (Vec<AdopathEntry>, usize) {
+) -> (Vec<AdopathEntry>, usize, usize) {
     let mut entries = Vec::new();
     let mut package_count = 0;
+    let mut missing_package_count = 0;
 
     // Add local ado paths first (in declared order)
     for local_path in local_ado_paths {
@@ -158,6 +174,7 @@ fn build_adopath_from_lockfile(
             path: local_path.display().to_string(),
             source: "local",
             label: None,
+            installed: true,
         });
     }
 
@@ -172,12 +189,19 @@ fn build_adopath_from_lockfile(
 
                 for (name, entry) in sorted_packages {
                     if let Ok(pkg_path) = global_cache::package_path(name, &entry.version) {
+                        let installed =
+                            global_cache::is_cached(name, &entry.version).unwrap_or(false);
+                        if installed {
+                            package_count += 1;
+                        } else {
+                            missing_package_count += 1;
+                        }
                         entries.push(AdopathEntry {
                             path: pkg_path.display().to_string(),
                             source: "package",
                             label: Some(name.clone()),
+                            installed,
                         });
-                        package_count += 1;
                     }
                 }
             }
@@ -193,9 +217,10 @@ fn build_adopath_from_lockfile(
         path: "BASE".to_string(),
         source: "builtin",
         label: None,
+        installed: true,
     });
 
-    (entries, package_count)
+    (entries, package_count, missing_package_count)
 }
 
 fn print_human_output(info: &EnvironmentInfo) {
@@ -223,7 +248,14 @@ fn print_human_output(info: &EnvironmentInfo) {
         } else {
             println!("  Config: stacy.toml (not found, using defaults)");
         }
-        println!("  Packages: {} installed", info.package_count);
+        if info.missing_package_count > 0 {
+            println!(
+                "  Packages: {} installed, {} missing (run 'stacy install')",
+                info.package_count, info.missing_package_count
+            );
+        } else {
+            println!("  Packages: {} installed", info.package_count);
+        }
     } else {
         println!("  Root: (not in a project)");
         println!("  Tip: Run 'stacy init' to create a project");
@@ -241,6 +273,9 @@ fn print_human_output(info: &EnvironmentInfo) {
     for (i, entry) in info.adopath.iter().enumerate() {
         let label = match (entry.source, &entry.label) {
             ("local", _) => format!("{} (local)", entry.path),
+            ("package", Some(name)) if !entry.installed => {
+                format!("{} ({}, not installed)", entry.path, name)
+            }
             ("package", Some(name)) => format!("{} ({})", entry.path, name),
             _ => entry.path.clone(),
         };
@@ -269,6 +304,7 @@ fn print_json_output(info: &EnvironmentInfo) {
             "config_file": info.config_file.as_ref().map(|p| p.display().to_string()),
             "has_config": info.has_config,
             "package_count": info.package_count,
+            "missing_package_count": info.missing_package_count,
         },
         "paths": {
             "cache": info.cache_dir.display().to_string(),
@@ -283,6 +319,9 @@ fn print_json_output(info: &EnvironmentInfo) {
             obj.insert("source".to_string(), json!(e.source));
             if let Some(ref label) = e.label {
                 obj.insert("label".to_string(), json!(label));
+            }
+            if e.source == "package" {
+                obj.insert("installed".to_string(), json!(e.installed));
             }
             serde_json::Value::Object(obj)
         }).collect::<Vec<_>>(),

--- a/src/cli/output_types.rs
+++ b/src/cli/output_types.rs
@@ -412,6 +412,10 @@ pub struct EnvOutput {
     pub has_config: bool,
     /// Progress shown (1=yes, 0=no)
     pub show_progress: bool,
+    /// Locked packages present in the global cache
+    pub package_count: usize,
+    /// Locked packages absent from the global cache
+    pub missing_package_count: usize,
     /// Global package cache directory
     pub cache_dir: PathBuf,
     /// Project log directory
@@ -440,6 +444,14 @@ impl CommandOutput for EnvOutput {
         lines.push(format_stata_scalar_usize(
             "adopath_count",
             self.adopath_count,
+        ));
+        lines.push(format_stata_scalar_usize(
+            "package_count",
+            self.package_count,
+        ));
+        lines.push(format_stata_scalar_usize(
+            "missing_package_count",
+            self.missing_package_count,
         ));
         lines.push(format_stata_local(
             "cache_dir",
@@ -1191,6 +1203,8 @@ mod tests {
             has_config: true,
             show_progress: true,
             adopath_count: 4,
+            package_count: 2,
+            missing_package_count: 1,
             cache_dir: PathBuf::from("/home/user/.cache/stacy/packages"),
             log_dir: PathBuf::from("logs"),
             project_root: Some(PathBuf::from("/project")),
@@ -1200,6 +1214,8 @@ mod tests {
 
         let stata = output.to_stata();
         assert!(stata.contains("scalar stacy_has_config = 1"));
+        assert!(stata.contains("scalar stacy_package_count = 2"));
+        assert!(stata.contains("scalar stacy_missing_package_count = 1"));
         assert!(stata.contains("global stacy_cache_dir"));
         assert!(stata.contains("global stacy_project_root \"/project\""));
         assert!(stata.contains("global stacy_stata_binary \"/usr/local/bin/stata\""));
@@ -1211,6 +1227,8 @@ mod tests {
             has_config: false,
             show_progress: true,
             adopath_count: 4,
+            package_count: 0,
+            missing_package_count: 0,
             cache_dir: PathBuf::from("/home/user/.cache/stacy/packages"),
             log_dir: PathBuf::from("logs"),
             project_root: None,
@@ -1979,6 +1997,8 @@ mod tests {
                     has_config: true,
                     show_progress: false,
                     adopath_count: 3,
+                    package_count: 1,
+                    missing_package_count: 0,
                     cache_dir: PathBuf::from("/tmp/cache"),
                     log_dir: PathBuf::from("logs"),
                     project_root: Some(PathBuf::from("/project")),

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -374,16 +374,10 @@ fn resolve_working_dir(script: &Path, args: &RunArgs) -> Result<(PathBuf, Option
 /// Build the log-retention policy for a run.
 ///
 /// `--log <path>` makes the log a durable artifact at that path. Otherwise it is
-/// internal: removed on success, kept on failure — and kept for machine-readable
-/// formats, whose output reports the path. Kept logs go to `[run] log_dir`.
-fn log_policy(
-    project: &Option<crate::project::Project>,
-    format: OutputFormat,
-    dest: Option<PathBuf>,
-) -> LogPolicy {
-    LogPolicy::for_project(project.as_ref())
-        .keep_on_success(format.is_machine_readable())
-        .with_dest(dest)
+/// internal: removed on success, kept on failure, whatever the output format.
+/// Kept logs go to `[run] log_dir`.
+fn log_policy(project: &Option<crate::project::Project>, dest: Option<PathBuf>) -> LogPolicy {
+    LogPolicy::for_project(project.as_ref()).with_dest(dest)
 }
 
 /// Warn if semicolons detected in inline code (Stata uses newlines)
@@ -473,9 +467,10 @@ fn execute_inline(args: &RunArgs) -> Result<()> {
     let mut result = executor.run(&script_path, project_root)?;
     // The log is owned by the retention policy, not by TempScript: an inline run
     // that failed keeps its log (in log_dir when configured) so the path printed
-    // below actually resolves.
-    result.log_file =
-        log_policy(&project, format, args.log.clone()).finalize(&result.log_file, result.success);
+    // below actually resolves. A successful run has no log, and reports none.
+    result.log_file = log_policy(&project, args.log.clone())
+        .finalize(&result.log_file, result.success)
+        .unwrap_or_default();
 
     if let Some(ref mut m) = metrics {
         m.end_phase("execution");
@@ -766,10 +761,10 @@ fn execute_single(script_path: &Path, args: &RunArgs) -> Result<()> {
     }
 
     // Log retention: --log moves it aside; otherwise internal — removed on
-    // success in human mode (output was already streamed), kept on failure
-    // and for machine formats whose output references it.
-    result.log_file =
-        log_policy(&project, format, args.log.clone()).finalize(&result.log_file, result.success);
+    // success, kept on failure so the path printed below resolves.
+    result.log_file = log_policy(&project, args.log.clone())
+        .finalize(&result.log_file, result.success)
+        .unwrap_or_default();
 
     // Build output
     let output = RunOutput {
@@ -942,7 +937,7 @@ fn execute_sequential(args: &RunArgs) -> Result<()> {
         .with_local_ado_paths(local_ado_paths)
         .with_timeout(args.timeout.map(Duration::from_secs));
     let project_root = project.as_ref().map(|p| p.root.as_path());
-    let policy = log_policy(&project, format, None);
+    let policy = log_policy(&project, None);
 
     let start = Instant::now();
     let mut results: Vec<ScriptRunResult> = Vec::new();
@@ -983,9 +978,10 @@ fn execute_sequential(args: &RunArgs) -> Result<()> {
             executor.run(script, project_root)?
         };
 
-        // Log retention: internal file — removed on success in human mode
-        // (output was already streamed), kept on failure / machine formats.
-        let final_log = policy.finalize(&result.log_file, result.success);
+        // Log retention: internal file — removed on success, kept on failure.
+        let final_log = policy
+            .finalize(&result.log_file, result.success)
+            .unwrap_or_default();
 
         let script_result = ScriptRunResult {
             script: script.clone(),
@@ -1101,7 +1097,7 @@ fn execute_parallel(args: &RunArgs) -> Result<()> {
         .with_local_ado_paths(local_ado_paths)
         .with_timeout(args.timeout.map(Duration::from_secs));
     let project_root = project.as_ref().map(|p| p.root.as_path());
-    let policy = log_policy(&project, format, None);
+    let policy = log_policy(&project, None);
 
     if !args.quiet && format == OutputFormat::Human {
         eprintln!(
@@ -1184,9 +1180,11 @@ fn execute_parallel(args: &RunArgs) -> Result<()> {
                 }
             }
 
-            // Log retention: removed on success in human mode (output shown
-            // above), kept on failure / machine formats.
-            result.log_file = policy.finalize(&result.log_file, result.success);
+            // Log retention: removed on success (the output was shown above),
+            // kept on failure.
+            result.log_file = policy
+                .finalize(&result.log_file, result.success)
+                .unwrap_or_default();
 
             script_results.push(result);
         }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -6,6 +6,7 @@ use crate::cli::output_types::{
     CacheHitOutput, CommandOutput, ParallelRunOutput, RunOutput, ScriptRunResult,
 };
 use crate::error::{Error, Result};
+use crate::executor::log_policy::LogPolicy;
 use crate::utils::temp::TempScript;
 use clap::Args;
 use std::io::{IsTerminal, Read};
@@ -248,7 +249,8 @@ pub struct RunArgs {
     pub timeout: Option<u64>,
 
     /// Write the raw Stata log to this path (in addition to normal output).
-    /// Without this flag the log is internal: removed on success, kept on failure.
+    /// Without this flag the log is internal: removed on success, kept on
+    /// failure in the project's log_dir ([run] log_dir in stacy.toml).
     #[arg(long, value_name = "PATH", conflicts_with = "parallel")]
     pub log: Option<PathBuf>,
 }
@@ -369,37 +371,19 @@ fn resolve_working_dir(script: &Path, args: &RunArgs) -> Result<(PathBuf, Option
     }
 }
 
-/// Apply the log-retention policy after a run.
+/// Build the log-retention policy for a run.
 ///
-/// `--log <path>` moves the raw log there (the durable artifact) and returns
-/// that path. Otherwise the log is an internal file: removed when `delete`
-/// is set (success in human mode, where output was already streamed), kept
-/// for inspection when not (failures, and machine-readable formats whose
-/// output references it).
-fn finalize_log(log_file: &Path, delete: bool, dest: Option<&Path>) -> PathBuf {
-    match dest {
-        Some(dest) => {
-            // Rename, falling back to copy+remove across filesystems
-            let moved = std::fs::rename(log_file, dest).or_else(|_| {
-                std::fs::copy(log_file, dest).map(|_| {
-                    let _ = std::fs::remove_file(log_file);
-                })
-            });
-            match moved {
-                Ok(()) => dest.to_path_buf(),
-                Err(e) => {
-                    eprintln!("Warning: could not write log to {}: {}", dest.display(), e);
-                    log_file.to_path_buf()
-                }
-            }
-        }
-        None => {
-            if delete {
-                let _ = std::fs::remove_file(log_file);
-            }
-            log_file.to_path_buf()
-        }
-    }
+/// `--log <path>` makes the log a durable artifact at that path. Otherwise it is
+/// internal: removed on success, kept on failure — and kept for machine-readable
+/// formats, whose output reports the path. Kept logs go to `[run] log_dir`.
+fn log_policy(
+    project: &Option<crate::project::Project>,
+    format: OutputFormat,
+    dest: Option<PathBuf>,
+) -> LogPolicy {
+    LogPolicy::for_project(project.as_ref())
+        .keep_on_success(format.is_machine_readable())
+        .with_dest(dest)
 }
 
 /// Warn if semicolons detected in inline code (Stata uses newlines)
@@ -458,7 +442,7 @@ fn execute_inline(args: &RunArgs) -> Result<()> {
 
     // Create temp file for inline code
     let cwd = std::env::current_dir()?;
-    let mut temp_script = TempScript::new(&code, &cwd)?;
+    let temp_script = TempScript::new(&code, &cwd)?;
     let script_path = temp_script.path().to_path_buf();
 
     // Create executor
@@ -487,12 +471,11 @@ fn execute_inline(args: &RunArgs) -> Result<()> {
 
     // Run Stata
     let mut result = executor.run(&script_path, project_root)?;
-    // The wrapper-derived log path doesn't match TempScript's expected
-    // `script.with_extension("log")`. Hand the real path to TempScript so
-    // its Drop cleans up the inline-run log (preserves pre-#20 behavior).
-    temp_script.set_actual_log(result.log_file.clone());
-    // --log moves it out first; TempScript's best-effort Drop then no-ops.
-    result.log_file = finalize_log(&result.log_file, false, args.log.as_deref());
+    // The log is owned by the retention policy, not by TempScript: an inline run
+    // that failed keeps its log (in log_dir when configured) so the path printed
+    // below actually resolves.
+    result.log_file =
+        log_policy(&project, format, args.log.clone()).finalize(&result.log_file, result.success);
 
     if let Some(ref mut m) = metrics {
         m.end_phase("execution");
@@ -762,11 +745,6 @@ fn execute_single(script_path: &Path, args: &RunArgs) -> Result<()> {
     } else {
         executor.run(effective_script, project_root)?
     };
-    // Tell the trace TempScript where the real log lives so Drop cleans it up
-    // (the wrapper stem doesn't match TempScript's `script.with_extension("log")`).
-    if let Some(ref mut ts) = _trace_temp_script {
-        ts.set_actual_log(result.log_file.clone());
-    }
 
     if let Some(ref mut m) = metrics {
         m.end_phase("execution");
@@ -790,11 +768,8 @@ fn execute_single(script_path: &Path, args: &RunArgs) -> Result<()> {
     // Log retention: --log moves it aside; otherwise internal — removed on
     // success in human mode (output was already streamed), kept on failure
     // and for machine formats whose output references it.
-    result.log_file = finalize_log(
-        &result.log_file,
-        result.success && !format.is_machine_readable(),
-        args.log.as_deref(),
-    );
+    result.log_file =
+        log_policy(&project, format, args.log.clone()).finalize(&result.log_file, result.success);
 
     // Build output
     let output = RunOutput {
@@ -967,6 +942,7 @@ fn execute_sequential(args: &RunArgs) -> Result<()> {
         .with_local_ado_paths(local_ado_paths)
         .with_timeout(args.timeout.map(Duration::from_secs));
     let project_root = project.as_ref().map(|p| p.root.as_path());
+    let policy = log_policy(&project, format, None);
 
     let start = Instant::now();
     let mut results: Vec<ScriptRunResult> = Vec::new();
@@ -1006,19 +982,10 @@ fn execute_sequential(args: &RunArgs) -> Result<()> {
         } else {
             executor.run(script, project_root)?
         };
-        // Hand the wrapper-derived log path to the trace TempScript so Drop
-        // cleans it up (see #20 — the stem no longer matches script.with_extension).
-        if let Some(ref mut ts) = _trace_temp_script {
-            ts.set_actual_log(result.log_file.clone());
-        }
 
         // Log retention: internal file — removed on success in human mode
         // (output was already streamed), kept on failure / machine formats.
-        let final_log = finalize_log(
-            &result.log_file,
-            result.success && !format.is_machine_readable(),
-            None,
-        );
+        let final_log = policy.finalize(&result.log_file, result.success);
 
         let script_result = ScriptRunResult {
             script: script.clone(),
@@ -1134,6 +1101,7 @@ fn execute_parallel(args: &RunArgs) -> Result<()> {
         .with_local_ado_paths(local_ado_paths)
         .with_timeout(args.timeout.map(Duration::from_secs));
     let project_root = project.as_ref().map(|p| p.root.as_path());
+    let policy = log_policy(&project, format, None);
 
     if !args.quiet && format == OutputFormat::Human {
         eprintln!(
@@ -1218,11 +1186,7 @@ fn execute_parallel(args: &RunArgs) -> Result<()> {
 
             // Log retention: removed on success in human mode (output shown
             // above), kept on failure / machine formats.
-            result.log_file = finalize_log(
-                &result.log_file,
-                result.success && !format.is_machine_readable(),
-                None,
-            );
+            result.log_file = policy.finalize(&result.log_file, result.success);
 
             script_results.push(result);
         }

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -7,6 +7,7 @@ use crate::cli::output_types::{
     CommandOutput, ScriptResultOutput, TaskInfo, TaskListOutput, TaskOutput,
 };
 use crate::error::{Error, Result};
+use crate::executor::log_policy::LogPolicy;
 use crate::executor::StataExecutor;
 use crate::packages::lockfile::{load_lockfile, verify_lockfile_sync};
 use crate::project::config::TaskDef;
@@ -173,8 +174,13 @@ pub fn execute(args: &TaskArgs) -> Result<()> {
     let executor = StataExecutor::try_new(None, resolve_verbosity(false, 0, format))?
         .with_local_ado_paths(project.resolve_local_ado_paths());
 
-    // Create task executor
-    let task_executor = TaskExecutor::new(&graph, &executor, &project.root).with_args(task_args);
+    // Create task executor. Each script's log follows the same retention rule as
+    // `stacy run`: removed on success, kept (in `[run] log_dir`) on failure (#98).
+    let policy =
+        LogPolicy::for_project(Some(&project)).keep_on_success(format.is_machine_readable());
+    let task_executor = TaskExecutor::new(&graph, &executor, &project.root)
+        .with_args(task_args)
+        .with_log_policy(policy);
 
     // Run the task
     let result = task_executor.execute(task_name)?;

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -176,11 +176,9 @@ pub fn execute(args: &TaskArgs) -> Result<()> {
 
     // Create task executor. Each script's log follows the same retention rule as
     // `stacy run`: removed on success, kept (in `[run] log_dir`) on failure (#98).
-    let policy =
-        LogPolicy::for_project(Some(&project)).keep_on_success(format.is_machine_readable());
     let task_executor = TaskExecutor::new(&graph, &executor, &project.root)
         .with_args(task_args)
-        .with_log_policy(policy);
+        .with_log_policy(LogPolicy::for_project(Some(&project)));
 
     // Run the task
     let result = task_executor.execute(task_name)?;

--- a/src/cli/test.rs
+++ b/src/cli/test.rs
@@ -8,6 +8,7 @@ use crate::cli::output_types::{
 };
 use crate::cli::test_output;
 use crate::error::{Error, Result};
+use crate::executor::log_policy::LogPolicy;
 use crate::executor::StataExecutor;
 use crate::project::Project;
 use crate::test::discovery::{discover_tests, find_test};
@@ -111,10 +112,21 @@ pub fn execute(args: &TestArgs) -> Result<()> {
         .map(|p| p.root.clone())
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
 
+    // Log retention (#98): a passing test's log is internal, a failing test's
+    // log is kept — in `[run] log_dir` when the project sets one.
+    let policy = LogPolicy::for_project(project.as_ref());
+
     // Handle specific test
     if let Some(ref test_name) = args.test {
         if let Some(test) = find_test(&project_root, test_name)? {
-            return run_single_test(args, &project_root, &test, &local_ado_paths, working_dir);
+            return run_single_test(
+                args,
+                &project_root,
+                &test,
+                &local_ado_paths,
+                working_dir,
+                policy,
+            );
         } else {
             let msg = format!("Test '{}' not found", test_name);
             if format.is_machine_readable() {
@@ -175,7 +187,14 @@ pub fn execute(args: &TestArgs) -> Result<()> {
     }
 
     // Run tests
-    run_tests(args, &project_root, &tests, &local_ado_paths, working_dir)
+    run_tests(
+        args,
+        &project_root,
+        &tests,
+        &local_ado_paths,
+        working_dir,
+        policy,
+    )
 }
 
 fn run_single_test(
@@ -184,6 +203,7 @@ fn run_single_test(
     test: &crate::test::discovery::TestFile,
     local_ado_paths: &[std::path::PathBuf],
     working_dir: TestWorkingDir,
+    log_policy: LogPolicy,
 ) -> Result<()> {
     let format = args.format;
 
@@ -193,7 +213,9 @@ fn run_single_test(
         .with_local_ado_paths(local_ado_paths.to_vec());
 
     // Create test runner
-    let runner = TestRunner::new(&executor, project_root).with_working_dir(working_dir);
+    let runner = TestRunner::new(&executor, project_root)
+        .with_working_dir(working_dir)
+        .with_log_policy(log_policy);
 
     // Run the test
     if !args.quiet && format == OutputFormat::Human {
@@ -240,6 +262,7 @@ fn run_tests(
     tests: &[crate::test::discovery::TestFile],
     local_ado_paths: &[std::path::PathBuf],
     working_dir: TestWorkingDir,
+    log_policy: LogPolicy,
 ) -> Result<()> {
     let format = args.format;
 
@@ -251,7 +274,8 @@ fn run_tests(
     // Create test runner
     let runner = TestRunner::new(&executor, project_root)
         .with_parallel(args.parallel)
-        .with_working_dir(working_dir);
+        .with_working_dir(working_dir)
+        .with_log_policy(log_policy);
 
     // Print header
     if !args.quiet && format == OutputFormat::Human {

--- a/src/executor/log_policy.rs
+++ b/src/executor/log_policy.rs
@@ -7,7 +7,14 @@
 //! - `--log FILE` — the log is a durable artifact: move it to FILE, keep it
 //!   whether the run passed or failed.
 //! - otherwise the log is internal: removed when the run succeeded, kept when it
-//!   failed (or when a machine-readable format reported its path).
+//!   failed.
+//!
+//! The rule does not depend on the output format. `--format json` and
+//! `--format stata` used to keep the log of a successful run so that the
+//! `log_file` they report would resolve; since the in-Stata wrappers always run
+//! `--format stata`, that left one log per successful `stacy_run` behind for
+//! good. They now report no log when there is none, and callers that want the
+//! raw log of a passing run ask for it with `--log`.
 //!
 //! Kept logs land in `[run] log_dir` from `stacy.toml` when the run happened
 //! inside a project — without that they piled up in the working directory (#98).
@@ -20,9 +27,6 @@ use std::path::{Path, PathBuf};
 pub struct LogPolicy {
     /// Directory kept logs are moved into. `None` leaves them in place.
     keep_dir: Option<PathBuf>,
-    /// Keep the log even when the run succeeded (machine-readable output
-    /// reports the path, so the file has to exist).
-    keep_on_success: bool,
     /// Explicit destination from `--log`. Wins over everything else.
     dest: Option<PathBuf>,
 }
@@ -42,12 +46,6 @@ impl LogPolicy {
         }
     }
 
-    /// Keep the log even when the run succeeds.
-    pub fn keep_on_success(mut self, keep: bool) -> Self {
-        self.keep_on_success = keep;
-        self
-    }
-
     /// Write the log to this exact path (`--log FILE`), pass or fail.
     pub fn with_dest(mut self, dest: Option<PathBuf>) -> Self {
         self.dest = dest;
@@ -59,18 +57,19 @@ impl LogPolicy {
         self.keep_dir.as_deref()
     }
 
-    /// Apply the policy to `log` and return the path it now lives at.
+    /// Apply the policy to `log` and return the path it now lives at, or `None`
+    /// when the log was removed and there is nothing left to point at.
     ///
     /// Call this only after everything that reads the log (streaming, error
     /// context, printed excerpts) is done.
-    pub fn finalize(&self, log: &Path, success: bool) -> PathBuf {
+    pub fn finalize(&self, log: &Path, success: bool) -> Option<PathBuf> {
         if let Some(dest) = &self.dest {
-            return move_log(log, dest);
+            return Some(move_log(log, dest));
         }
 
-        if success && !self.keep_on_success {
+        if success {
             let _ = std::fs::remove_file(log);
-            return log.to_path_buf();
+            return None;
         }
 
         match (&self.keep_dir, log.file_name()) {
@@ -81,11 +80,11 @@ impl LogPolicy {
                         dir.display(),
                         e
                     );
-                    return log.to_path_buf();
+                    return Some(log.to_path_buf());
                 }
-                move_log(log, &dir.join(name))
+                Some(move_log(log, &dir.join(name)))
             }
-            _ => log.to_path_buf(),
+            _ => Some(log.to_path_buf()),
         }
     }
 }
@@ -137,8 +136,9 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let log = write_log(temp.path());
 
-        LogPolicy::new().finalize(&log, true);
+        let final_path = LogPolicy::new().finalize(&log, true);
 
+        assert_eq!(final_path, None, "a removed log has no path to report");
         assert!(!log.exists(), "successful run should not keep its log");
     }
 
@@ -149,7 +149,7 @@ mod tests {
 
         let final_path = LogPolicy::new().finalize(&log, false);
 
-        assert_eq!(final_path, log);
+        assert_eq!(final_path, Some(log.clone()));
         assert!(log.exists(), "failed run must keep its log");
     }
 
@@ -163,7 +163,7 @@ mod tests {
             keep_dir: Some(log_dir.clone()),
             ..LogPolicy::new()
         };
-        let final_path = policy.finalize(&log, false);
+        let final_path = policy.finalize(&log, false).expect("failure keeps the log");
 
         assert_eq!(final_path, log_dir.join("analysis_1_2_0.log"));
         assert!(final_path.exists(), "kept log should be in log_dir");
@@ -181,30 +181,13 @@ mod tests {
             keep_dir: Some(log_dir.clone()),
             ..LogPolicy::new()
         };
-        policy.finalize(&log, true);
+        assert_eq!(policy.finalize(&log, true), None);
 
         assert!(!log.exists());
         assert!(
             !log_dir.join("analysis_1_2_0.log").exists(),
             "a successful run should not populate log_dir"
         );
-    }
-
-    #[test]
-    fn test_keep_on_success_moves_log_into_log_dir() {
-        let temp = TempDir::new().unwrap();
-        let log = write_log(temp.path());
-        let log_dir = temp.path().join("logs");
-
-        let policy = LogPolicy {
-            keep_dir: Some(log_dir.clone()),
-            ..LogPolicy::new()
-        }
-        .keep_on_success(true);
-        let final_path = policy.finalize(&log, true);
-
-        assert_eq!(final_path, log_dir.join("analysis_1_2_0.log"));
-        assert!(final_path.exists());
     }
 
     #[test]
@@ -221,7 +204,7 @@ mod tests {
         .with_dest(Some(dest.clone()));
         let final_path = policy.finalize(&log, true);
 
-        assert_eq!(final_path, dest);
+        assert_eq!(final_path, Some(dest.clone()));
         assert!(dest.exists(), "--log destination must be written");
         assert!(!log.exists());
         assert!(!log_dir.exists(), "--log must not populate log_dir");
@@ -236,7 +219,7 @@ mod tests {
         let policy = LogPolicy::new().with_dest(Some(dest.clone()));
         let final_path = policy.finalize(&log, false);
 
-        assert_eq!(final_path, dest);
+        assert_eq!(final_path, Some(dest.clone()));
         assert_eq!(fs::read_to_string(&dest).unwrap(), "log body\n");
     }
 }

--- a/src/executor/log_policy.rs
+++ b/src/executor/log_policy.rs
@@ -1,0 +1,242 @@
+//! Retention policy for the per-invocation Stata log.
+//!
+//! Stata's batch mode writes `<script_stem>.log` into the process working
+//! directory and offers no flag to redirect it (see `run_paths`). So the log is
+//! always born next to the run, and stacy decides afterwards what happens to it:
+//!
+//! - `--log FILE` — the log is a durable artifact: move it to FILE, keep it
+//!   whether the run passed or failed.
+//! - otherwise the log is internal: removed when the run succeeded, kept when it
+//!   failed (or when a machine-readable format reported its path).
+//!
+//! Kept logs land in `[run] log_dir` from `stacy.toml` when the run happened
+//! inside a project — without that they piled up in the working directory (#98).
+
+use crate::project::Project;
+use std::path::{Path, PathBuf};
+
+/// What to do with a log file once the run is over.
+#[derive(Debug, Clone, Default)]
+pub struct LogPolicy {
+    /// Directory kept logs are moved into. `None` leaves them in place.
+    keep_dir: Option<PathBuf>,
+    /// Keep the log even when the run succeeded (machine-readable output
+    /// reports the path, so the file has to exist).
+    keep_on_success: bool,
+    /// Explicit destination from `--log`. Wins over everything else.
+    dest: Option<PathBuf>,
+}
+
+impl LogPolicy {
+    /// Internal log: removed on success, kept on failure, in the working dir.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resolve `[run] log_dir` against the project root. Outside a project the
+    /// log stays where Stata wrote it.
+    pub fn for_project(project: Option<&Project>) -> Self {
+        Self {
+            keep_dir: project.and_then(log_dir_for),
+            ..Self::default()
+        }
+    }
+
+    /// Keep the log even when the run succeeds.
+    pub fn keep_on_success(mut self, keep: bool) -> Self {
+        self.keep_on_success = keep;
+        self
+    }
+
+    /// Write the log to this exact path (`--log FILE`), pass or fail.
+    pub fn with_dest(mut self, dest: Option<PathBuf>) -> Self {
+        self.dest = dest;
+        self
+    }
+
+    /// Directory kept logs are moved into, if any.
+    pub fn keep_dir(&self) -> Option<&Path> {
+        self.keep_dir.as_deref()
+    }
+
+    /// Apply the policy to `log` and return the path it now lives at.
+    ///
+    /// Call this only after everything that reads the log (streaming, error
+    /// context, printed excerpts) is done.
+    pub fn finalize(&self, log: &Path, success: bool) -> PathBuf {
+        if let Some(dest) = &self.dest {
+            return move_log(log, dest);
+        }
+
+        if success && !self.keep_on_success {
+            let _ = std::fs::remove_file(log);
+            return log.to_path_buf();
+        }
+
+        match (&self.keep_dir, log.file_name()) {
+            (Some(dir), Some(name)) => {
+                if let Err(e) = std::fs::create_dir_all(dir) {
+                    eprintln!(
+                        "Warning: could not create log directory {}: {}",
+                        dir.display(),
+                        e
+                    );
+                    return log.to_path_buf();
+                }
+                move_log(log, &dir.join(name))
+            }
+            _ => log.to_path_buf(),
+        }
+    }
+}
+
+/// Absolute `[run] log_dir` for a project, if the log file has somewhere to go.
+fn log_dir_for(project: &Project) -> Option<PathBuf> {
+    let config = project.config.as_ref()?;
+    let dir = &config.run.log_dir;
+    if dir.as_os_str().is_empty() {
+        return None;
+    }
+    Some(project.root.join(dir))
+}
+
+/// Move `log` to `dest`, falling back to copy+remove across filesystems.
+/// On failure the log is left where it is and its original path is returned.
+fn move_log(log: &Path, dest: &Path) -> PathBuf {
+    if log == dest {
+        return dest.to_path_buf();
+    }
+    let moved = std::fs::rename(log, dest).or_else(|_| {
+        std::fs::copy(log, dest).map(|_| {
+            let _ = std::fs::remove_file(log);
+        })
+    });
+    match moved {
+        Ok(()) => dest.to_path_buf(),
+        Err(e) => {
+            eprintln!("Warning: could not write log to {}: {}", dest.display(), e);
+            log.to_path_buf()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_log(dir: &Path) -> PathBuf {
+        let log = dir.join("analysis_1_2_0.log");
+        fs::write(&log, "log body\n").unwrap();
+        log
+    }
+
+    #[test]
+    fn test_success_removes_internal_log() {
+        let temp = TempDir::new().unwrap();
+        let log = write_log(temp.path());
+
+        LogPolicy::new().finalize(&log, true);
+
+        assert!(!log.exists(), "successful run should not keep its log");
+    }
+
+    #[test]
+    fn test_failure_keeps_log_in_place_without_log_dir() {
+        let temp = TempDir::new().unwrap();
+        let log = write_log(temp.path());
+
+        let final_path = LogPolicy::new().finalize(&log, false);
+
+        assert_eq!(final_path, log);
+        assert!(log.exists(), "failed run must keep its log");
+    }
+
+    #[test]
+    fn test_failure_moves_log_into_log_dir() {
+        let temp = TempDir::new().unwrap();
+        let log = write_log(temp.path());
+        let log_dir = temp.path().join("logs");
+
+        let policy = LogPolicy {
+            keep_dir: Some(log_dir.clone()),
+            ..LogPolicy::new()
+        };
+        let final_path = policy.finalize(&log, false);
+
+        assert_eq!(final_path, log_dir.join("analysis_1_2_0.log"));
+        assert!(final_path.exists(), "kept log should be in log_dir");
+        assert!(!log.exists(), "kept log should not stay in the working dir");
+        assert_eq!(fs::read_to_string(&final_path).unwrap(), "log body\n");
+    }
+
+    #[test]
+    fn test_success_removes_log_even_with_log_dir() {
+        let temp = TempDir::new().unwrap();
+        let log = write_log(temp.path());
+        let log_dir = temp.path().join("logs");
+
+        let policy = LogPolicy {
+            keep_dir: Some(log_dir.clone()),
+            ..LogPolicy::new()
+        };
+        policy.finalize(&log, true);
+
+        assert!(!log.exists());
+        assert!(
+            !log_dir.join("analysis_1_2_0.log").exists(),
+            "a successful run should not populate log_dir"
+        );
+    }
+
+    #[test]
+    fn test_keep_on_success_moves_log_into_log_dir() {
+        let temp = TempDir::new().unwrap();
+        let log = write_log(temp.path());
+        let log_dir = temp.path().join("logs");
+
+        let policy = LogPolicy {
+            keep_dir: Some(log_dir.clone()),
+            ..LogPolicy::new()
+        }
+        .keep_on_success(true);
+        let final_path = policy.finalize(&log, true);
+
+        assert_eq!(final_path, log_dir.join("analysis_1_2_0.log"));
+        assert!(final_path.exists());
+    }
+
+    #[test]
+    fn test_dest_wins_over_log_dir() {
+        let temp = TempDir::new().unwrap();
+        let log = write_log(temp.path());
+        let log_dir = temp.path().join("logs");
+        let dest = temp.path().join("run.log");
+
+        let policy = LogPolicy {
+            keep_dir: Some(log_dir.clone()),
+            ..LogPolicy::new()
+        }
+        .with_dest(Some(dest.clone()));
+        let final_path = policy.finalize(&log, true);
+
+        assert_eq!(final_path, dest);
+        assert!(dest.exists(), "--log destination must be written");
+        assert!(!log.exists());
+        assert!(!log_dir.exists(), "--log must not populate log_dir");
+    }
+
+    #[test]
+    fn test_dest_kept_on_failure() {
+        let temp = TempDir::new().unwrap();
+        let log = write_log(temp.path());
+        let dest = temp.path().join("run.log");
+
+        let policy = LogPolicy::new().with_dest(Some(dest.clone()));
+        let final_path = policy.finalize(&log, false);
+
+        assert_eq!(final_path, dest);
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "log body\n");
+    }
+}

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,4 +1,5 @@
 pub mod binary;
+pub mod log_policy;
 pub mod log_reader;
 pub mod progress;
 pub mod run_paths;

--- a/src/packages/local.rs
+++ b/src/packages/local.rs
@@ -111,6 +111,30 @@ pub fn scan_local_directory(name: &str, dir: &std::path::Path) -> Result<LocalPa
         )));
     }
 
+    // The directory must actually hold the package that was asked for (#100).
+    // Without this, `stacy add badname --source local:<dir>` installed whatever
+    // the directory happened to contain and reported success.
+    let wanted = format!("{}.ado", name.to_lowercase());
+    if !files
+        .iter()
+        .any(|f| f.name.to_lowercase() == wanted.as_str())
+    {
+        let found: Vec<&str> = files
+            .iter()
+            .filter(|f| f.name.ends_with(".ado"))
+            .map(|f| f.name.as_str())
+            .collect();
+        return Err(Error::Config(format!(
+            "Package '{}' not found in local directory: {}\n  \
+             expected {}, found: {}\n  \
+             hint: use the name of the .ado file, or point --source at the directory that holds it",
+            name,
+            dir.display(),
+            wanted,
+            found.join(", ")
+        )));
+    }
+
     let package_checksum = calculate_combined_checksum(&checksums);
 
     Ok(LocalPackageDownload {
@@ -155,6 +179,50 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("not found"));
+    }
+
+    #[test]
+    fn test_scan_rejects_name_not_in_directory() {
+        // #100: the requested name has to be the package that's actually there.
+        let temp = TempDir::new().unwrap();
+        fs::write(
+            temp.path().join("othername.ado"),
+            "program define othername\nend",
+        )
+        .unwrap();
+
+        let err = scan_local_directory("badname", temp.path())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("badname"),
+            "error should name the request: {}",
+            err
+        );
+        assert!(
+            err.contains("othername.ado"),
+            "error should list what the directory holds: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_scan_accepts_case_insensitive_name_match() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("MyPkg.ado"), "program define mypkg\nend").unwrap();
+
+        let result = scan_local_directory("mypkg", temp.path()).unwrap();
+        assert_eq!(result.files.len(), 1);
+    }
+
+    #[test]
+    fn test_scan_accepts_extra_files_alongside_the_named_package() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("mypkg.ado"), "program define mypkg\nend").unwrap();
+        fs::write(temp.path().join("helper.ado"), "program define helper\nend").unwrap();
+
+        let result = scan_local_directory("mypkg", temp.path()).unwrap();
+        assert_eq!(result.files.len(), 2);
     }
 
     #[test]

--- a/src/project/config.rs
+++ b/src/project/config.rs
@@ -81,7 +81,7 @@ impl Default for RunSection {
 /// Supports two formats:
 /// - Simple: just the source string, e.g., `estout = "ssc"` or `ftools = "github:sergiocorreia/ftools"`
 /// - Detailed: object with source and optional version, e.g., `{ source = "ssc", version = "1.0.0" }`
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(untagged)]
 pub enum PackageSpec {
     /// Simple format: just source string (e.g., "ssc" or "github:user/repo")
@@ -92,6 +92,40 @@ pub enum PackageSpec {
         #[serde(skip_serializing_if = "Option::is_none")]
         version: Option<String>,
     },
+}
+
+/// The detailed table, split out so `deny_unknown_fields` applies to it (#100).
+/// `{ source = "ssc", verison = "1.0.0" }` used to parse and drop the pin.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DetailedSpec {
+    source: String,
+    #[serde(default)]
+    version: Option<String>,
+}
+
+// Hand-written so a bad key inside the table is an error naming the key.
+// `#[serde(untagged)]` would report "data did not match any variant" instead.
+impl<'de> Deserialize<'de> for PackageSpec {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match toml::Value::deserialize(deserializer)? {
+            toml::Value::String(source) => Ok(PackageSpec::Simple(source)),
+            table @ toml::Value::Table(_) => {
+                let spec = DetailedSpec::deserialize(table).map_err(serde::de::Error::custom)?;
+                Ok(PackageSpec::Detailed {
+                    source: spec.source,
+                    version: spec.version,
+                })
+            }
+            other => Err(serde::de::Error::custom(format!(
+                "expected a source string or a table with `source`, found {}",
+                other.type_str()
+            ))),
+        }
+    }
 }
 
 impl PackageSpec {
@@ -276,7 +310,7 @@ pub struct ScriptsSection {
 /// analyze = { script = "src/02_analyze.do", description = "Run main analysis" }
 /// outputs = { parallel = ["tables", "figures"] }
 /// ```
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 pub enum TaskDef {
     /// Simple: just a script path - `clean = "src/01_clean.do"`
@@ -287,8 +321,33 @@ pub enum TaskDef {
     Complex(ComplexTask),
 }
 
+// Hand-written for the same reason as PackageSpec: a misspelled key in the
+// object form (`parralel = [...]`) must be an error, not a silent downgrade to
+// a plain script task (#100).
+impl<'de> Deserialize<'de> for TaskDef {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match toml::Value::deserialize(deserializer)? {
+            toml::Value::String(script) => Ok(TaskDef::Simple(PathBuf::from(script))),
+            array @ toml::Value::Array(_) => Vec::<String>::deserialize(array)
+                .map(TaskDef::Sequential)
+                .map_err(serde::de::Error::custom),
+            table @ toml::Value::Table(_) => ComplexTask::deserialize(table)
+                .map(TaskDef::Complex)
+                .map_err(serde::de::Error::custom),
+            other => Err(serde::de::Error::custom(format!(
+                "expected a script path, a list of task names, or a table, found {}",
+                other.type_str()
+            ))),
+        }
+    }
+}
+
 /// Complex task definition with additional options
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ComplexTask {
     /// List of tasks to run in parallel
     #[serde(default)]
@@ -821,6 +880,50 @@ pipeline = ["clean", "analyze", "outputs"]
         };
         assert_eq!(spec.source(), "ssc");
         assert_eq!(spec.version(), Some("1.0.0"));
+    }
+
+    #[test]
+    fn test_package_spec_detailed_parses_with_its_version_pin() {
+        let config: Config = toml::from_str(
+            "[packages.dependencies]\nreghdfe = { source = \"ssc\", version = \"6.12.3\" }\n",
+        )
+        .unwrap();
+
+        let spec = &config.packages.dependencies["reghdfe"];
+        assert_eq!(spec.source(), "ssc");
+        assert_eq!(spec.version(), Some("6.12.3"));
+    }
+
+    #[test]
+    fn test_package_spec_rejects_unknown_key() {
+        // #100: `verison` used to parse and silently drop the pin.
+        let err = toml::from_str::<Config>(
+            "[packages.dependencies]\nreghdfe = { source = \"ssc\", verison = \"6.12.3\" }\n",
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("verison"),
+            "error should name the key: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_complex_task_rejects_unknown_key() {
+        // #100: a misspelled `parallel` used to degrade to a plain script task.
+        let err = toml::from_str::<Config>(
+            "[scripts]\nbuild = { script = \"x.do\", parralel = [\"a\"] }\n",
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("parralel"),
+            "error should name the key: {}",
+            err
+        );
     }
 
     #[test]

--- a/src/project/config.rs
+++ b/src/project/config.rs
@@ -9,8 +9,12 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 /// Project configuration loaded from stacy.toml
+///
+/// Unknown keys are rejected (#100). A misplaced key — `[dependencies]` instead
+/// of `[packages.dependencies]` — used to be dropped without a word, and `lock`
+/// and `install` then reported success on zero packages.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     /// Project-level settings
     pub project: ProjectSection,
@@ -26,7 +30,7 @@ pub struct Config {
 
 /// Path settings for local ado directories
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct PathsSection {
     /// Local ado directories to prepend to S_ADO (relative to project root)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -35,7 +39,7 @@ pub struct PathsSection {
 
 /// Project-level settings (committed to version control)
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ProjectSection {
     /// Project name (for display purposes)
     pub name: Option<String>,
@@ -49,7 +53,7 @@ pub struct ProjectSection {
 
 /// Execution settings for `stacy run`
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct RunSection {
     /// Directory for log files (relative to project root)
     pub log_dir: PathBuf,
@@ -143,7 +147,7 @@ impl std::fmt::Display for DependencyGroup {
 
 /// Package management settings
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct PackagesSection {
     /// Production dependencies: package_name -> source spec
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -242,6 +246,9 @@ impl PackagesSection {
 }
 
 /// Task/script definitions for `stacy task` command
+///
+/// Open by design: every key is a user-chosen task name, so `deny_unknown_fields`
+/// does not apply here (and serde does not support it alongside `flatten`).
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct ScriptsSection {
@@ -340,13 +347,42 @@ pub fn load_config(project_root: &Path) -> Result<Option<Config>> {
     Ok(Some(config))
 }
 
-/// Format TOML parse error with line/column information
+/// Format a TOML parse error: the toml crate renders line, column and the
+/// offending snippet. Unknown keys get an extra line saying where the key
+/// actually belongs, when we can tell.
 fn format_toml_error(err: &toml::de::Error) -> String {
-    if let Some(span) = err.span() {
-        format!("at position {}-{}: {}", span.start, span.end, err.message())
-    } else {
-        err.message().to_string()
+    let mut msg = err.to_string();
+    if let Some(hint) = unknown_key_hint(err.message()) {
+        msg.push('\n');
+        msg.push_str(&hint);
     }
+    msg
+}
+
+/// Point a misplaced top-level dependency key at the section it belongs in.
+///
+/// serde's message ("unknown field `dependencies`, expected one of `project`,
+/// ...") names the key; this adds the fix.
+fn unknown_key_hint(message: &str) -> Option<String> {
+    let key = message
+        .split("unknown field `")
+        .nth(1)?
+        .split('`')
+        .next()?
+        .to_string();
+
+    // Only top-level keys can be confused with the [packages.*] sections.
+    if !message.contains("`project`") {
+        return None;
+    }
+
+    let section = match key.as_str() {
+        "dependencies" => "[packages.dependencies]",
+        "dev" => "[packages.dev]",
+        "test" => "[packages.test]",
+        _ => return None,
+    };
+    Some(format!("hint: declare these under {}", section))
 }
 
 /// Validate configuration values.
@@ -506,6 +542,93 @@ show_progress = false
         let err = result.unwrap_err();
         let err_msg = format!("{}", err);
         assert!(err_msg.contains("Failed to parse stacy.toml"));
+    }
+
+    #[test]
+    fn test_misplaced_dependencies_section_is_rejected() {
+        // #100: `[dependencies]` instead of `[packages.dependencies]` used to be
+        // dropped silently, and `lock`/`install` then reported success on zero
+        // packages.
+        let temp = TempDir::new().unwrap();
+        fs::write(
+            temp.path().join("stacy.toml"),
+            "[project]\nname = \"t\"\n\n[dependencies]\nestout = \"ssc\"\n",
+        )
+        .unwrap();
+
+        let err = load_config(temp.path()).unwrap_err().to_string();
+        assert!(
+            err.contains("dependencies"),
+            "error must name the offending key: {}",
+            err
+        );
+        assert!(
+            err.contains("[packages.dependencies]"),
+            "error must say where the key belongs: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_unknown_key_in_run_section_is_rejected() {
+        let temp = TempDir::new().unwrap();
+        fs::write(
+            temp.path().join("stacy.toml"),
+            "[run]\nlog_dirs = \"logs\"\n",
+        )
+        .unwrap();
+
+        let err = load_config(temp.path()).unwrap_err().to_string();
+        assert!(
+            err.contains("log_dirs"),
+            "error must name the offending key: {}",
+            err
+        );
+        assert!(
+            err.contains("log_dir"),
+            "error should list the valid keys: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_unknown_key_in_packages_section_is_rejected() {
+        let temp = TempDir::new().unwrap();
+        fs::write(
+            temp.path().join("stacy.toml"),
+            "[packages.deps]\nestout = \"ssc\"\n",
+        )
+        .unwrap();
+
+        let err = load_config(temp.path()).unwrap_err().to_string();
+        assert!(err.contains("deps"), "error must name the key: {}", err);
+    }
+
+    #[test]
+    fn test_unknown_key_in_project_section_is_rejected() {
+        let temp = TempDir::new().unwrap();
+        fs::write(
+            temp.path().join("stacy.toml"),
+            "[project]\nnaem = \"typo\"\n",
+        )
+        .unwrap();
+
+        let err = load_config(temp.path()).unwrap_err().to_string();
+        assert!(err.contains("naem"), "error must name the key: {}", err);
+    }
+
+    #[test]
+    fn test_task_names_are_not_unknown_keys() {
+        // [scripts] is open by design — task names are user-chosen.
+        let temp = TempDir::new().unwrap();
+        fs::write(
+            temp.path().join("stacy.toml"),
+            "[scripts]\nanything_goes = \"src/x.do\"\n",
+        )
+        .unwrap();
+
+        let config = load_config(temp.path()).unwrap().unwrap();
+        assert!(config.scripts.tasks.contains_key("anything_goes"));
     }
 
     #[test]

--- a/src/task/executor.rs
+++ b/src/task/executor.rs
@@ -3,6 +3,7 @@
 //! Handles sequential and parallel execution of tasks defined in the task graph.
 
 use crate::error::{Error, Result};
+use crate::executor::log_policy::LogPolicy;
 use crate::executor::StataExecutor;
 use crate::project::config::TaskDef;
 use crate::task::TaskGraph;
@@ -93,6 +94,8 @@ pub struct TaskExecutor<'a> {
     project_root: &'a Path,
     /// Arguments to pass to scripts (name -> value)
     args: HashMap<String, String>,
+    /// What happens to each script's log once it has run
+    log_policy: LogPolicy,
 }
 
 impl<'a> TaskExecutor<'a> {
@@ -103,12 +106,19 @@ impl<'a> TaskExecutor<'a> {
             stata,
             project_root,
             args: HashMap::new(),
+            log_policy: LogPolicy::new(),
         }
     }
 
     /// Set arguments to pass to scripts
     pub fn with_args(mut self, args: HashMap<String, String>) -> Self {
         self.args = args;
+        self
+    }
+
+    /// Set the log-retention policy applied after each script (#98).
+    pub fn with_log_policy(mut self, policy: LogPolicy) -> Self {
+        self.log_policy = policy;
         self
     }
 
@@ -180,13 +190,17 @@ impl<'a> TaskExecutor<'a> {
 
         let duration = start.elapsed();
 
+        // Same contract as `stacy run`: the log is internal unless the run
+        // failed. Without this every task left its log in the working directory.
+        let log_file = self.log_policy.finalize(&result.log_file, result.success);
+
         let script_result = ScriptResult {
             name: name.to_string(),
             script: script_path,
             success: result.success,
             exit_code: result.exit_code,
             duration,
-            log_file: result.log_file,
+            log_file,
         };
 
         let mut task_result = TaskResult::empty(name);

--- a/src/task/executor.rs
+++ b/src/task/executor.rs
@@ -192,7 +192,10 @@ impl<'a> TaskExecutor<'a> {
 
         // Same contract as `stacy run`: the log is internal unless the run
         // failed. Without this every task left its log in the working directory.
-        let log_file = self.log_policy.finalize(&result.log_file, result.success);
+        let log_file = self
+            .log_policy
+            .finalize(&result.log_file, result.success)
+            .unwrap_or_default();
 
         let script_result = ScriptResult {
             name: name.to_string(),

--- a/src/test/runner.rs
+++ b/src/test/runner.rs
@@ -3,6 +3,7 @@
 //! Executes discovered tests sequentially or in parallel using StataExecutor.
 
 use crate::error::{Result, StataError};
+use crate::executor::log_policy::LogPolicy;
 use crate::executor::StataExecutor;
 use crate::test::discovery::TestFile;
 
@@ -136,6 +137,8 @@ pub struct TestRunner<'a> {
     parallel: bool,
     /// Working directory mode for test execution
     working_dir: TestWorkingDir,
+    /// What happens to each test's log once it has run
+    log_policy: LogPolicy,
 }
 
 impl<'a> TestRunner<'a> {
@@ -146,12 +149,19 @@ impl<'a> TestRunner<'a> {
             project_root,
             parallel: false,
             working_dir: TestWorkingDir::default(),
+            log_policy: LogPolicy::new(),
         }
     }
 
     /// Enable parallel test execution
     pub fn with_parallel(mut self, parallel: bool) -> Self {
         self.parallel = parallel;
+        self
+    }
+
+    /// Set the log-retention policy applied after each test (#98).
+    pub fn with_log_policy(mut self, policy: LogPolicy) -> Self {
+        self.log_policy = policy;
         self
     }
 
@@ -181,6 +191,10 @@ impl<'a> TestRunner<'a> {
             None
         };
 
+        // A passing test's log is internal and is removed; a failing test keeps
+        // its log (in `[run] log_dir` when set) — the failure report reads it.
+        let log_file = self.log_policy.finalize(&result.log_file, result.success);
+
         Ok(TestResult {
             name: test.name.clone(),
             path: test.path.clone(),
@@ -188,7 +202,7 @@ impl<'a> TestRunner<'a> {
             exit_code: result.exit_code,
             duration,
             error_message,
-            log_file: Some(result.log_file),
+            log_file: Some(log_file),
         })
     }
 

--- a/src/test/runner.rs
+++ b/src/test/runner.rs
@@ -202,7 +202,7 @@ impl<'a> TestRunner<'a> {
             exit_code: result.exit_code,
             duration,
             error_message,
-            log_file: Some(log_file),
+            log_file,
         })
     }
 

--- a/src/utils/temp.rs
+++ b/src/utils/temp.rs
@@ -15,15 +15,14 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// The file is automatically deleted when the struct goes out of scope,
 /// ensuring cleanup even on panic or early return.
 ///
-/// The associated log file (created by Stata) is also cleaned up. Since #20,
-/// the executor wraps every script for collision-safe parallel runs, so the
-/// real log path no longer matches `script.with_extension("log")`. Callers
-/// must record the actual path via [`set_actual_log`](Self::set_actual_log)
-/// after execution; Drop cleans both.
+/// The log file that Stata writes is NOT owned here: since #20 its name derives
+/// from the per-invocation wrapper, and since #98 its lifetime belongs to
+/// [`LogPolicy`](crate::executor::log_policy::LogPolicy) — removed on success,
+/// kept (in `[run] log_dir`) on failure. Drop still clears a stale
+/// `<script>.log` should an older Stata write one next to the script.
 pub struct TempScript {
     path: PathBuf,
     log_path: PathBuf,
-    actual_log: Option<PathBuf>,
 }
 
 impl TempScript {
@@ -60,11 +59,7 @@ impl TempScript {
         // Ensure file is flushed to disk before Stata reads it
         file.flush()?;
 
-        Ok(Self {
-            path,
-            log_path,
-            actual_log: None,
-        })
+        Ok(Self { path, log_path })
     }
 
     /// Get the path to the temporary script.
@@ -76,14 +71,6 @@ impl TempScript {
     pub fn log_path(&self) -> &Path {
         &self.log_path
     }
-
-    /// Record the real log path produced by execution, so Drop cleans it up.
-    /// Call this with `result.log_file` after running Stata against the script.
-    /// See #20: the wrapper-script disambiguation means the real log lives at
-    /// `<stem>_<pid>_<nanos>_<n>.log`, not at `<stem>.log`.
-    pub fn set_actual_log(&mut self, path: PathBuf) {
-        self.actual_log = Some(path);
-    }
 }
 
 impl Drop for TempScript {
@@ -91,11 +78,6 @@ impl Drop for TempScript {
         // Best-effort cleanup - don't panic if files don't exist
         let _ = fs::remove_file(&self.path);
         let _ = fs::remove_file(&self.log_path);
-        if let Some(ref p) = self.actual_log {
-            if p != &self.log_path {
-                let _ = fs::remove_file(p);
-            }
-        }
     }
 }
 
@@ -173,31 +155,26 @@ mod tests {
     }
 
     #[test]
-    fn test_temp_script_cleans_actual_log() {
-        // #20: the real log file no longer matches script.with_extension("log").
-        // set_actual_log() must register the real path so Drop cleans it.
+    fn test_temp_script_leaves_wrapper_log_to_the_policy() {
+        // #98: the wrapper-derived log (`<stem>_<pid>_<nanos>_<n>.log`) is owned
+        // by LogPolicy, which keeps it when the run failed. TempScript must not
+        // delete it behind the policy's back.
         let temp_dir = TempDir::new().unwrap();
         let script_path;
-        let actual_log_path;
+        let wrapper_log;
 
         {
-            let mut script = TempScript::new("display 1", temp_dir.path()).unwrap();
+            let script = TempScript::new("display 1", temp_dir.path()).unwrap();
             script_path = script.path().to_path_buf();
 
-            // Simulate the wrapper-derived log path produced by RunPaths.
-            actual_log_path = temp_dir.path().join("_stacy_inline_xxx_42_0_0.log");
-            fs::write(&actual_log_path, "log content").unwrap();
-
-            script.set_actual_log(actual_log_path.clone());
-
-            assert!(script_path.exists());
-            assert!(actual_log_path.exists());
+            wrapper_log = temp_dir.path().join("_stacy_inline_xxx_42_0_0.log");
+            fs::write(&wrapper_log, "log content").unwrap();
         } // script dropped here
 
         assert!(!script_path.exists(), "temp .do should be gone");
         assert!(
-            !actual_log_path.exists(),
-            "actual log should be cleaned up via set_actual_log"
+            wrapper_log.exists(),
+            "the wrapper log is the policy's to keep or remove"
         );
     }
 

--- a/stata/stacy_env.ado
+++ b/stata/stacy_env.ado
@@ -13,6 +13,8 @@
     Returns:
         r(adopath_count       ) - Number of adopath entries (scalar)
         r(has_config          ) - stacy.toml exists (1=yes, 0=no) (scalar)
+        r(missing_package_count) - Locked packages absent from the cache (scalar)
+        r(package_count       ) - Locked packages present in the cache (scalar)
         r(show_progress       ) - Progress shown (1=yes, 0=no) (scalar)
         r(cache_dir           ) - Global package cache directory (local)
         r(log_dir             ) - Project log directory (local)
@@ -41,6 +43,16 @@ program define stacy_env, rclass
     capture confirm scalar stacy_has_config
     if _rc == 0 {
         return scalar has_config = scalar(stacy_has_config)
+    }
+
+    capture confirm scalar stacy_missing_package_count
+    if _rc == 0 {
+        return scalar missing_package_count = scalar(stacy_missing_package_count)
+    }
+
+    capture confirm scalar stacy_package_count
+    if _rc == 0 {
+        return scalar package_count = scalar(stacy_package_count)
     }
 
     capture confirm scalar stacy_show_progress

--- a/stata/stacy_env.sthlp
+++ b/stata/stacy_env.sthlp
@@ -34,6 +34,8 @@
 {p2col 5 25 29 2: Scalars}{p_end}
 {synopt:{cmd:r(adopath_count)}}Number of adopath entries{p_end}
 {synopt:{cmd:r(has_config)}}stacy.toml exists (1=yes, 0=no){p_end}
+{synopt:{cmd:r(missing_package_count)}}Locked packages absent from the cache{p_end}
+{synopt:{cmd:r(package_count)}}Locked packages present in the cache{p_end}
 {synopt:{cmd:r(show_progress)}}Progress shown (1=yes, 0=no){p_end}
 
 {p2col 5 25 29 2: Macros}{p_end}

--- a/stata/stacy_run.ado
+++ b/stata/stacy_run.ado
@@ -32,7 +32,7 @@
         r(error_count         ) - Number of errors detected (scalar)
         r(exit_code           ) - Exit code (0=success) (scalar)
         r(success             ) - Whether script succeeded (1=yes, 0=no) (scalar)
-        r(log_file            ) - Path to log file (local)
+        r(log_file            ) - Path to the kept log file (empty when the run succeeded) (local)
         r(script              ) - Path to script (local)
         r(source              ) - 'file' or 'inline' (local)
 */

--- a/stata/stacy_run.sthlp
+++ b/stata/stacy_run.sthlp
@@ -112,7 +112,7 @@
 {synopt:{cmd:r(success)}}Whether script succeeded (1=yes, 0=no){p_end}
 
 {p2col 5 25 29 2: Macros}{p_end}
-{synopt:{cmd:r(log_file)}}Path to log file{p_end}
+{synopt:{cmd:r(log_file)}}Path to the kept log file (empty when the run succeeded){p_end}
 {synopt:{cmd:r(script)}}Path to script{p_end}
 {synopt:{cmd:r(source)}}'file' or 'inline'{p_end}
 

--- a/tests/edge_cases_test.rs
+++ b/tests/edge_cases_test.rs
@@ -7,6 +7,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use tempfile::TempDir;
 
 const STACY_BINARY: &str = env!("CARGO_BIN_EXE_stacy");
 
@@ -14,15 +15,18 @@ fn edge_case_script(name: &str) -> PathBuf {
     PathBuf::from("tests/edge_cases").join(name)
 }
 
-/// Run stacy with `--format=json` and return the log file path it reports.
+/// Run stacy with `--format=json` and `--log <dest>`, and return the log path it
+/// reports.
 ///
-/// Since #20, the log no longer lives at `script.with_extension("log")` —
-/// each invocation gets a unique stem. JSON output is the contract for
-/// discovering where Stata wrote the log.
-fn run_and_get_log(script: &Path) -> PathBuf {
+/// The batch log of a successful run is removed (#98), so a test that wants to
+/// inspect it asks for it with `--log` — the flag that makes the log durable.
+/// JSON output stays the contract for where the log ended up.
+fn run_and_get_log(script: &Path, dest: &Path) -> PathBuf {
     let output = Command::new(STACY_BINARY)
         .arg("run")
         .arg("--format=json")
+        .arg("--log")
+        .arg(dest)
         .arg(script)
         .output()
         .expect("Failed to execute stacy");
@@ -45,12 +49,12 @@ fn run_and_get_log(script: &Path) -> PathBuf {
 #[ignore] // Requires Stata - run locally with: cargo test --test edge_cases_test -- --ignored
 fn test_spaces_in_filename() {
     let script = edge_case_script("my script.do");
+    let temp = TempDir::new().expect("Failed to create temp dir");
 
     // Verify script exists
     assert!(script.exists(), "Test script should exist");
 
-    // Run stacy and ask it where the log landed (#20: not script.with_extension("log") anymore).
-    let log_file = run_and_get_log(&script);
+    let log_file = run_and_get_log(&script, &temp.path().join("run.log"));
 
     assert!(
         log_file.exists(),
@@ -63,12 +67,12 @@ fn test_spaces_in_filename() {
 #[ignore] // Requires Stata - run locally with: cargo test --test edge_cases_test -- --ignored
 fn test_unicode_in_filename() {
     let script = edge_case_script("café_analysis.do");
+    let temp = TempDir::new().expect("Failed to create temp dir");
 
     // Verify script exists
     assert!(script.exists(), "Test script should exist");
 
-    // Run stacy and ask it where the log landed (#20).
-    let log_file = run_and_get_log(&script);
+    let log_file = run_and_get_log(&script, &temp.path().join("run.log"));
 
     assert!(
         log_file.exists(),
@@ -81,12 +85,12 @@ fn test_unicode_in_filename() {
 #[ignore] // Requires Stata - run locally with: cargo test --test edge_cases_test -- --ignored --nocapture
 fn test_large_log_file() {
     let script = edge_case_script("large_log_generator.do");
+    let temp = TempDir::new().expect("Failed to create temp dir");
 
     // Verify script exists
     assert!(script.exists(), "Test script should exist");
 
-    // Run stacy and ask it where the log landed (#20).
-    let log_file = run_and_get_log(&script);
+    let log_file = run_and_get_log(&script, &temp.path().join("run.log"));
 
     assert!(
         log_file.exists(),

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -1636,9 +1636,9 @@ fn test_task_frozen_flag_exists() {
 }
 
 #[test]
-fn test_task_table_without_work_fails() {
-    // A table-form task whose work key is typo'd (serde drops unknown keys)
-    // must error, not succeed as a no-op (#92)
+fn test_task_table_with_typoed_work_key_fails() {
+    // A table-form task whose work key is typo'd must error rather than succeed
+    // as a no-op (#92). The unknown key is now named outright (#100).
     let temp = TempDir::new().unwrap();
     fs::write(
         temp.path().join("stacy.toml"),
@@ -1648,6 +1648,30 @@ name = "test"
 [scripts.build]
 description = "Build everything"
 scripts = ["src/01_clean.do"]
+"#,
+    )
+    .unwrap();
+
+    stacy()
+        .current_dir(temp.path())
+        .arg("task")
+        .arg("build")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unknown field `scripts`"));
+}
+
+#[test]
+fn test_task_table_without_work_fails() {
+    // Every key is known, but none of them defines any work (#92).
+    let temp = TempDir::new().unwrap();
+    fs::write(
+        temp.path().join("stacy.toml"),
+        r#"[project]
+name = "test"
+
+[scripts.build]
+description = "Build everything"
 "#,
     )
     .unwrap();

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -2573,15 +2573,17 @@ fn test_run_parallel_same_stem_no_log_collision() {
 
 // Issue #20: each invocation must produce a distinct log file path so
 // concurrent stacy processes from a shared cwd never write to the same file.
+//
+// The script errors on purpose: only a failed run keeps its log (#98), so a
+// failure is what lets the test see the path stacy generated.
 #[test]
 #[ignore]
 fn test_run_log_path_unique_per_invocation() {
     let temp = TempDir::new().unwrap();
-    fs::write(temp.path().join("test.do"), "display 42\n").unwrap();
-    let script = temp.path().join("test.do");
+    fs::write(temp.path().join("test.do"), "error 198\n").unwrap();
 
-    let log1 = run_and_extract_log(&script);
-    let log2 = run_and_extract_log(&script);
+    let log1 = run_and_extract_log(temp.path(), "test.do");
+    let log2 = run_and_extract_log(temp.path(), "test.do");
 
     assert_ne!(
         log1, log2,
@@ -2681,13 +2683,15 @@ fn test_version_check_rejects_stale_binary() {
     );
 }
 
-fn run_and_extract_log(script: &std::path::Path) -> String {
+/// Run a failing script in `dir` and return the log path stacy reports.
+fn run_and_extract_log(dir: &std::path::Path, script: &str) -> String {
     let out = stacy()
+        .current_dir(dir)
         .arg("run")
         .arg("--format=json")
         .arg(script)
         .assert()
-        .success()
+        .failure()
         .get_output()
         .stdout
         .clone();

--- a/tests/test_config_unknown_keys.rs
+++ b/tests/test_config_unknown_keys.rs
@@ -54,6 +54,41 @@ fn test_run_rejects_unknown_key() {
 }
 
 #[test]
+fn test_unknown_key_in_a_package_table_is_rejected() {
+    let temp = TempDir::new().unwrap();
+    // A typo in `version` used to drop the pin and resolve the latest instead.
+    fs::write(
+        temp.path().join("stacy.toml"),
+        "[project]\nname = \"t\"\n\n[packages.dependencies]\nestout = { source = \"ssc\", verison = \"1.0.0\" }\n",
+    )
+    .unwrap();
+
+    stacy()
+        .current_dir(temp.path())
+        .arg("env")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("verison"));
+}
+
+#[test]
+fn test_unknown_key_in_a_task_table_is_rejected() {
+    let temp = TempDir::new().unwrap();
+    fs::write(
+        temp.path().join("stacy.toml"),
+        "[project]\nname = \"t\"\n\n[scripts]\nbuild = { script = \"x.do\", parralel = [\"a\"] }\n",
+    )
+    .unwrap();
+
+    stacy()
+        .current_dir(temp.path())
+        .arg("env")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("parralel"));
+}
+
+#[test]
 fn test_valid_config_still_loads() {
     let temp = TempDir::new().unwrap();
     fs::write(
@@ -73,9 +108,13 @@ ado = ["ado"]
 
 [packages.dependencies]
 estout = "ssc"
+reghdfe = { source = "github:sergiocorreia/reghdfe", version = "v6.12.3" }
 
 [scripts]
 clean = "src/01_clean.do"
+all = ["clean"]
+analyze = { script = "src/02_analyze.do", args = ["--fast"], description = "Estimates" }
+outputs = { parallel = ["clean"] }
 "#,
     )
     .unwrap();

--- a/tests/test_config_unknown_keys.rs
+++ b/tests/test_config_unknown_keys.rs
@@ -1,0 +1,88 @@
+//! Regression tests for #100: unknown keys in stacy.toml were dropped silently.
+//!
+//! A dependency under `[dependencies]` instead of `[packages.dependencies]`
+//! vanished, and `lock`/`install` then reported success on zero packages.
+
+use assert_cmd::{cargo_bin_cmd, Command};
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn stacy() -> Command {
+    cargo_bin_cmd!("stacy")
+}
+
+#[test]
+fn test_lock_rejects_misplaced_dependencies_key() {
+    let temp = TempDir::new().unwrap();
+    fs::write(
+        temp.path().join("stacy.toml"),
+        "[project]\nname = \"t\"\n\n[dependencies]\nestout = \"ssc\"\n",
+    )
+    .unwrap();
+
+    stacy()
+        .current_dir(temp.path())
+        .arg("lock")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("dependencies"))
+        .stderr(predicate::str::contains("[packages.dependencies]"));
+
+    assert!(
+        !temp.path().join("stacy.lock").exists(),
+        "a rejected config must not produce a lockfile"
+    );
+}
+
+#[test]
+fn test_run_rejects_unknown_key() {
+    let temp = TempDir::new().unwrap();
+    fs::write(
+        temp.path().join("stacy.toml"),
+        "[run]\nlog_dirs = \"logs\"\n",
+    )
+    .unwrap();
+    fs::write(temp.path().join("x.do"), "display 1\n").unwrap();
+
+    stacy()
+        .current_dir(temp.path())
+        .args(["run", "x.do"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("log_dirs"));
+}
+
+#[test]
+fn test_valid_config_still_loads() {
+    let temp = TempDir::new().unwrap();
+    fs::write(
+        temp.path().join("stacy.toml"),
+        r#"[project]
+name = "t"
+authors = ["A <a@example.com>"]
+
+[run]
+log_dir = "logs"
+show_progress = false
+progress_interval_seconds = 5
+max_log_size_mb = 100
+
+[paths]
+ado = ["ado"]
+
+[packages.dependencies]
+estout = "ssc"
+
+[scripts]
+clean = "src/01_clean.do"
+"#,
+    )
+    .unwrap();
+
+    stacy()
+        .current_dir(temp.path())
+        .arg("env")
+        .assert()
+        .success();
+}

--- a/tests/test_env_package_status.rs
+++ b/tests/test_env_package_status.rs
@@ -1,0 +1,161 @@
+//! Regression tests for #99: `stacy env` must check the cache before calling a
+//! locked package installed.
+//!
+//! `env` built each adopath entry from `global_cache::package_path`, which only
+//! constructs a path. A cold cache therefore reported every locked package as
+//! installed.
+
+use assert_cmd::{cargo_bin_cmd, Command};
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn stacy() -> Command {
+    cargo_bin_cmd!("stacy")
+}
+
+/// Project with one locked package (estout 1.0.0).
+fn setup_project(root: &Path) {
+    fs::write(
+        root.join("stacy.toml"),
+        "[project]\nname = \"t\"\n\n[packages.dependencies]\nestout = \"ssc\"\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("stacy.lock"),
+        r#"version = "1"
+
+[packages.estout]
+version = "1.0.0"
+checksum = "deadbeef"
+group = "production"
+
+[packages.estout.source]
+type = "SSC"
+name = "estout"
+"#,
+    )
+    .unwrap();
+}
+
+/// Populate the global cache with the package files stacy expects.
+fn install_into_cache(cache_home: &Path) {
+    let pkg = cache_home.join("stacy/packages/estout/1.0.0");
+    fs::create_dir_all(&pkg).unwrap();
+    fs::write(pkg.join("estout.ado"), "program define estout\nend\n").unwrap();
+}
+
+#[test]
+fn test_env_cold_cache_reports_package_missing() {
+    let temp = TempDir::new().unwrap();
+    let cache_home = TempDir::new().unwrap();
+    setup_project(temp.path());
+
+    stacy()
+        .current_dir(temp.path())
+        .env("XDG_CACHE_HOME", cache_home.path())
+        .arg("env")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Packages: 0 installed, 1 missing"))
+        .stdout(predicate::str::contains("not installed"));
+}
+
+#[test]
+fn test_env_warm_cache_reports_package_installed() {
+    let temp = TempDir::new().unwrap();
+    let cache_home = TempDir::new().unwrap();
+    setup_project(temp.path());
+    install_into_cache(cache_home.path());
+
+    stacy()
+        .current_dir(temp.path())
+        .env("XDG_CACHE_HOME", cache_home.path())
+        .arg("env")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Packages: 1 installed"))
+        .stdout(predicate::str::contains("missing").not())
+        .stdout(predicate::str::contains("not installed").not());
+}
+
+#[test]
+fn test_env_json_reports_missing_package() {
+    let temp = TempDir::new().unwrap();
+    let cache_home = TempDir::new().unwrap();
+    setup_project(temp.path());
+
+    let output = stacy()
+        .current_dir(temp.path())
+        .env("XDG_CACHE_HOME", cache_home.path())
+        .args(["env", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["project"]["package_count"], 0);
+    assert_eq!(json["project"]["missing_package_count"], 1);
+
+    let entry = json["s_ado"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["source"] == "package")
+        .expect("package entry in s_ado");
+    assert_eq!(entry["label"], "estout");
+    assert_eq!(entry["installed"], false);
+}
+
+#[test]
+fn test_env_json_reports_installed_package() {
+    let temp = TempDir::new().unwrap();
+    let cache_home = TempDir::new().unwrap();
+    setup_project(temp.path());
+    install_into_cache(cache_home.path());
+
+    let output = stacy()
+        .current_dir(temp.path())
+        .env("XDG_CACHE_HOME", cache_home.path())
+        .args(["env", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["project"]["package_count"], 1);
+    assert_eq!(json["project"]["missing_package_count"], 0);
+
+    let entry = json["s_ado"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["source"] == "package")
+        .expect("package entry in s_ado");
+    assert_eq!(entry["installed"], true);
+}
+
+#[test]
+fn test_env_stata_format_reports_package_counts() {
+    let temp = TempDir::new().unwrap();
+    let cache_home = TempDir::new().unwrap();
+    setup_project(temp.path());
+
+    let output = stacy()
+        .current_dir(temp.path())
+        .env("XDG_CACHE_HOME", cache_home.path())
+        .args(["env", "--format", "stata"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("scalar stacy_package_count = 0"),
+        "missing package_count scalar:\n{}",
+        stdout
+    );
+    assert!(
+        stdout.contains("scalar stacy_missing_package_count = 1"),
+        "missing missing_package_count scalar:\n{}",
+        stdout
+    );
+}

--- a/tests/test_local_source.rs
+++ b/tests/test_local_source.rs
@@ -1,0 +1,56 @@
+//! Regression tests for #100: a `local:` source installed whatever the directory
+//! contained, regardless of the package name that was asked for.
+
+use assert_cmd::{cargo_bin_cmd, Command};
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn stacy() -> Command {
+    cargo_bin_cmd!("stacy")
+}
+
+#[test]
+fn test_add_local_rejects_name_the_directory_does_not_hold() {
+    let temp = TempDir::new().unwrap();
+    fs::write(temp.path().join("stacy.toml"), "[project]\nname = \"t\"\n").unwrap();
+
+    let lib = temp.path().join("lib/othername");
+    fs::create_dir_all(&lib).unwrap();
+    fs::write(lib.join("othername.ado"), "program define othername\nend\n").unwrap();
+
+    stacy()
+        .current_dir(temp.path())
+        .args(["add", "badname", "--source", "local:./lib/othername"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("badname"))
+        .stderr(predicate::str::contains("othername.ado"));
+
+    // Nothing was written: no lockfile entry, no manifest entry.
+    assert!(!temp.path().join("stacy.lock").exists());
+    let config = fs::read_to_string(temp.path().join("stacy.toml")).unwrap();
+    assert!(!config.contains("badname"));
+}
+
+#[test]
+fn test_add_local_accepts_matching_name() {
+    let temp = TempDir::new().unwrap();
+    let cache_home = TempDir::new().unwrap();
+    fs::write(temp.path().join("stacy.toml"), "[project]\nname = \"t\"\n").unwrap();
+
+    let lib = temp.path().join("lib/myutils");
+    fs::create_dir_all(&lib).unwrap();
+    fs::write(lib.join("myutils.ado"), "program define myutils\nend\n").unwrap();
+
+    stacy()
+        .current_dir(temp.path())
+        .env("XDG_CACHE_HOME", cache_home.path())
+        .args(["add", "myutils", "--source", "local:./lib/myutils"])
+        .assert()
+        .success();
+
+    let config = fs::read_to_string(temp.path().join("stacy.toml")).unwrap();
+    assert!(config.contains("myutils"));
+    assert!(temp.path().join("stacy.lock").exists());
+}

--- a/tests/test_log_retention.rs
+++ b/tests/test_log_retention.rs
@@ -224,6 +224,93 @@ fn test_failed_inline_run_keeps_the_log_it_printed() {
 }
 
 #[test]
+fn test_successful_machine_format_runs_leave_no_logs_behind() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("logs"));
+    let fake = write_fake_stata(temp.path(), "pass");
+
+    // `--format stata` is what the in-Stata wrappers always pass, so one log per
+    // successful `stacy_run` would accumulate forever.
+    for _ in 0..3 {
+        stacy()
+            .current_dir(temp.path())
+            .env("STATA_BINARY", &fake)
+            .args(["run", "--format", "stata", "src/01_clean.do"])
+            .assert()
+            .success();
+    }
+
+    assert!(logs_in(temp.path()).is_empty());
+    assert!(
+        !temp.path().join("logs").exists(),
+        "successful machine-format runs must not accumulate logs"
+    );
+}
+
+#[test]
+fn test_successful_json_run_reports_no_log() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("logs"));
+    let fake = write_fake_stata(temp.path(), "pass");
+
+    let output = stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["run", "--format", "json", "src/01_clean.do"])
+        .output()
+        .unwrap();
+
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        v["log_file"].as_str(),
+        Some(""),
+        "a removed log must not be reported as a path that does not exist"
+    );
+    assert!(logs_in(temp.path()).is_empty());
+    assert!(!temp.path().join("logs").exists());
+}
+
+#[test]
+fn test_failed_json_run_reports_the_kept_log() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("logs"));
+    let fake = write_fake_stata(temp.path(), "fail");
+
+    let output = stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["run", "--format", "json", "src/01_clean.do"])
+        .output()
+        .unwrap();
+
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let reported = Path::new(v["log_file"].as_str().expect("log_file field"));
+    assert!(
+        reported.exists(),
+        "failure must report a log that exists: {}",
+        reported.display()
+    );
+    assert_eq!(logs_in(&temp.path().join("logs")).len(), 1);
+}
+
+#[test]
+fn test_successful_machine_format_task_leaves_no_log_behind() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("logs"));
+    let fake = write_fake_stata(temp.path(), "pass");
+
+    stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["task", "clean", "--format", "stata"])
+        .assert()
+        .success();
+
+    assert!(logs_in(temp.path()).is_empty());
+    assert!(!temp.path().join("logs").exists());
+}
+
+#[test]
 fn test_successful_task_leaves_no_log_behind() {
     let temp = TempDir::new().unwrap();
     setup_project(temp.path(), Some("logs"));

--- a/tests/test_log_retention.rs
+++ b/tests/test_log_retention.rs
@@ -1,0 +1,322 @@
+//! Regression tests for #98: `[run] log_dir` is honored, and per-script logs
+//! follow the documented contract — removed on success, kept on failure.
+//!
+//! Before this, `log_dir` was parsed and reported by `stacy env` but nothing
+//! consumed it: logs were written next to the run (the project root) and `task`,
+//! `test` and `bench` never cleaned them up.
+
+#![cfg(unix)]
+
+use assert_cmd::{cargo_bin_cmd, Command};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn stacy() -> Command {
+    cargo_bin_cmd!("stacy")
+}
+
+/// Fake Stata: writes `<wrapper stem>.log` into its cwd, as `stata -b do` does.
+/// `outcome` "pass" writes a clean log; "fail" appends an r(198) trailer.
+fn write_fake_stata(dir: &Path, outcome: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let path = dir.join(format!("fake-stata-{}", outcome));
+    let body = if outcome == "fail" {
+        "#!/bin/sh\n\
+         for arg in \"$@\"; do last=\"$arg\"; done\n\
+         stem=$(basename \"$last\" .do)\n\
+         printf '%s\\n' '. display xx' 'invalid syntax' 'r(198);' '' 'end of do-file' 'r(198);' \
+         > \"$stem.log\"\n"
+            .to_string()
+    } else {
+        "#!/bin/sh\n\
+         for arg in \"$@\"; do last=\"$arg\"; done\n\
+         stem=$(basename \"$last\" .do)\n\
+         printf '%s\\n' '. display 1' '1' '' 'end of do-file' > \"$stem.log\"\n"
+            .to_string()
+    };
+    fs::write(&path, body).unwrap();
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).unwrap();
+    path
+}
+
+/// Project with a script, a task and a test, optionally setting `[run] log_dir`.
+fn setup_project(root: &Path, log_dir: Option<&str>) {
+    let run_section = match log_dir {
+        Some(dir) => format!("\n[run]\nlog_dir = \"{}\"\n", dir),
+        None => String::new(),
+    };
+    fs::write(
+        root.join("stacy.toml"),
+        format!(
+            "[project]\nname = \"t\"\n{}\n[scripts]\nclean = \"src/01_clean.do\"\n",
+            run_section
+        ),
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/01_clean.do"), "display 1\n").unwrap();
+    fs::create_dir_all(root.join("tests")).unwrap();
+    fs::write(root.join("tests/test_smoke.do"), "display 1\n").unwrap();
+}
+
+/// `.log` files sitting directly in `dir`.
+fn logs_in(dir: &Path) -> Vec<PathBuf> {
+    let mut found: Vec<PathBuf> = fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("log"))
+        .collect();
+    found.sort();
+    found
+}
+
+#[test]
+fn test_successful_run_leaves_no_log_behind() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("logs"));
+    let fake = write_fake_stata(temp.path(), "pass");
+
+    stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["run", "src/01_clean.do"])
+        .assert()
+        .success();
+
+    assert!(
+        logs_in(temp.path()).is_empty(),
+        "a successful run must not leave a log in the project root"
+    );
+    assert!(
+        !temp.path().join("logs").exists(),
+        "a successful run has nothing to keep, so log_dir stays absent"
+    );
+}
+
+#[test]
+fn test_failed_run_keeps_log_in_log_dir() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("logs"));
+    let fake = write_fake_stata(temp.path(), "fail");
+
+    let output = stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["run", "src/01_clean.do"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2), "syntax error exit code");
+    assert!(
+        logs_in(temp.path()).is_empty(),
+        "the kept log belongs in log_dir, not the project root"
+    );
+
+    let kept = logs_in(&temp.path().join("logs"));
+    assert_eq!(kept.len(), 1, "failed run should keep exactly one log");
+
+    // The path stacy printed must be the path the log actually lives at.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let printed = stderr
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("Log: "))
+        .expect("failure output should name the kept log");
+    let printed = Path::new(printed.trim());
+    assert!(
+        printed.exists(),
+        "printed log path does not exist: {}",
+        printed.display()
+    );
+    // macOS resolves the temp dir through /private, so compare canonical paths.
+    assert_eq!(
+        printed.canonicalize().unwrap(),
+        kept[0].canonicalize().unwrap()
+    );
+}
+
+#[test]
+fn test_custom_log_dir_is_used() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("output/logs"));
+    let fake = write_fake_stata(temp.path(), "fail");
+
+    stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["run", "src/01_clean.do"])
+        .output()
+        .unwrap();
+
+    assert_eq!(logs_in(&temp.path().join("output/logs")).len(), 1);
+}
+
+#[test]
+fn test_log_flag_wins_over_log_dir() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("logs"));
+    let fake = write_fake_stata(temp.path(), "fail");
+
+    stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["run", "src/01_clean.do", "--log", "run.log"])
+        .output()
+        .unwrap();
+
+    let dest = temp.path().join("run.log");
+    assert!(dest.exists(), "--log destination must be written");
+    assert!(
+        !temp.path().join("logs").exists(),
+        "--log must not also populate log_dir"
+    );
+}
+
+#[test]
+fn test_log_flag_written_on_success() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("logs"));
+    let fake = write_fake_stata(temp.path(), "pass");
+
+    stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["run", "src/01_clean.do", "--log", "run.log"])
+        .assert()
+        .success();
+
+    assert!(
+        temp.path().join("run.log").exists(),
+        "--log is a durable artifact, kept even when the run passes"
+    );
+    assert!(logs_in(temp.path()).len() == 1, "only the --log artifact");
+}
+
+#[test]
+fn test_failed_inline_run_keeps_the_log_it_printed() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("logs"));
+    let fake = write_fake_stata(temp.path(), "fail");
+
+    let output = stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["run", "-c", "display xx"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let printed = stderr
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("Log: "))
+        .expect("failure output should name the kept log");
+    assert!(
+        Path::new(printed.trim()).exists(),
+        "inline failure printed a log path that was then deleted: {}",
+        printed
+    );
+    assert!(
+        logs_in(temp.path()).is_empty(),
+        "the inline log belongs in log_dir"
+    );
+}
+
+#[test]
+fn test_successful_task_leaves_no_log_behind() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("logs"));
+    let fake = write_fake_stata(temp.path(), "pass");
+
+    stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["task", "clean"])
+        .assert()
+        .success();
+
+    assert!(
+        logs_in(temp.path()).is_empty(),
+        "stacy task must not leave logs in the project root"
+    );
+    assert!(!temp.path().join("logs").exists());
+}
+
+#[test]
+fn test_failed_task_keeps_log_in_log_dir() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("logs"));
+    let fake = write_fake_stata(temp.path(), "fail");
+
+    stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["task", "clean"])
+        .output()
+        .unwrap();
+
+    assert!(logs_in(temp.path()).is_empty());
+    assert_eq!(logs_in(&temp.path().join("logs")).len(), 1);
+}
+
+#[test]
+fn test_successful_test_run_leaves_no_log_behind() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("logs"));
+    let fake = write_fake_stata(temp.path(), "pass");
+
+    stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .arg("test")
+        .assert()
+        .success();
+
+    assert!(
+        logs_in(temp.path()).is_empty(),
+        "stacy test must not leave logs in the project root"
+    );
+    assert!(logs_in(&temp.path().join("tests")).is_empty());
+}
+
+#[test]
+fn test_successful_bench_leaves_no_log_behind() {
+    let temp = TempDir::new().unwrap();
+    setup_project(temp.path(), Some("logs"));
+    let fake = write_fake_stata(temp.path(), "pass");
+
+    stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["bench", "src/01_clean.do", "--runs", "2", "--no-warmup"])
+        .assert()
+        .success();
+
+    assert!(
+        logs_in(temp.path()).is_empty(),
+        "stacy bench must not leave one log per run behind"
+    );
+}
+
+#[test]
+fn test_failure_outside_a_project_keeps_log_in_place() {
+    let temp = TempDir::new().unwrap();
+    // No stacy.toml — nothing configures log_dir, so the log stays where Stata
+    // wrote it rather than vanishing.
+    fs::write(temp.path().join("x.do"), "display xx\n").unwrap();
+    let fake = write_fake_stata(temp.path(), "fail");
+
+    stacy()
+        .current_dir(temp.path())
+        .env("STATA_BINARY", &fake)
+        .args(["run", "x.do"])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        logs_in(temp.path()).len(),
+        1,
+        "a failed run outside a project keeps its log next to the run"
+    );
+}

--- a/tests/test_stata_output.rs
+++ b/tests/test_stata_output.rs
@@ -494,14 +494,15 @@ fn test_cache_clean_format_stata_syntax() {
 #[test]
 fn test_task_list_format_stata_syntax() {
     let temp = TempDir::new().unwrap();
-    // Create a stacy.toml with tasks
+    // Tasks live in [scripts]; the old fixture's [tasks.build] was silently
+    // dropped, so this listed nothing at all (#100).
     fs::write(
         temp.path().join("stacy.toml"),
         r#"[project]
 name = "test"
 
-[tasks.build]
-scripts = ["main.do"]
+[scripts]
+build = "main.do"
 "#,
     )
     .unwrap();


### PR DESCRIPTION
`[run] log_dir` was parsed and reported by `stacy env` but nothing consumed it: logs were written next to the run, and `task`, `test` and `bench` never removed them, so a successful run left logs in the project root. A new `executor::log_policy` owns the log once a run is over — `--log FILE` wins, otherwise it is removed on success and kept on failure in `log_dir` — and every command that runs Stata applies it.

`stacy env` counted locked packages as installed without checking the cache; it now checks per entry and reports installed and missing counts in human, json and stata output.

Unknown keys in `stacy.toml` were dropped silently, so a dependency under `[dependencies]` instead of `[packages.dependencies]` vanished and `lock` reported success on zero packages; the config structs now reject unknown keys and name the offending one. A `local:` source installed whatever the directory contained regardless of the requested name; it now requires `<name>.ado` to be there.

Closes #98
Closes #99
Closes #100