### PR TITLE
fix: honor stacy.lock on install and run

### DIFF
--- a/docs/src/commands/install.md
+++ b/docs/src/commands/install.md
@@ -10,16 +10,22 @@ stacy install [OPTIONS]
 
 ## Description
 
-Installs packages defined in `stacy.lock` (or `stacy.toml` if no lockfile exists).
-This ensures reproducible environments by installing exact versions from the
-lockfile. Can also install individual packages directly from SSC or GitHub.
+Installs the packages `stacy.lock` pins, at the versions and checksums it records.
+
+`install` reads the lockfile; it never writes it. If a source no longer serves the
+pinned version, or serves different bytes under it, the install fails and
+`stacy.lock` is left untouched. Use `stacy update` to move a pin.
+
+SSC serves only the current revision of a package, so a pinned version that has
+left the package cache cannot be downloaded again. A cold-cache install of a
+superseded pin fails rather than installing a different version under it.
 
 ## Options
 
 | Option | Description |
 |--------|-------------|
 | `--frozen` | Fail if lockfile doesn't match stacy.toml |
-| `--no-verify` | Skip checksum verification |
+| `--no-verify` | Skip checksum verification (the version pin is still enforced) |
 | `--with` | Include dependency groups (comma-separated: dev, test) |
 
 ## Examples

--- a/docs/src/commands/install.md
+++ b/docs/src/commands/install.md
@@ -20,12 +20,16 @@ SSC serves only the current revision of a package, so a pinned version that has
 left the package cache cannot be downloaded again. A cold-cache install of a
 superseded pin fails rather than installing a different version under it.
 
+The version pin is checked where the package names its own version. A `.pkg`
+manifest with no `Distribution-Date` line names none, so for those packages the
+checksum alone decides whether the pin is satisfied.
+
 ## Options
 
 | Option | Description |
 |--------|-------------|
 | `--frozen` | Fail if lockfile doesn't match stacy.toml |
-| `--no-verify` | Skip checksum verification (the version pin is still enforced) |
+| `--no-verify` | Skip checksum verification (a version the source names is still checked) |
 | `--with` | Include dependency groups (comma-separated: dev, test) |
 
 ## Examples

--- a/docs/src/commands/run.md
+++ b/docs/src/commands/run.md
@@ -34,11 +34,11 @@ Multiple scripts can be run sequentially (default, fail-fast) or in parallel
 To check a quick result without a script file, use `stacy run -c 'display ...'`.
 
 In a project with a `stacy.lock`, run builds the ado-path from the lockfile and
-checks it against the package cache before starting Stata. Every locked package
-must be installed and must still hash to the checksum the lockfile records. A
-package that is missing, or that has been modified since it was installed, fails
-the run instead of executing. Every package in `stacy.lock` is on the ado-path,
-so dev and test dependencies must be installed too (`stacy install --with dev,test`).
+checks it against the package cache before starting Stata. A cached package that
+no longer hashes to the checksum the lockfile records fails the run instead of
+executing, as does a production package that is not installed at all. dev and
+test packages are only checked if they are installed, since `stacy install`
+installs the production group by default. `--no-verify` skips the check.
 
 ## Arguments
 
@@ -60,6 +60,7 @@ so dev and test dependencies must be installed too (`stacy install --with dev,te
 | `--force` | Force rebuild even if cached |
 | `-j, --jobs` | Max parallel jobs (default: CPU count) |
 | `--log` | Write the raw Stata log to this path |
+| `--no-verify` | Skip the check of the package cache against stacy.lock |
 | `-P, --parallel` | Run scripts in parallel |
 | `--profile` | Include execution metrics |
 | `-q, --quiet` | Suppress output |

--- a/docs/src/commands/run.md
+++ b/docs/src/commands/run.md
@@ -33,6 +33,13 @@ Multiple scripts can be run sequentially (default, fail-fast) or in parallel
 
 To check a quick result without a script file, use `stacy run -c 'display ...'`.
 
+In a project with a `stacy.lock`, run builds the ado-path from the lockfile and
+checks it against the package cache before starting Stata. Every locked package
+must be installed and must still hash to the checksum the lockfile records. A
+package that is missing, or that has been modified since it was installed, fails
+the run instead of executing. Every package in `stacy.lock` is on the ado-path,
+so dev and test dependencies must be installed too (`stacy install --with dev,test`).
+
 ## Arguments
 
 | Argument | Description |

--- a/docs/src/reference/lockfile.md
+++ b/docs/src/reference/lockfile.md
@@ -68,8 +68,12 @@ tag = "v6.12.3"
 The lockfile is an input to `stacy install` and `stacy run`, never an output of them:
 
 - **`stacy install` installs what the lockfile pins.** It does not re-resolve versions and it does not write `stacy.lock`. If the source no longer serves the pinned version, or serves different bytes under it, the install fails and the lockfile is left untouched. This holds with and without `--frozen`.
-- **`stacy run` checks the cache against the lockfile before it starts Stata.** If a locked package is missing from the cache, or its cached files no longer hash to the locked checksum, the run fails instead of executing.
+- **`stacy run` checks the cache against the lockfile before it starts Stata.** If a cached package no longer hashes to the locked checksum, or a production package is not installed at all, the run fails instead of executing.
 - **Only `stacy add`, `stacy update`, and `stacy lock` write `stacy.lock`.** Moving a pin is an explicit act.
+
+### Which packages `run` requires
+
+`stacy install` installs the production group by default, so that is the group `run` requires to be present: a locked production package that is not in the cache fails the run. dev and test packages are installed on request (`stacy install --with dev,test`), so `run` does not require them — but it does check them against their locked checksums when they are installed, since every locked package is on the ado-path.
 
 ### A pinned version can become unfetchable
 
@@ -86,6 +90,8 @@ estout: stacy.lock pins version 20240315, but SSC serves 20260413
 
 This is a real limit of SSC, not something stacy can work around. The choice is to fail loudly or to run a different package than the one you locked; stacy fails.
 
+The version pin is only enforced where the package names its own version. A `.pkg` manifest without a `Distribution-Date` line names none — `stacy add` records the date it fetched the package, which says nothing about the contents — so for those packages the checksum decides whether the pin is satisfied. A cold-cache install of such a package succeeds as long as the bytes still hash to the locked checksum, whatever the date in the lockfile says.
+
 ## How Checksums Work
 
 Checksums verify that the installed package matches exactly what was recorded:
@@ -100,7 +106,9 @@ The checksum covers all `.ado` and `.sthlp` files in the package, sorted and con
 - SSC updates that changed the package
 - Manual modifications to cached files
 
-Checksums are checked by `stacy install` and again by `stacy run` before every run. Verification on `run` is always on: it reads and hashes the locked packages, which costs milliseconds against a Stata startup measured in seconds, and a default that silently runs modified code would not be a reproducibility guarantee.
+Checksums are checked by `stacy install` and again by `stacy run` before every run. Verification on `run` is on by default: it reads and hashes the locked packages, which costs milliseconds against a Stata startup measured in seconds, and a default that silently runs modified code would not be a reproducibility guarantee.
+
+`--no-verify` turns checksum verification off. It applies to both commands, and it has to: `stacy install --no-verify` caches whatever the source served, which by definition does not match the locked checksum, so `stacy run` on that cache needs `--no-verify` too. Prefer `stacy update <package>` to re-lock, and expect your results to change.
 
 ## Fields Reference
 
@@ -187,14 +195,14 @@ If the re-download also mismatches, the source changed the package without chang
 
 ### "The package cache does not match stacy.lock"
 
-`stacy run` reports this when a locked package is missing from the cache or has been modified since it was installed:
+`stacy run` reports this when a locked production package is missing from the cache, or when any locked package has been modified since it was installed:
 
 ```bash
 stacy install                    # Install the locked packages
-stacy install --with dev,test    # ...including dev and test groups
+stacy cache packages clean       # ...or clear a modified cache first
 ```
 
-Every package in `stacy.lock` is on the ado-path of every run, so all of them must be installed — including dev and test dependencies.
+A cached package that no longer hashes to its locked checksum is reported as modified whatever group it is in, since every locked package is on the ado-path.
 
 ### Merge conflicts in lockfile
 

--- a/docs/src/reference/lockfile.md
+++ b/docs/src/reference/lockfile.md
@@ -65,9 +65,10 @@ tag = "v6.12.3"
 
 ## What the lockfile guarantees
 
-The lockfile is an input to `stacy install`, never an output of it:
+The lockfile is an input to `stacy install` and `stacy run`, never an output of them:
 
 - **`stacy install` installs what the lockfile pins.** It does not re-resolve versions and it does not write `stacy.lock`. If the source no longer serves the pinned version, or serves different bytes under it, the install fails and the lockfile is left untouched. This holds with and without `--frozen`.
+- **`stacy run` checks the cache against the lockfile before it starts Stata.** If a locked package is missing from the cache, or its cached files no longer hash to the locked checksum, the run fails instead of executing.
 - **Only `stacy add`, `stacy update`, and `stacy lock` write `stacy.lock`.** Moving a pin is an explicit act.
 
 ### A pinned version can become unfetchable
@@ -99,7 +100,7 @@ The checksum covers all `.ado` and `.sthlp` files in the package, sorted and con
 - SSC updates that changed the package
 - Manual modifications to cached files
 
-If checksums don't match, `stacy install` fails with an error explaining the mismatch.
+Checksums are checked by `stacy install` and again by `stacy run` before every run. Verification on `run` is always on: it reads and hashes the locked packages, which costs milliseconds against a Stata startup measured in seconds, and a default that silently runs modified code would not be a reproducibility guarantee.
 
 ## Fields Reference
 
@@ -183,6 +184,17 @@ stacy install               # Re-download
 ```
 
 If the re-download also mismatches, the source changed the package without changing its version. Run `stacy update <package>` to re-lock it, and expect your results to change.
+
+### "The package cache does not match stacy.lock"
+
+`stacy run` reports this when a locked package is missing from the cache or has been modified since it was installed:
+
+```bash
+stacy install                    # Install the locked packages
+stacy install --with dev,test    # ...including dev and test groups
+```
+
+Every package in `stacy.lock` is on the ado-path of every run, so all of them must be installed — including dev and test dependencies.
 
 ### Merge conflicts in lockfile
 

--- a/docs/src/reference/lockfile.md
+++ b/docs/src/reference/lockfile.md
@@ -63,6 +63,28 @@ repo = "sergiocorreia/reghdfe"
 tag = "v6.12.3"
 ```
 
+## What the lockfile guarantees
+
+The lockfile is an input to `stacy install`, never an output of it:
+
+- **`stacy install` installs what the lockfile pins.** It does not re-resolve versions and it does not write `stacy.lock`. If the source no longer serves the pinned version, or serves different bytes under it, the install fails and the lockfile is left untouched. This holds with and without `--frozen`.
+- **Only `stacy add`, `stacy update`, and `stacy lock` write `stacy.lock`.** Moving a pin is an explicit act.
+
+### A pinned version can become unfetchable
+
+SSC serves only the current revision of a package. Once a pinned version leaves your package cache, it cannot be downloaded again. A cold-cache install of a superseded pin therefore fails:
+
+```
+estout: stacy.lock pins version 20240315, but SSC serves 20260413
+  SSC serves only the current revision of a package, so once a pinned version
+  leaves the package cache it cannot be downloaded again.
+  hint: run `stacy update estout` to move the pin to 20260413 (your results may
+        change), or restore 20240315 into the package cache from a machine that
+        still has it.
+```
+
+This is a real limit of SSC, not something stacy can work around. The choice is to fail loudly or to run a different package than the one you locked; stacy fails.
+
 ## How Checksums Work
 
 Checksums verify that the installed package matches exactly what was recorded:
@@ -159,6 +181,8 @@ The cached package differs from what's in the lockfile:
 stacy cache packages clean  # Clear cache
 stacy install               # Re-download
 ```
+
+If the re-download also mismatches, the source changed the package without changing its version. Run `stacy update <package>` to re-lock it, and expect your results to change.
 
 ### Merge conflicts in lockfile
 

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -73,11 +73,11 @@ Multiple scripts can be run sequentially (default, fail-fast) or in parallel
 To check a quick result without a script file, use `stacy run -c 'display ...'`.
 
 In a project with a `stacy.lock`, run builds the ado-path from the lockfile and
-checks it against the package cache before starting Stata. Every locked package
-must be installed and must still hash to the checksum the lockfile records. A
-package that is missing, or that has been modified since it was installed, fails
-the run instead of executing. Every package in `stacy.lock` is on the ado-path,
-so dev and test dependencies must be installed too (`stacy install --with dev,test`).
+checks it against the package cache before starting Stata. A cached package that
+no longer hashes to the checksum the lockfile records fails the run instead of
+executing, as does a production package that is not installed at all. dev and
+test packages are only checked if they are installed, since `stacy install`
+installs the production group by default. `--no-verify` skips the check.
 """
 see_also = ["bench", "task", "../reference/exit-codes.md", "../guides/build-integration.md"]
 
@@ -91,6 +91,7 @@ verbose = { type = "bool", description = "Extra output", stata_option = "Verbose
 json = { type = "bool", description = "JSON output (internal)" }
 profile = { type = "bool", description = "Include execution metrics", stata_option = "Profile" }
 allow_global = { type = "bool", long = "allow-global", description = "Allow globally installed packages", stata_option = "AllowGlobal" }
+no_verify = { type = "bool", long = "no-verify", description = "Skip the check of the package cache against stacy.lock", stata_option = "NOVerify" }
 trace = { type = "int", long = "trace", description = "Enable execution tracing at given depth", stata_option = "Trace(integer)" }
 timeout = { type = "int", long = "timeout", description = "Kill script if it exceeds this many seconds", stata_option = "Timeout(integer)" }
 parallel = { type = "bool", short = "P", description = "Run scripts in parallel", stata_option = "PARALLEL" }
@@ -299,13 +300,17 @@ pinned version, or serves different bytes under it, the install fails and
 SSC serves only the current revision of a package, so a pinned version that has
 left the package cache cannot be downloaded again. A cold-cache install of a
 superseded pin fails rather than installing a different version under it.
+
+The version pin is checked where the package names its own version. A `.pkg`
+manifest with no `Distribution-Date` line names none, so for those packages the
+checksum alone decides whether the pin is satisfied.
 """
 see_also = ["add", "lock", "list"]
 
 [commands.install.args]
 with = { type = "string", long = "with", description = "Include dependency groups (comma-separated: dev, test)", stata_option = "With(string)" }
 frozen = { type = "bool", long = "frozen", description = "Fail if lockfile doesn't match stacy.toml", stata_option = "FROZEN" }
-no_verify = { type = "bool", long = "no-verify", description = "Skip checksum verification (the version pin is still enforced)", stata_option = "NOVerify" }
+no_verify = { type = "bool", long = "no-verify", description = "Skip checksum verification (a version the source names is still checked)", stata_option = "NOVerify" }
 json = { type = "bool", description = "JSON output (internal)" }
 
 [commands.install.returns]

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -71,6 +71,13 @@ Multiple scripts can be run sequentially (default, fail-fast) or in parallel
 (`--parallel`). Parallel mode runs all scripts regardless of failures.
 
 To check a quick result without a script file, use `stacy run -c 'display ...'`.
+
+In a project with a `stacy.lock`, run builds the ado-path from the lockfile and
+checks it against the package cache before starting Stata. Every locked package
+must be installed and must still hash to the checksum the lockfile records. A
+package that is missing, or that has been modified since it was installed, fails
+the run instead of executing. Every package in `stacy.lock` is on the ado-path,
+so dev and test dependencies must be installed too (`stacy install --with dev,test`).
 """
 see_also = ["bench", "task", "../reference/exit-codes.md", "../guides/build-integration.md"]
 

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -283,16 +283,22 @@ description = "Install packages from lockfile or SSC/GitHub"
 category = "packages"
 stata_command = "stacy_install"
 long_description = """
-Installs packages defined in `stacy.lock` (or `stacy.toml` if no lockfile exists).
-This ensures reproducible environments by installing exact versions from the
-lockfile. Can also install individual packages directly from SSC or GitHub.
+Installs the packages `stacy.lock` pins, at the versions and checksums it records.
+
+`install` reads the lockfile; it never writes it. If a source no longer serves the
+pinned version, or serves different bytes under it, the install fails and
+`stacy.lock` is left untouched. Use `stacy update` to move a pin.
+
+SSC serves only the current revision of a package, so a pinned version that has
+left the package cache cannot be downloaded again. A cold-cache install of a
+superseded pin fails rather than installing a different version under it.
 """
 see_also = ["add", "lock", "list"]
 
 [commands.install.args]
 with = { type = "string", long = "with", description = "Include dependency groups (comma-separated: dev, test)", stata_option = "With(string)" }
 frozen = { type = "bool", long = "frozen", description = "Fail if lockfile doesn't match stacy.toml", stata_option = "FROZEN" }
-no_verify = { type = "bool", long = "no-verify", description = "Skip checksum verification", stata_option = "NOVerify" }
+no_verify = { type = "bool", long = "no-verify", description = "Skip checksum verification (the version pin is still enforced)", stata_option = "NOVerify" }
 json = { type = "bool", description = "JSON output (internal)" }
 
 [commands.install.returns]

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -6,10 +6,10 @@ use crate::cli::output_format::OutputFormat;
 use crate::cli::output_types::{CommandOutput, InstallOutput};
 use crate::error::{Error, Result};
 use crate::packages::global_cache;
-use crate::packages::installer::{install_package, install_package_github, is_package_installed};
+use crate::packages::installer::{install_locked, is_package_installed};
 use crate::packages::lockfile::{check_version_mismatch, load_lockfile, verify_lockfile_sync};
 use crate::project::config::load_config;
-use crate::project::{PackageSource, Project};
+use crate::project::Project;
 use clap::Args;
 use std::collections::HashSet;
 use std::path::Path;
@@ -22,7 +22,7 @@ Examples:
   stacy install --no-verify               Skip checksum verification
   stacy install --frozen                  Fail if lockfile is out of sync (for CI)")]
 pub struct InstallArgs {
-    /// Skip checksum verification
+    /// Skip checksum verification (the version pin is still enforced)
     #[arg(long)]
     pub no_verify: bool,
 
@@ -195,8 +195,8 @@ fn install_from_lockfile(args: &InstallArgs) -> Result<()> {
         .filter(|r| matches!(r.action, SyncAction::Skipped(_)))
         .count() as i32;
 
-    // Compute checksum failures *before* emitting output, so the Stata/JSON
-    // output reflects the real outcome instead of a stale "success".
+    // Compute failures *before* emitting output, so the Stata/JSON output
+    // reflects the real outcome instead of a stale "success".
     let failed_names: Vec<&str> = if verify {
         results
             .iter()
@@ -206,14 +206,29 @@ fn install_from_lockfile(args: &InstallArgs) -> Result<()> {
     } else {
         Vec::new()
     };
-    let failed_count = failed_names.len() as i32;
 
-    let error_message: Option<String> = if failed_count > 0 {
-        Some(format!(
+    // Packages the source served differently from what stacy.lock pins.
+    let mismatches: Vec<&str> = results
+        .iter()
+        .filter_map(|r| match &r.action {
+            SyncAction::Mismatched(msg) => Some(msg.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    let failed_count = (failed_names.len() + mismatches.len()) as i32;
+
+    let mut problems: Vec<String> = mismatches.iter().map(|m| m.to_string()).collect();
+    if !failed_names.is_empty() {
+        problems.push(format!(
             "{} package(s) failed checksum verification: {}. Use --no-verify to skip.",
-            failed_count,
+            failed_names.len(),
             failed_names.join(", ")
-        ))
+        ));
+    }
+
+    let error_message: Option<String> = if !problems.is_empty() {
+        Some(problems.join("\n\n"))
     } else if skipped_count > 0 && installed_count == 0 {
         Some(format!(
             "{} package(s) skipped, none installed",
@@ -246,7 +261,9 @@ fn install_from_lockfile(args: &InstallArgs) -> Result<()> {
     }
 
     if failed_count > 0 {
-        return Err(Error::Config(error_message.unwrap()));
+        // Both kinds of failure — a source that disagrees with the pin, and a
+        // cached package that no longer hashes to it — are integrity failures.
+        return Err(Error::Integrity(error_message.unwrap()));
     }
 
     Ok(())
@@ -269,7 +286,10 @@ struct SyncedPackage {
 enum SyncAction {
     Installed,
     AlreadyInstalled,
+    /// Could not be fetched (offline, 404, unreachable source)
     Skipped(String),
+    /// Fetched, but not what stacy.lock pins — carries the explanation
+    Mismatched(String),
 }
 
 fn sync_package(
@@ -295,159 +315,41 @@ fn sync_package(
         });
     }
 
-    // Install based on source
-    let group = entry.group.as_str();
-    match &entry.source {
-        PackageSource::SSC { name: pkg_name } => {
-            match install_package(pkg_name, "ssc", project_root, group) {
-                Ok(result) => {
-                    // Warn if downloaded from mirror and checksum differs from lockfile
-                    if result.from_mirror {
-                        if let Some(expected) = &entry.checksum {
-                            let expected = expected.strip_prefix("sha256:").unwrap_or(expected);
-                            if result.package_checksum != expected {
-                                use colored::Colorize;
-                                eprintln!(
-                                    "{} {} downloaded from mirror; checksum differs from lockfile",
-                                    "warning:".yellow().bold(),
-                                    name,
-                                );
-                                eprintln!(
-                                    "    hint: SSC primary may have updated. Run `stacy update {}` to refresh.",
-                                    name,
-                                );
-                            }
-                        }
-                    }
+    // Cold cache: fetch exactly what the lockfile pins. install_locked leaves
+    // stacy.lock alone and fails if the source no longer serves that version
+    // or those bytes — install materializes the lockfile, it never rewrites it.
+    let action = match install_locked(name, entry, project_root, verify) {
+        Ok(_) => SyncAction::Installed,
+        // The source disagrees with the pin: a hard failure, not a skip.
+        Err(Error::Integrity(msg)) => SyncAction::Mismatched(msg),
+        // Transient: unreachable source, 404, IO. Reported, doesn't abort.
+        Err(e) => SyncAction::Skipped(e.to_string()),
+    };
 
-                    let checksum_ok = if verify {
-                        verify_package_checksum(name, entry)
-                    } else {
-                        None
-                    };
+    let checksum_ok = match (verify, &action) {
+        (true, SyncAction::Installed) => verify_package_checksum(name, entry),
+        _ => None,
+    };
 
-                    Ok(SyncedPackage {
-                        name: name.to_string(),
-                        version: entry.version.clone(),
-                        action: SyncAction::Installed,
-                        checksum_ok,
-                    })
-                }
-                Err(e) => Ok(SyncedPackage {
-                    name: name.to_string(),
-                    version: entry.version.clone(),
-                    action: SyncAction::Skipped(e.to_string()),
-                    checksum_ok: None,
-                }),
-            }
-        }
-        PackageSource::GitHub { repo, tag, commit } => {
-            // Parse repo into user/repo
-            let parts: Vec<&str> = repo.split('/').collect();
-            if parts.len() == 2 {
-                // Use commit SHA for downloads when available (exact reproducibility)
-                let git_ref = commit.as_deref().unwrap_or(tag.as_str());
-                match install_package_github(
-                    name,
-                    parts[0],
-                    parts[1],
-                    Some(git_ref),
-                    project_root,
-                    group,
-                ) {
-                    Ok(_) => {
-                        let checksum_ok = if verify {
-                            verify_package_checksum(name, entry)
-                        } else {
-                            None
-                        };
-
-                        Ok(SyncedPackage {
-                            name: name.to_string(),
-                            version: entry.version.clone(),
-                            action: SyncAction::Installed,
-                            checksum_ok,
-                        })
-                    }
-                    Err(e) => Ok(SyncedPackage {
-                        name: name.to_string(),
-                        version: entry.version.clone(),
-                        action: SyncAction::Skipped(e.to_string()),
-                        checksum_ok: None,
-                    }),
-                }
-            } else {
-                Ok(SyncedPackage {
-                    name: name.to_string(),
-                    version: entry.version.clone(),
-                    action: SyncAction::Skipped(format!("Invalid repo format: {}", repo)),
-                    checksum_ok: None,
-                })
-            }
-        }
-        PackageSource::Local { path } => {
-            match crate::packages::installer::install_from_local(name, path, project_root, group) {
-                Ok(_) => {
-                    let checksum_ok = if verify {
-                        verify_package_checksum(name, entry)
-                    } else {
-                        None
-                    };
-                    Ok(SyncedPackage {
-                        name: name.to_string(),
-                        version: entry.version.clone(),
-                        action: SyncAction::Installed,
-                        checksum_ok,
-                    })
-                }
-                Err(e) => Ok(SyncedPackage {
-                    name: name.to_string(),
-                    version: entry.version.clone(),
-                    action: SyncAction::Skipped(e.to_string()),
-                    checksum_ok: None,
-                }),
-            }
-        }
-        PackageSource::Net { url } => {
-            match crate::packages::installer::install_from_net(name, url, project_root, group) {
-                Ok(result) => {
-                    let checksum_ok = if verify {
-                        verify_package_checksum(name, entry)
-                    } else {
-                        None
-                    };
-                    Ok(SyncedPackage {
-                        name: name.to_string(),
-                        version: result.version,
-                        action: SyncAction::Installed,
-                        checksum_ok,
-                    })
-                }
-                Err(e) => Ok(SyncedPackage {
-                    name: name.to_string(),
-                    version: entry.version.clone(),
-                    action: SyncAction::Skipped(e.to_string()),
-                    checksum_ok: None,
-                }),
-            }
-        }
-    }
+    Ok(SyncedPackage {
+        name: name.to_string(),
+        version: entry.version.clone(),
+        action,
+        checksum_ok,
+    })
 }
 
 fn verify_package_checksum(name: &str, entry: &crate::project::PackageEntry) -> Option<bool> {
-    // Get expected checksum from lockfile
-    let expected = entry.checksum.as_ref()?;
-    let expected = expected.strip_prefix("sha256:").unwrap_or(expected);
+    // Nothing recorded to verify against (pre-checksum lockfile)
+    entry.checksum.as_ref()?;
 
-    // Find the package in the global cache
-    let cache_dir = global_cache::package_path(name, &entry.version).ok()?;
-    if !cache_dir.exists() {
-        return Some(false);
+    // Same comparison `stacy run` makes before every run
+    match global_cache::check_cached_package(name, entry) {
+        global_cache::CacheState::Verified => Some(true),
+        global_cache::CacheState::Missing | global_cache::CacheState::Modified => Some(false),
+        // Unreachable: the entry has a checksum, so it is comparable
+        global_cache::CacheState::Unverifiable => None,
     }
-
-    // Same hash `stacy add` records at download time
-    let actual = global_cache::hash_package_dir(&cache_dir)?;
-    Some(actual == expected)
 }
 
 fn print_sync_json_output(results: &[SyncedPackage], summary: &InstallOutput) {
@@ -463,9 +365,10 @@ fn print_sync_json_output(results: &[SyncedPackage], summary: &InstallOutput) {
                     SyncAction::Installed => "installed",
                     SyncAction::AlreadyInstalled => "already_installed",
                     SyncAction::Skipped(_) => "skipped",
+                    SyncAction::Mismatched(_) => "mismatched",
                 },
                 "error": match &r.action {
-                    SyncAction::Skipped(e) => Some(e.as_str()),
+                    SyncAction::Skipped(e) | SyncAction::Mismatched(e) => Some(e.as_str()),
                     _ => None,
                 },
                 "checksum_verified": r.checksum_ok,
@@ -493,6 +396,7 @@ fn print_sync_human_output(results: &[SyncedPackage]) {
     let mut installed = Vec::new();
     let mut already = Vec::new();
     let mut skipped = Vec::new();
+    let mut mismatched = Vec::new();
 
     for result in results {
         match &result.action {
@@ -510,13 +414,18 @@ fn print_sync_human_output(results: &[SyncedPackage]) {
                 );
                 skipped.push(&result.name);
             }
+            // The message is surfaced by the error this run exits with —
+            // printing it here too would just duplicate it.
+            SyncAction::Mismatched(_) => {
+                mismatched.push(&result.name);
+            }
         }
     }
 
     println!();
 
     // Summary
-    if installed.is_empty() && skipped.is_empty() {
+    if installed.is_empty() && skipped.is_empty() && mismatched.is_empty() {
         println!("All {} packages already installed.", already.len());
     } else {
         let mut summary = Vec::new();
@@ -528,6 +437,9 @@ fn print_sync_human_output(results: &[SyncedPackage]) {
         }
         if !skipped.is_empty() {
             summary.push(format!("{} skipped", skipped.len()));
+        }
+        if !mismatched.is_empty() {
+            summary.push(format!("{} failed", mismatched.len()));
         }
         println!("Install complete: {}", summary.join(", "));
     }
@@ -565,7 +477,7 @@ fn print_sync_human_output(results: &[SyncedPackage]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::packages::ssc::{calculate_combined_checksum, calculate_sha256};
+    use crate::packages::ssc::calculate_combined_checksum;
     use serial_test::serial;
     use tempfile::TempDir;
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -239,6 +239,12 @@ pub struct RunArgs {
     #[arg(long)]
     pub allow_global: bool,
 
+    /// Skip the check of the package cache against stacy.lock.
+    /// By default a locked package that is missing or has been modified since
+    /// it was installed fails the run. Counterpart of `stacy install --no-verify`.
+    #[arg(long)]
+    pub no_verify: bool,
+
     /// Enable Stata execution tracing at given depth (set trace on, set tracedepth N)
     #[arg(long, value_name = "DEPTH", conflicts_with_all = ["quiet", "parallel"])]
     pub trace: Option<u32>,
@@ -472,7 +478,8 @@ fn execute_inline(args: &RunArgs) -> Result<()> {
     let executor = StataExecutor::try_new(engine_ref, verbosity)?
         .with_allow_global(args.allow_global)
         .with_local_ado_paths(local_ado_paths)
-        .with_timeout(args.timeout.map(Duration::from_secs));
+        .with_timeout(args.timeout.map(Duration::from_secs))
+        .with_verify_packages(!args.no_verify);
     let project_root = project.as_ref().map(|p| p.root.as_path());
 
     if let Some(ref mut m) = metrics {
@@ -718,7 +725,8 @@ fn execute_single(script_path: &Path, args: &RunArgs) -> Result<()> {
     let executor = StataExecutor::try_new(engine_ref, verbosity)?
         .with_allow_global(args.allow_global)
         .with_local_ado_paths(local_ado_paths)
-        .with_timeout(args.timeout.map(Duration::from_secs));
+        .with_timeout(args.timeout.map(Duration::from_secs))
+        .with_verify_packages(!args.no_verify);
 
     if let Some(ref mut m) = metrics {
         m.end_phase("setup");
@@ -965,7 +973,8 @@ fn execute_sequential(args: &RunArgs) -> Result<()> {
     let executor = StataExecutor::try_new(engine_ref, verbosity)?
         .with_allow_global(args.allow_global)
         .with_local_ado_paths(local_ado_paths)
-        .with_timeout(args.timeout.map(Duration::from_secs));
+        .with_timeout(args.timeout.map(Duration::from_secs))
+        .with_verify_packages(!args.no_verify);
     let project_root = project.as_ref().map(|p| p.root.as_path());
 
     let start = Instant::now();
@@ -1132,7 +1141,8 @@ fn execute_parallel(args: &RunArgs) -> Result<()> {
     let executor = StataExecutor::try_new(engine_ref, verbosity)?
         .with_allow_global(args.allow_global)
         .with_local_ado_paths(local_ado_paths)
-        .with_timeout(args.timeout.map(Duration::from_secs));
+        .with_timeout(args.timeout.map(Duration::from_secs))
+        .with_verify_packages(!args.no_verify);
     let project_root = project.as_ref().map(|p| p.root.as_path());
 
     if !args.quiet && format == OutputFormat::Human {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -27,6 +27,13 @@ pub enum Error {
     #[error("Network error: {0}")]
     Network(String),
 
+    /// A package does not match what stacy.lock records for it: the source
+    /// serves a different version or different bytes, or the cached copy has
+    /// been modified. Distinct from `Config` and `Network` so callers can tell
+    /// "the lockfile is not being honoured" from "the download failed".
+    #[error("{0}")]
+    Integrity(String),
+
     #[error("Project not found. Run `stacy init` to create a project.")]
     ProjectNotFound,
 }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -32,6 +32,9 @@ pub struct StataExecutor {
     local_ado_paths: Vec<PathBuf>,
     /// Kill the Stata process if it exceeds this duration.
     timeout: Option<Duration>,
+    /// Check the locked packages against the package cache before starting Stata.
+    /// Default is true; `stacy run --no-verify` turns it off.
+    verify_packages: bool,
 }
 
 impl Default for StataExecutor {
@@ -76,6 +79,7 @@ impl StataExecutor {
             allow_global: false,
             local_ado_paths: Vec::new(),
             timeout: None,
+            verify_packages: true,
         })
     }
 
@@ -88,6 +92,7 @@ impl StataExecutor {
             allow_global: false,
             local_ado_paths: Vec::new(),
             timeout: None,
+            verify_packages: true,
         }
     }
 
@@ -112,6 +117,12 @@ impl StataExecutor {
     /// Set execution timeout (SIGTERM → 5s grace → SIGKILL)
     pub fn with_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.timeout = timeout;
+        self
+    }
+
+    /// Check the locked packages against the package cache before starting Stata
+    pub fn with_verify_packages(mut self, verify: bool) -> Self {
+        self.verify_packages = verify;
         self
     }
 
@@ -183,6 +194,7 @@ impl StataExecutor {
             options = options.with_args(args);
         }
         options = options.with_allow_global(self.allow_global);
+        options = options.with_verify_packages(self.verify_packages);
         if !self.local_ado_paths.is_empty() {
             options = options.with_local_ado_paths(self.local_ado_paths.clone());
         }

--- a/src/executor/runner.rs
+++ b/src/executor/runner.rs
@@ -61,6 +61,9 @@ pub struct RunOptions<'a> {
     pub working_dir: Option<&'a Path>,
     /// Local ado directories to prepend to S_ADO (resolved to absolute paths).
     pub local_ado_paths: Vec<PathBuf>,
+    /// Check the locked packages against the package cache before starting
+    /// Stata. Default is true; `stacy run --no-verify` turns it off.
+    pub verify_packages: bool,
     /// Precomputed path where Stata will write the log file. When set, the
     /// runner uses this directly instead of deriving it from the script's stem.
     /// Callers that pass a wrapper script (see `executor::run_paths`) must set
@@ -79,6 +82,7 @@ impl<'a> RunOptions<'a> {
             allow_global: false,
             working_dir: None,
             local_ado_paths: Vec::new(),
+            verify_packages: true,
             log_file: None,
         }
     }
@@ -110,6 +114,11 @@ impl<'a> RunOptions<'a> {
 
     pub fn with_local_ado_paths(mut self, paths: Vec<PathBuf>) -> Self {
         self.local_ado_paths = paths;
+        self
+    }
+
+    pub fn with_verify_packages(mut self, verify: bool) -> Self {
+        self.verify_packages = verify;
         self
     }
 
@@ -179,8 +188,12 @@ pub fn run_stata(script: &Path, options: RunOptions) -> Result<RunResult> {
         if let Some(lockfile) = &lockfile_opt {
             // The lockfile only guarantees anything if the cache still holds
             // what it names. Check before Stata starts, so a modified or
-            // absent package fails loudly instead of running (#97).
-            global_cache::verify_lockfile_against_cache(lockfile)?;
+            // absent package fails loudly instead of running (#97). `--no-verify`
+            // opts out, and is the counterpart of `stacy install --no-verify`:
+            // a cache installed without checking will not match the lockfile.
+            if options.verify_packages {
+                global_cache::verify_lockfile_against_cache(lockfile)?;
+            }
 
             let s_ado = global_cache::build_s_ado(
                 lockfile,

--- a/src/executor/runner.rs
+++ b/src/executor/runner.rs
@@ -177,6 +177,11 @@ pub fn run_stata(script: &Path, options: RunOptions) -> Result<RunResult> {
         let has_local_paths = !options.local_ado_paths.is_empty();
 
         if let Some(lockfile) = &lockfile_opt {
+            // The lockfile only guarantees anything if the cache still holds
+            // what it names. Check before Stata starts, so a modified or
+            // absent package fails loudly instead of running (#97).
+            global_cache::verify_lockfile_against_cache(lockfile)?;
+
             let s_ado = global_cache::build_s_ado(
                 lockfile,
                 options.allow_global,

--- a/src/packages/global_cache.rs
+++ b/src/packages/global_cache.rs
@@ -426,17 +426,26 @@ pub fn check_cached_package(name: &str, entry: &PackageEntry) -> CacheState {
     }
 }
 
-/// Check every locked package against the global cache.
+/// Check the locked packages against the global cache.
 ///
 /// `stacy run` calls this before it starts Stata, so the packages on S_ADO are
-/// the ones the lockfile names: present, and byte-for-byte what was locked.
-/// Without it a modified or absent cached package runs silently (#97).
+/// the ones the lockfile names: byte-for-byte what was locked. Without it a
+/// modified or absent cached package runs silently (#97).
 ///
-/// This is on the hot path of every run, and it is always on rather than gated
-/// behind a strict mode — a default that silently runs modified code is not a
-/// reproducibility guarantee. The cost is one read plus a SHA256 of each locked
-/// package's files, which for the sizes SSC and GitHub packages actually reach
-/// is a few milliseconds against a Stata startup measured in seconds.
+/// A cached package is checked against its locked checksum whatever group it is
+/// in, since every locked package is on the ado-path. An *absent* package is an
+/// error only in the production group: `stacy install` installs that group by
+/// default, so a missing production package means the project was never
+/// installed. dev and test packages are installed on request
+/// (`stacy install --with dev,test`), and a project that never installs them
+/// must still be able to run.
+///
+/// This is on the hot path of every run, and it is on by default rather than
+/// gated behind a strict mode — a default that silently runs modified code is
+/// not a reproducibility guarantee. `stacy run --no-verify` turns it off. The
+/// cost is one read plus a SHA256 of each locked package's files, which for the
+/// sizes SSC and GitHub packages actually reach is a few milliseconds against a
+/// Stata startup measured in seconds.
 pub fn verify_lockfile_against_cache(lockfile: &Lockfile) -> Result<()> {
     let mut missing: Vec<&str> = Vec::new();
     let mut modified: Vec<&str> = Vec::new();
@@ -444,7 +453,11 @@ pub fn verify_lockfile_against_cache(lockfile: &Lockfile) -> Result<()> {
     for (name, entry) in &lockfile.packages {
         match check_cached_package(name, entry) {
             CacheState::Verified | CacheState::Unverifiable => {}
-            CacheState::Missing => missing.push(name),
+            CacheState::Missing => {
+                if entry.group == "production" {
+                    missing.push(name);
+                }
+            }
             CacheState::Modified => modified.push(name),
         }
     }
@@ -469,7 +482,7 @@ pub fn verify_lockfile_against_cache(lockfile: &Lockfile) -> Result<()> {
     if !missing.is_empty() {
         msg.push_str(&format!(
             "  not installed: {}\n  \
-             hint: run `stacy install` (add `--with dev,test` for those groups).\n",
+             hint: run `stacy install`.\n",
             missing.join(", ")
         ));
     }

--- a/src/packages/global_cache.rs
+++ b/src/packages/global_cache.rs
@@ -426,6 +426,57 @@ pub fn check_cached_package(name: &str, entry: &PackageEntry) -> CacheState {
     }
 }
 
+/// Check every locked package against the global cache.
+///
+/// `stacy run` calls this before it starts Stata, so the packages on S_ADO are
+/// the ones the lockfile names: present, and byte-for-byte what was locked.
+/// Without it a modified or absent cached package runs silently (#97).
+///
+/// This is on the hot path of every run, and it is always on rather than gated
+/// behind a strict mode — a default that silently runs modified code is not a
+/// reproducibility guarantee. The cost is one read plus a SHA256 of each locked
+/// package's files, which for the sizes SSC and GitHub packages actually reach
+/// is a few milliseconds against a Stata startup measured in seconds.
+pub fn verify_lockfile_against_cache(lockfile: &Lockfile) -> Result<()> {
+    let mut missing: Vec<&str> = Vec::new();
+    let mut modified: Vec<&str> = Vec::new();
+
+    for (name, entry) in &lockfile.packages {
+        match check_cached_package(name, entry) {
+            CacheState::Verified | CacheState::Unverifiable => {}
+            CacheState::Missing => missing.push(name),
+            CacheState::Modified => modified.push(name),
+        }
+    }
+
+    if missing.is_empty() && modified.is_empty() {
+        return Ok(());
+    }
+
+    missing.sort_unstable();
+    modified.sort_unstable();
+
+    let mut msg = String::from("the package cache does not match stacy.lock\n");
+
+    if !modified.is_empty() {
+        msg.push_str(&format!(
+            "  modified since install: {}\n  \
+             These cached files no longer hash to the checksum stacy.lock records.\n  \
+             hint: run `stacy cache packages clean`, then `stacy install` to re-download them.\n",
+            modified.join(", ")
+        ));
+    }
+    if !missing.is_empty() {
+        msg.push_str(&format!(
+            "  not installed: {}\n  \
+             hint: run `stacy install` (add `--with dev,test` for those groups).\n",
+            missing.join(", ")
+        ));
+    }
+
+    Err(Error::Integrity(msg.trim_end().to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/packages/global_cache.rs
+++ b/src/packages/global_cache.rs
@@ -7,7 +7,7 @@
 //! to the cached packages.
 
 use crate::error::{Error, Result};
-use crate::project::Lockfile;
+use crate::project::{Lockfile, PackageEntry};
 use std::path::PathBuf;
 
 /// Get the global package cache directory.
@@ -389,6 +389,41 @@ pub fn hash_package_dir(dir: &std::path::Path) -> Option<String> {
         return None;
     }
     Some(calculate_combined_checksum(&checksums))
+}
+
+/// How a locked package compares to what is actually in the global cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheState {
+    /// Cached files hash to the checksum recorded in the lockfile.
+    Verified,
+    /// Cached, but the lockfile records no checksum to compare against.
+    Unverifiable,
+    /// Not in the cache, or the cache directory is empty.
+    Missing,
+    /// Cached, but the files hash to something other than the locked checksum.
+    Modified,
+}
+
+/// Compare one locked package against the global cache.
+pub fn check_cached_package(name: &str, entry: &PackageEntry) -> CacheState {
+    if !is_cached(name, &entry.version).unwrap_or(false) {
+        return CacheState::Missing;
+    }
+
+    let Some(expected) = entry.checksum.as_deref() else {
+        return CacheState::Unverifiable;
+    };
+    let expected = expected.strip_prefix("sha256:").unwrap_or(expected);
+
+    let Ok(dir) = package_path(name, &entry.version) else {
+        return CacheState::Missing;
+    };
+
+    match hash_package_dir(&dir) {
+        Some(actual) if actual == expected => CacheState::Verified,
+        Some(_) => CacheState::Modified,
+        None => CacheState::Missing,
+    }
 }
 
 #[cfg(test)]

--- a/src/packages/installer.rs
+++ b/src/packages/installer.rs
@@ -42,8 +42,17 @@ pub struct InstallResult {
 /// fetched as the new pin, while `install` checks what it fetched against the
 /// pin that already exists.
 struct ResolvedPackage {
-    /// Version derived from the manifest (or a source-specific fallback)
-    version: String,
+    /// The version the package itself names: the manifest's `Distribution-Date`,
+    /// a resolved commit SHA, or a local directory's content hash.
+    ///
+    /// `None` when the source names no version of its own. `add`/`update` then
+    /// invent one (`pin_version`), and `install` cannot use the version to
+    /// decide whether the pin is satisfied — the checksum is the only identity
+    /// such a package has.
+    declared_version: Option<String>,
+    /// Version to record when the source names none: today's date for SSC and
+    /// net packages, the git ref for GitHub ones.
+    fallback_version: String,
     /// Files fetched from the source
     files: Vec<DownloadedFile>,
     /// Combined checksum of all fetched files
@@ -58,17 +67,22 @@ struct ResolvedPackage {
     commit: Option<String>,
 }
 
+impl ResolvedPackage {
+    /// The version to record when this package is being pinned (`add`/`update`).
+    fn pin_version(&self) -> String {
+        self.declared_version
+            .clone()
+            .unwrap_or_else(|| self.fallback_version.clone())
+    }
+}
+
 /// Fetch a package from SSC.
 fn resolve_ssc(name: &str) -> Result<ResolvedPackage> {
     let download = SscDownloader::new().download_package(name)?;
 
     Ok(ResolvedPackage {
-        // Version from the manifest, or today's date when it declares none
-        version: download
-            .manifest
-            .distribution_date
-            .clone()
-            .unwrap_or_else(crate::utils::date::today_yyyymmdd),
+        declared_version: download.manifest.distribution_date.clone(),
+        fallback_version: crate::utils::date::today_yyyymmdd(),
         files: download.files,
         package_checksum: download.package_checksum,
         from_mirror: download.from_mirror,
@@ -92,18 +106,17 @@ fn resolve_github(
     // Resolve the commit SHA for reproducibility (graceful degradation)
     let commit = downloader.resolve_commit_sha(user, repo, &download.git_ref);
 
-    // Version from the manifest, or the short SHA / git ref as fallback
-    let version = download
-        .manifest
-        .distribution_date
-        .clone()
-        .unwrap_or_else(|| match &commit {
-            Some(sha) => sha.get(..8).unwrap_or(sha.as_str()).to_string(),
-            None => git_ref.unwrap_or("main").to_string(),
-        });
+    // The manifest's date names the version; failing that, the commit does.
+    // A git ref alone names nothing — `main` is whatever it points at today.
+    let declared_version = download.manifest.distribution_date.clone().or_else(|| {
+        commit
+            .as_ref()
+            .map(|sha| sha.get(..8).unwrap_or(sha.as_str()).to_string())
+    });
 
     Ok(ResolvedPackage {
-        version,
+        declared_version,
+        fallback_version: git_ref.unwrap_or("main").to_string(),
         files: download.files,
         package_checksum: download.package_checksum,
         from_mirror: false, // GitHub packages don't use SSC mirrors
@@ -118,11 +131,8 @@ fn resolve_net(name: &str, url: &str) -> Result<ResolvedPackage> {
     let download = NetDownloader::new().download_package(name, url)?;
 
     Ok(ResolvedPackage {
-        version: download
-            .manifest
-            .distribution_date
-            .clone()
-            .unwrap_or_else(crate::utils::date::today_yyyymmdd),
+        declared_version: download.manifest.distribution_date.clone(),
+        fallback_version: crate::utils::date::today_yyyymmdd(),
         files: download.files,
         package_checksum: download.package_checksum,
         from_mirror: false,
@@ -142,9 +152,13 @@ fn resolve_local(name: &str, path: &str, project_root: &Path) -> Result<Resolved
 
     let download = local::scan_local_directory(name, &dir)?;
 
+    // Local packages have no manifest: the version is the short content hash,
+    // so the directory does name its own version.
+    let version = download.package_checksum[..8].to_string();
+
     Ok(ResolvedPackage {
-        // Local packages have no manifest: the version is the short checksum
-        version: download.package_checksum[..8].to_string(),
+        declared_version: Some(version.clone()),
+        fallback_version: version,
         files: download.files,
         package_checksum: download.package_checksum,
         from_mirror: false,
@@ -188,18 +202,19 @@ fn cache_and_lock(
     project_root: &Path,
     group: &str,
 ) -> Result<InstallResult> {
-    let (_cache_dir, saved_files) = atomic_save_to_cache(&resolved.files, name, &resolved.version)?;
+    let version = resolved.pin_version();
+    let (_cache_dir, saved_files) = atomic_save_to_cache(&resolved.files, name, &version)?;
 
     let mut lockfile = load_lockfile(project_root)?.unwrap_or_else(create_lockfile);
     let was_update = lockfile.packages.contains_key(name);
 
-    let entry = create_package_entry(&resolved.version, source, &resolved.package_checksum, group);
+    let entry = create_package_entry(&version, source, &resolved.package_checksum, group);
     add_package(&mut lockfile, name, entry);
     save_lockfile(project_root, &lockfile)?;
 
     Ok(InstallResult {
         name: name.to_string(),
-        version: resolved.version,
+        version,
         files_installed: saved_files,
         was_update,
         from_mirror: resolved.from_mirror,
@@ -310,14 +325,23 @@ pub fn install_from_local(
 /// Install a package exactly as `stacy.lock` pins it.
 ///
 /// This is the `stacy install` path, and it never writes `stacy.lock`: the
-/// lockfile is the input, not the output. The fetched package must carry the
-/// pinned version, and (unless `verify` is off) hash to the pinned checksum.
-/// Anything else is an `Error::Integrity` — installing a different version
-/// under the pinned name is exactly the drift the lockfile exists to prevent.
+/// lockfile is the input, not the output. What the source serves must match the
+/// pin, or the install fails with an `Error::Integrity` — installing a different
+/// package under the pinned name is exactly the drift the lockfile prevents.
 ///
-/// `verify` mirrors `stacy install --no-verify`: it turns off the checksum
-/// comparison. The version pin is always enforced, because a different version
-/// is a different package rather than a question about bytes.
+/// Matching the pin means:
+///
+/// - The version, where the source names one. A `.pkg` with no
+///   `Distribution-Date` names no version — `add` recorded the date it fetched
+///   the package, which says nothing about the bytes — so there the pin is
+///   checked by checksum alone. Enforcing the version there would fail every
+///   cold-cache install made on a later day than the one that wrote the lock.
+/// - The checksum, whenever the lockfile records one and `verify` is on.
+///   `verify` is what `stacy install --no-verify` turns off.
+///
+/// A package whose source names no version and whose lockfile entry carries no
+/// checksum (lockfiles written before checksums) has nothing to check against,
+/// and installs as it did before.
 pub fn install_locked(
     name: &str,
     entry: &PackageEntry,
@@ -327,12 +351,12 @@ pub fn install_locked(
     let name = name.to_lowercase();
     let resolved = resolve_from_source(&name, &entry.source, project_root)?;
 
-    if resolved.version != entry.version {
-        return Err(Error::Integrity(version_mismatch_message(
-            &name,
-            entry,
-            &resolved.version,
-        )));
+    if let Some(served) = resolved.declared_version.as_deref() {
+        if served != entry.version {
+            return Err(Error::Integrity(version_mismatch_message(
+                &name, entry, served,
+            )));
+        }
     }
 
     if verify {
@@ -346,6 +370,7 @@ pub fn install_locked(
         }
     }
 
+    // Cached under the pinned version: that is the name `run` looks it up by.
     let (_cache_dir, saved_files) = atomic_save_to_cache(&resolved.files, &name, &entry.version)?;
 
     Ok(InstallResult {
@@ -415,8 +440,9 @@ fn checksum_mismatch_message(
          stacy.lock records sha256:{expected}\n  \
          {origin} serves sha256:{actual}\n  \
          The source changed the package contents without changing its version.\n  \
-         hint: run `stacy update {name}` to re-lock it, or `stacy install --no-verify` \
-         to install the served copy anyway.",
+         hint: run `stacy update {name}` to re-lock it (your results may change).\n  \
+         `stacy install --no-verify` installs the served copy without checking it; \
+         since it will not match stacy.lock, `stacy run` then needs --no-verify too.",
         name = name,
         version = entry.version,
         expected = expected,

--- a/src/packages/installer.rs
+++ b/src/packages/installer.rs
@@ -11,8 +11,8 @@ use crate::packages::lockfile::{
     add_package, create_lockfile, create_package_entry, load_lockfile, save_lockfile,
 };
 use crate::packages::net::NetDownloader;
-use crate::packages::ssc::SscDownloader;
-use crate::project::{PackageSource, Project};
+use crate::packages::ssc::{DownloadedFile, SscDownloader};
+use crate::project::{PackageEntry, PackageSource, Project};
 use std::path::{Path, PathBuf};
 
 /// Result of installing a package
@@ -36,7 +36,180 @@ pub struct InstallResult {
     pub required_stata_version: Option<String>,
 }
 
-/// Install a package from SSC
+/// A package fetched from its source, not yet written to the cache or lockfile.
+///
+/// Fetching and recording are separate steps: `add`/`update` record what they
+/// fetched as the new pin, while `install` checks what it fetched against the
+/// pin that already exists.
+struct ResolvedPackage {
+    /// Version derived from the manifest (or a source-specific fallback)
+    version: String,
+    /// Files fetched from the source
+    files: Vec<DownloadedFile>,
+    /// Combined checksum of all fetched files
+    package_checksum: String,
+    /// Whether the download came from an SSC mirror (not the primary server)
+    from_mirror: bool,
+    /// Package names declared on the manifest's `Requires:` line
+    declared_deps: Vec<String>,
+    /// Minimum Stata version declared on the manifest's `Requires:` line
+    required_stata_version: Option<String>,
+    /// Commit SHA, for GitHub sources where it could be resolved
+    commit: Option<String>,
+}
+
+/// Fetch a package from SSC.
+fn resolve_ssc(name: &str) -> Result<ResolvedPackage> {
+    let download = SscDownloader::new().download_package(name)?;
+
+    Ok(ResolvedPackage {
+        // Version from the manifest, or today's date when it declares none
+        version: download
+            .manifest
+            .distribution_date
+            .clone()
+            .unwrap_or_else(crate::utils::date::today_yyyymmdd),
+        files: download.files,
+        package_checksum: download.package_checksum,
+        from_mirror: download.from_mirror,
+        declared_deps: download.manifest.requires,
+        required_stata_version: download.manifest.stata_version,
+        commit: None,
+    })
+}
+
+/// Fetch a package from GitHub. `git_ref` may be a branch, tag, or commit;
+/// when None the downloader tries `main`, then `master`.
+fn resolve_github(
+    name: &str,
+    user: &str,
+    repo: &str,
+    git_ref: Option<&str>,
+) -> Result<ResolvedPackage> {
+    let downloader = GitHubDownloader::new();
+    let download = downloader.download_package(name, user, repo, git_ref)?;
+
+    // Resolve the commit SHA for reproducibility (graceful degradation)
+    let commit = downloader.resolve_commit_sha(user, repo, &download.git_ref);
+
+    // Version from the manifest, or the short SHA / git ref as fallback
+    let version = download
+        .manifest
+        .distribution_date
+        .clone()
+        .unwrap_or_else(|| match &commit {
+            Some(sha) => sha.get(..8).unwrap_or(sha.as_str()).to_string(),
+            None => git_ref.unwrap_or("main").to_string(),
+        });
+
+    Ok(ResolvedPackage {
+        version,
+        files: download.files,
+        package_checksum: download.package_checksum,
+        from_mirror: false, // GitHub packages don't use SSC mirrors
+        declared_deps: download.manifest.requires,
+        required_stata_version: download.manifest.stata_version,
+        commit,
+    })
+}
+
+/// Fetch a package from a net URL.
+fn resolve_net(name: &str, url: &str) -> Result<ResolvedPackage> {
+    let download = NetDownloader::new().download_package(name, url)?;
+
+    Ok(ResolvedPackage {
+        version: download
+            .manifest
+            .distribution_date
+            .clone()
+            .unwrap_or_else(crate::utils::date::today_yyyymmdd),
+        files: download.files,
+        package_checksum: download.package_checksum,
+        from_mirror: false,
+        declared_deps: download.manifest.requires,
+        required_stata_version: download.manifest.stata_version,
+        commit: None,
+    })
+}
+
+/// Read a package from a local directory (relative to the project root, or absolute).
+fn resolve_local(name: &str, path: &str, project_root: &Path) -> Result<ResolvedPackage> {
+    let dir = if Path::new(path).is_absolute() {
+        PathBuf::from(path)
+    } else {
+        project_root.join(path)
+    };
+
+    let download = local::scan_local_directory(name, &dir)?;
+
+    Ok(ResolvedPackage {
+        // Local packages have no manifest: the version is the short checksum
+        version: download.package_checksum[..8].to_string(),
+        files: download.files,
+        package_checksum: download.package_checksum,
+        from_mirror: false,
+        declared_deps: Vec::new(),
+        required_stata_version: None,
+        commit: None,
+    })
+}
+
+/// Fetch a package from the source the lockfile records for it.
+fn resolve_from_source(
+    name: &str,
+    source: &PackageSource,
+    project_root: &Path,
+) -> Result<ResolvedPackage> {
+    match source {
+        PackageSource::SSC { name: ssc_name } => resolve_ssc(ssc_name),
+        PackageSource::GitHub { repo, tag, commit } => {
+            let (user, repo_name) = repo.split_once('/').ok_or_else(|| {
+                Error::Config(format!(
+                    "Invalid GitHub repo format: {} (want owner/repo)",
+                    repo
+                ))
+            })?;
+            // A locked commit SHA pins the exact tree; fall back to the tag.
+            let git_ref = commit.as_deref().unwrap_or(tag.as_str());
+            resolve_github(name, user, repo_name, Some(git_ref))
+        }
+        PackageSource::Net { url } => resolve_net(name, url),
+        PackageSource::Local { path } => resolve_local(name, path, project_root),
+    }
+}
+
+/// Record a freshly fetched package in the cache and the lockfile.
+///
+/// This is the `add`/`update` path: what the source served becomes the new pin.
+fn cache_and_lock(
+    name: &str,
+    resolved: ResolvedPackage,
+    source: PackageSource,
+    project_root: &Path,
+    group: &str,
+) -> Result<InstallResult> {
+    let (_cache_dir, saved_files) = atomic_save_to_cache(&resolved.files, name, &resolved.version)?;
+
+    let mut lockfile = load_lockfile(project_root)?.unwrap_or_else(create_lockfile);
+    let was_update = lockfile.packages.contains_key(name);
+
+    let entry = create_package_entry(&resolved.version, source, &resolved.package_checksum, group);
+    add_package(&mut lockfile, name, entry);
+    save_lockfile(project_root, &lockfile)?;
+
+    Ok(InstallResult {
+        name: name.to_string(),
+        version: resolved.version,
+        files_installed: saved_files,
+        was_update,
+        from_mirror: resolved.from_mirror,
+        package_checksum: resolved.package_checksum,
+        declared_deps: resolved.declared_deps,
+        required_stata_version: resolved.required_stata_version,
+    })
+}
+
+/// Install a package from SSC, recording it in the lockfile.
 ///
 /// # Arguments
 /// * `name` - Package name to install
@@ -47,52 +220,9 @@ pub struct InstallResult {
 /// InstallResult with details about what was installed
 pub fn install_from_ssc(name: &str, project_root: &Path, group: &str) -> Result<InstallResult> {
     let name = name.to_lowercase();
-
-    // Download package
-    let downloader = SscDownloader::new();
-    let download = downloader.download_package(&name)?;
-
-    // Get version from manifest (use distribution date or today's date)
-    let version = download
-        .manifest
-        .distribution_date
-        .clone()
-        .unwrap_or_else(crate::utils::date::today_yyyymmdd);
-
-    // Save files to global cache atomically
-    let (_cache_dir, saved_files) = atomic_save_to_cache(&download.files, &name, &version)?;
-
-    // Load or create lockfile
-    let mut lockfile = load_lockfile(project_root)?.unwrap_or_else(create_lockfile);
-
-    // Check if this is an update
-    let was_update = lockfile.packages.contains_key(&name);
-
-    // Create package entry
-    let entry = create_package_entry(
-        &version,
-        PackageSource::SSC { name: name.clone() },
-        &download.package_checksum,
-        group,
-    );
-
-    // Update lockfile
-    add_package(&mut lockfile, &name, entry);
-    save_lockfile(project_root, &lockfile)?;
-
-    let from_mirror = download.from_mirror;
-    let package_checksum = download.package_checksum.clone();
-
-    Ok(InstallResult {
-        name,
-        version,
-        files_installed: saved_files,
-        was_update,
-        from_mirror,
-        package_checksum,
-        declared_deps: download.manifest.requires,
-        required_stata_version: download.manifest.stata_version,
-    })
+    let resolved = resolve_ssc(&name)?;
+    let source = PackageSource::SSC { name: name.clone() };
+    cache_and_lock(&name, resolved, source, project_root, group)
 }
 
 /// Install a package (auto-detect source)
@@ -108,7 +238,7 @@ pub fn install_package(
     }
 }
 
-/// Install a package from GitHub
+/// Install a package from GitHub, recording it in the lockfile.
 ///
 /// # Arguments
 /// * `name` - Package name (used to find {name}.pkg)
@@ -126,66 +256,16 @@ pub fn install_package_github(
     group: &str,
 ) -> Result<InstallResult> {
     let name = name.to_lowercase();
-    let git_ref_str = git_ref.unwrap_or("main");
-
-    // Download package from GitHub
-    let downloader = GitHubDownloader::new();
-    let download = downloader.download_package(&name, user, repo, git_ref)?;
-
-    // Resolve commit SHA for reproducibility (graceful degradation)
-    let commit_sha = downloader.resolve_commit_sha(user, repo, &download.git_ref);
-
-    // Get version from manifest, or use short SHA / git ref as fallback
-    let version = download
-        .manifest
-        .distribution_date
-        .clone()
-        .unwrap_or_else(|| {
-            if let Some(ref sha) = commit_sha {
-                sha[..8].to_string()
-            } else {
-                git_ref_str.to_string()
-            }
-        });
-
-    // Save files to global cache atomically
-    let (_cache_dir, saved_files) = atomic_save_to_cache(&download.files, &name, &version)?;
-
-    // Load or create lockfile
-    let mut lockfile = load_lockfile(project_root)?.unwrap_or_else(create_lockfile);
-
-    // Check if this is an update
-    let was_update = lockfile.packages.contains_key(&name);
-
-    // Create package entry
-    let entry = create_package_entry(
-        &version,
-        PackageSource::GitHub {
-            repo: format!("{}/{}", user, repo),
-            tag: git_ref_str.to_string(),
-            commit: commit_sha,
-        },
-        &download.package_checksum,
-        group,
-    );
-
-    // Update lockfile
-    add_package(&mut lockfile, &name, entry);
-    save_lockfile(project_root, &lockfile)?;
-
-    Ok(InstallResult {
-        name,
-        version,
-        files_installed: saved_files,
-        was_update,
-        from_mirror: false, // GitHub packages don't use SSC mirrors
-        package_checksum: download.package_checksum.clone(),
-        declared_deps: download.manifest.requires.clone(),
-        required_stata_version: download.manifest.stata_version.clone(),
-    })
+    let resolved = resolve_github(&name, user, repo, git_ref)?;
+    let source = PackageSource::GitHub {
+        repo: format!("{}/{}", user, repo),
+        tag: git_ref.unwrap_or("main").to_string(),
+        commit: resolved.commit.clone(),
+    };
+    cache_and_lock(&name, resolved, source, project_root, group)
 }
 
-/// Install a package from a net URL
+/// Install a package from a net URL, recording it in the lockfile.
 ///
 /// # Arguments
 /// * `name` - Package name
@@ -199,54 +279,14 @@ pub fn install_from_net(
     group: &str,
 ) -> Result<InstallResult> {
     let name = name.to_lowercase();
-
-    // Download package
-    let downloader = NetDownloader::new();
-    let download = downloader.download_package(&name, url)?;
-
-    // Get version from manifest distribution_date or today's date
-    let version = download
-        .manifest
-        .distribution_date
-        .clone()
-        .unwrap_or_else(crate::utils::date::today_yyyymmdd);
-
-    // Save files to global cache atomically
-    let (_cache_dir, saved_files) = atomic_save_to_cache(&download.files, &name, &version)?;
-
-    // Load or create lockfile
-    let mut lockfile = load_lockfile(project_root)?.unwrap_or_else(create_lockfile);
-
-    // Check if this is an update
-    let was_update = lockfile.packages.contains_key(&name);
-
-    // Create package entry
-    let entry = create_package_entry(
-        &version,
-        PackageSource::Net {
-            url: url.to_string(),
-        },
-        &download.package_checksum,
-        group,
-    );
-
-    // Update lockfile
-    add_package(&mut lockfile, &name, entry);
-    save_lockfile(project_root, &lockfile)?;
-
-    Ok(InstallResult {
-        name,
-        version,
-        files_installed: saved_files,
-        was_update,
-        from_mirror: false,
-        package_checksum: download.package_checksum,
-        declared_deps: download.manifest.requires,
-        required_stata_version: download.manifest.stata_version,
-    })
+    let resolved = resolve_net(&name, url)?;
+    let source = PackageSource::Net {
+        url: url.to_string(),
+    };
+    cache_and_lock(&name, resolved, source, project_root, group)
 }
 
-/// Install a package from a local directory
+/// Install a package from a local directory, recording it in the lockfile.
 ///
 /// # Arguments
 /// * `name` - Package name
@@ -260,53 +300,129 @@ pub fn install_from_local(
     group: &str,
 ) -> Result<InstallResult> {
     let name = name.to_lowercase();
-
-    // Resolve path relative to project root
-    let dir = if std::path::Path::new(path).is_absolute() {
-        PathBuf::from(path)
-    } else {
-        project_root.join(path)
+    let resolved = resolve_local(&name, path, project_root)?;
+    let source = PackageSource::Local {
+        path: path.to_string(),
     };
+    cache_and_lock(&name, resolved, source, project_root, group)
+}
 
-    // Scan local directory
-    let download = local::scan_local_directory(&name, &dir)?;
+/// Install a package exactly as `stacy.lock` pins it.
+///
+/// This is the `stacy install` path, and it never writes `stacy.lock`: the
+/// lockfile is the input, not the output. The fetched package must carry the
+/// pinned version, and (unless `verify` is off) hash to the pinned checksum.
+/// Anything else is an `Error::Integrity` — installing a different version
+/// under the pinned name is exactly the drift the lockfile exists to prevent.
+///
+/// `verify` mirrors `stacy install --no-verify`: it turns off the checksum
+/// comparison. The version pin is always enforced, because a different version
+/// is a different package rather than a question about bytes.
+pub fn install_locked(
+    name: &str,
+    entry: &PackageEntry,
+    project_root: &Path,
+    verify: bool,
+) -> Result<InstallResult> {
+    let name = name.to_lowercase();
+    let resolved = resolve_from_source(&name, &entry.source, project_root)?;
 
-    // Version derived from combined checksum short hash (first 8 chars)
-    let version = download.package_checksum[..8].to_string();
+    if resolved.version != entry.version {
+        return Err(Error::Integrity(version_mismatch_message(
+            &name,
+            entry,
+            &resolved.version,
+        )));
+    }
 
-    // Save files to global cache atomically
-    let (_cache_dir, saved_files) = atomic_save_to_cache(&download.files, &name, &version)?;
+    if verify {
+        if let Some(expected) = entry.checksum.as_deref() {
+            let expected = expected.strip_prefix("sha256:").unwrap_or(expected);
+            if resolved.package_checksum != expected {
+                return Err(Error::Integrity(checksum_mismatch_message(
+                    &name, entry, expected, &resolved,
+                )));
+            }
+        }
+    }
 
-    // Load or create lockfile
-    let mut lockfile = load_lockfile(project_root)?.unwrap_or_else(create_lockfile);
-
-    // Check if this is an update
-    let was_update = lockfile.packages.contains_key(&name);
-
-    // Create package entry
-    let entry = create_package_entry(
-        &version,
-        PackageSource::Local {
-            path: path.to_string(),
-        },
-        &download.package_checksum,
-        group,
-    );
-
-    // Update lockfile
-    add_package(&mut lockfile, &name, entry);
-    save_lockfile(project_root, &lockfile)?;
+    let (_cache_dir, saved_files) = atomic_save_to_cache(&resolved.files, &name, &entry.version)?;
 
     Ok(InstallResult {
         name,
-        version,
+        version: entry.version.clone(),
         files_installed: saved_files,
-        was_update,
-        from_mirror: false,
-        package_checksum: download.package_checksum,
-        declared_deps: Vec::new(), // local packages have no manifest
-        required_stata_version: None,
+        was_update: false,
+        from_mirror: resolved.from_mirror,
+        package_checksum: resolved.package_checksum,
+        declared_deps: resolved.declared_deps,
+        required_stata_version: resolved.required_stata_version,
     })
+}
+
+/// Human-readable name of the place a package is fetched from.
+fn source_origin(source: &PackageSource) -> String {
+    match source {
+        PackageSource::SSC { .. } => "SSC".to_string(),
+        PackageSource::GitHub { repo, .. } => format!("GitHub ({})", repo),
+        PackageSource::Net { url } => url.clone(),
+        PackageSource::Local { path } => format!("the local directory {}", path),
+    }
+}
+
+/// Why the source cannot hand back the pinned version.
+fn source_pin_note(source: &PackageSource) -> &'static str {
+    match source {
+        PackageSource::SSC { .. } => {
+            "SSC serves only the current revision of a package, so once a pinned version \
+             leaves the package cache it cannot be downloaded again."
+        }
+        PackageSource::GitHub { .. } => "The repository no longer serves the pinned version.",
+        PackageSource::Net { .. } => "The URL no longer serves the pinned version.",
+        PackageSource::Local { .. } => {
+            "The directory's contents no longer match the pinned version."
+        }
+    }
+}
+
+fn version_mismatch_message(name: &str, entry: &PackageEntry, served: &str) -> String {
+    format!(
+        "{name}: stacy.lock pins version {pinned}, but {origin} serves {served}\n  \
+         {note}\n  \
+         hint: run `stacy update {name}` to move the pin to {served} (your results may change), \
+         or restore {pinned} into the package cache from a machine that still has it.",
+        name = name,
+        pinned = entry.version,
+        origin = source_origin(&entry.source),
+        served = served,
+        note = source_pin_note(&entry.source),
+    )
+}
+
+fn checksum_mismatch_message(
+    name: &str,
+    entry: &PackageEntry,
+    expected: &str,
+    resolved: &ResolvedPackage,
+) -> String {
+    let origin = if resolved.from_mirror {
+        "the SSC mirror".to_string()
+    } else {
+        source_origin(&entry.source)
+    };
+    format!(
+        "{name}: checksum mismatch for version {version}\n  \
+         stacy.lock records sha256:{expected}\n  \
+         {origin} serves sha256:{actual}\n  \
+         The source changed the package contents without changing its version.\n  \
+         hint: run `stacy update {name}` to re-lock it, or `stacy install --no-verify` \
+         to install the served copy anyway.",
+        name = name,
+        version = entry.version,
+        expected = expected,
+        origin = origin,
+        actual = resolved.package_checksum,
+    )
 }
 
 /// Check if a package version is installed in the global cache

--- a/stata/stacy_install.ado
+++ b/stata/stacy_install.ado
@@ -12,7 +12,7 @@
 
     Options:
         FROZEN               - Fail if lockfile doesn't match stacy.toml
-        NOVerify             - Skip checksum verification
+        NOVerify             - Skip checksum verification (the version pin is still enforced)
         With(string)         - Include dependency groups (comma-separated: dev, test)
 
     Returns:

--- a/stata/stacy_install.ado
+++ b/stata/stacy_install.ado
@@ -12,7 +12,7 @@
 
     Options:
         FROZEN               - Fail if lockfile doesn't match stacy.toml
-        NOVerify             - Skip checksum verification (the version pin is still enforced)
+        NOVerify             - Skip checksum verification (a version the source names is still checked)
         With(string)         - Include dependency groups (comma-separated: dev, test)
 
     Returns:

--- a/stata/stacy_install.sthlp
+++ b/stata/stacy_install.sthlp
@@ -22,7 +22,7 @@
 {synoptline}
 {syntab:Main}
 {synopt:{opt:frozen}}Fail if lockfile doesn't match stacy.toml{p_end}
-{synopt:{opt:noverify}}Skip checksum verification{p_end}
+{synopt:{opt:noverify}}Skip checksum verification (the version pin is still enforced){p_end}
 {synopt:{opt:with(string)}}Include dependency groups (comma-separated: dev, test){p_end}
 {synoptline}
 
@@ -41,7 +41,7 @@
 {opt frozen} fail if lockfile doesn't match stacy.toml.
 
 {phang}
-{opt no_verify} skip checksum verification.
+{opt no_verify} skip checksum verification (the version pin is still enforced).
 
 {phang}
 {opt with} include dependency groups (comma-separated: dev, test).

--- a/stata/stacy_install.sthlp
+++ b/stata/stacy_install.sthlp
@@ -22,7 +22,7 @@
 {synoptline}
 {syntab:Main}
 {synopt:{opt:frozen}}Fail if lockfile doesn't match stacy.toml{p_end}
-{synopt:{opt:noverify}}Skip checksum verification (the version pin is still enforced){p_end}
+{synopt:{opt:noverify}}Skip checksum verification (a version the source names is still checked){p_end}
 {synopt:{opt:with(string)}}Include dependency groups (comma-separated: dev, test){p_end}
 {synoptline}
 
@@ -41,7 +41,7 @@
 {opt frozen} fail if lockfile doesn't match stacy.toml.
 
 {phang}
-{opt no_verify} skip checksum verification (the version pin is still enforced).
+{opt no_verify} skip checksum verification (a version the source names is still checked).
 
 {phang}
 {opt with} include dependency groups (comma-separated: dev, test).

--- a/stata/stacy_run.ado
+++ b/stata/stacy_run.ado
@@ -20,6 +20,7 @@
         Force                - Force rebuild even if cached
         Jobs(integer)        - Max parallel jobs (default: CPU count)
         Log(string)          - Write the raw Stata log to this path
+        NOVerify             - Skip the check of the package cache against stacy.lock
         PARALLEL             - Run scripts in parallel
         Profile              - Include execution metrics
         Quietly              - Suppress output
@@ -39,7 +40,7 @@
 
 program define stacy_run, rclass
     version 14.0
-    syntax [anything(name=script)] [, AllowGlobal Cache CacheOnly Code(string) Directory(string) Engine(string) Force Jobs(string) Log(string) PARALLEL Profile Quietly Timeout(string) Trace(string) Verbose]
+    syntax [anything(name=script)] [, AllowGlobal Cache CacheOnly Code(string) Directory(string) Engine(string) Force Jobs(string) Log(string) NOVerify PARALLEL Profile Quietly Timeout(string) Trace(string) Verbose]
 
     * Build command arguments
     local cmd "run"
@@ -82,6 +83,10 @@ program define stacy_run, rclass
 
     if `"`log'"' != "" {
         local cmd `"`cmd' --log "`log'""'
+    }
+
+    if "`noverify'" != "" {
+        local cmd `"`cmd' --no-verify"'
     }
 
     if "`parallel'" != "" {

--- a/stata/stacy_run.sthlp
+++ b/stata/stacy_run.sthlp
@@ -30,6 +30,7 @@
 {synopt:{opt:force}}Force rebuild even if cached{p_end}
 {synopt:{opt:jobs(integer)}}Max parallel jobs (default: CPU count){p_end}
 {synopt:{opt:log(string)}}Write the raw Stata log to this path{p_end}
+{synopt:{opt:noverify}}Skip the check of the package cache against stacy.lock{p_end}
 {synopt:{opt:parallel}}Run scripts in parallel{p_end}
 {synopt:{opt:profile}}Include execution metrics{p_end}
 {synopt:{opt:quietly}}Suppress output{p_end}
@@ -78,6 +79,9 @@
 
 {phang}
 {opt log} write the raw stata log to this path.
+
+{phang}
+{opt no_verify} skip the check of the package cache against stacy.lock.
 
 {phang}
 {opt parallel} run scripts in parallel.

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -1513,39 +1513,35 @@ fn test_install_frozen_flag_exists() {
         .stdout(predicate::str::contains("CI"));
 }
 
+/// `--frozen` passes when the lockfile lists exactly what stacy.toml declares.
+///
+/// Uses a vendored `local:` package so the install runs offline, and locks it
+/// with `stacy add` so the pinned version and checksum are the real ones —
+/// `install` fetches what stacy.lock pins and will not re-resolve past it.
 #[test]
 fn test_install_frozen_in_sync() {
     let temp = TempDir::new().unwrap();
-    fs::write(
-        temp.path().join("stacy.toml"),
-        r#"[project]
+    let cache = TempDir::new().unwrap();
 
-[packages.dependencies]
-estout = "ssc"
-"#,
-    )
-    .unwrap();
-    fs::write(
-        temp.path().join("stacy.lock"),
-        r#"version = "1"
+    fs::write(temp.path().join("stacy.toml"), "[project]\n").unwrap();
 
-[packages.estout]
-version = "2024.03.15"
-checksum = "sha256:abc123"
-group = "production"
-
-[packages.estout.source]
-type = "SSC"
-name = "estout"
-"#,
-    )
-    .unwrap();
+    let vendor = temp.path().join("vendor").join("testpkg");
+    fs::create_dir_all(&vendor).unwrap();
+    fs::write(vendor.join("testpkg.ado"), "program define testpkg\nend\n").unwrap();
 
     stacy()
         .current_dir(temp.path())
-        .arg("install")
-        .arg("--frozen")
-        .arg("--no-verify")
+        .args(["add", "testpkg", "--source", "local:vendor/testpkg"])
+        .env("XDG_CACHE_HOME", cache.path())
+        .env("LOCALAPPDATA", cache.path())
+        .assert()
+        .success();
+
+    stacy()
+        .current_dir(temp.path())
+        .args(["install", "--frozen"])
+        .env("XDG_CACHE_HOME", cache.path())
+        .env("LOCALAPPDATA", cache.path())
         .assert()
         .success();
 }

--- a/tests/test_lockfile_integrity.rs
+++ b/tests/test_lockfile_integrity.rs
@@ -1,0 +1,202 @@
+//! Regression tests for the lockfile integrity guarantee (#96).
+//!
+//! `stacy install` materializes `stacy.lock`; it never rewrites it. On a cold
+//! cache it must fetch the pinned version and fail if the source no longer
+//! serves it, rather than quietly locking whatever the source serves today.
+//!
+//! These tests use a `local:` package source so they run without network.
+
+use assert_cmd::{cargo_bin_cmd, Command};
+use predicates::prelude::*;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+/// Contents of the vendored package the tests install from.
+const PKG_ADO: &[u8] = b"program define testpkg\nend\n";
+
+fn stacy() -> Command {
+    cargo_bin_cmd!("stacy")
+}
+
+/// Platform-correct cache subdirectory under a temp dir.
+fn cache_packages_dir(root: &Path) -> PathBuf {
+    if cfg!(windows) {
+        root.join("stacy").join("cache").join("packages")
+    } else {
+        root.join("stacy").join("packages")
+    }
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hex::encode(hasher.finalize())
+}
+
+/// Combined checksum: per-file SHA256s, sorted, then hashed
+/// (matches `ssc::calculate_combined_checksum`).
+fn combined_checksum(checksums: &[String]) -> String {
+    let mut sorted = checksums.to_vec();
+    sorted.sort();
+    let mut hasher = Sha256::new();
+    for cs in &sorted {
+        hasher.update(cs.as_bytes());
+    }
+    hex::encode(hasher.finalize())
+}
+
+/// The checksum and version `stacy add` would record for the vendored package.
+/// A local package's version is the first 8 chars of its combined checksum.
+fn vendored_checksum_and_version() -> (String, String) {
+    let checksum = combined_checksum(&[sha256_hex(PKG_ADO)]);
+    let version = checksum[..8].to_string();
+    (checksum, version)
+}
+
+/// Project with a vendored local package, plus an empty cache directory.
+///
+/// The lockfile pins `version` / `checksum` as given, so callers can pin the
+/// truth or a lie. Returns (project, cache).
+fn project_pinning(version: &str, checksum: &str) -> (TempDir, TempDir) {
+    let project = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+
+    // The package source on disk — no network needed to install it.
+    let vendor = project.path().join("vendor").join("testpkg");
+    fs::create_dir_all(&vendor).unwrap();
+    fs::write(vendor.join("testpkg.ado"), PKG_ADO).unwrap();
+
+    fs::write(
+        project.path().join("stacy.toml"),
+        "[project]\nname = \"test-project\"\n\n\
+         [packages.dependencies]\ntestpkg = \"local:vendor/testpkg\"\n",
+    )
+    .unwrap();
+
+    fs::write(
+        project.path().join("stacy.lock"),
+        format!(
+            r#"version = "1"
+stacy_version = "{}"
+
+[packages.testpkg]
+version = "{}"
+checksum = "sha256:{}"
+group = "production"
+
+[packages.testpkg.source]
+type = "Local"
+path = "vendor/testpkg"
+"#,
+            env!("CARGO_PKG_VERSION"),
+            version,
+            checksum,
+        ),
+    )
+    .unwrap();
+
+    (project, cache)
+}
+
+fn install(project: &TempDir, cache: &TempDir, extra: &[&str]) -> assert_cmd::assert::Assert {
+    stacy()
+        .arg("install")
+        .args(extra)
+        .current_dir(project.path())
+        .env("XDG_CACHE_HOME", cache.path())
+        .env("LOCALAPPDATA", cache.path())
+        .assert()
+}
+
+fn read_lock(project: &TempDir) -> Vec<u8> {
+    fs::read(project.path().join("stacy.lock")).unwrap()
+}
+
+/// #96: a cold `--frozen` install of a version the source cannot serve must
+/// fail — and must leave stacy.lock byte-for-byte untouched.
+#[test]
+fn test_frozen_install_fails_on_pinned_version_mismatch() {
+    let (checksum, _real_version) = vendored_checksum_and_version();
+    let (project, cache) = project_pinning("99999999", &checksum);
+    let before = read_lock(&project);
+
+    install(&project, &cache, &["--frozen"])
+        .failure()
+        .stderr(predicate::str::contains("99999999"))
+        .stderr(predicate::str::contains("stacy.lock pins version"));
+
+    assert_eq!(
+        read_lock(&project),
+        before,
+        "--frozen must not rewrite stacy.lock"
+    );
+}
+
+/// #96: the same holds without `--frozen`. Plain `install` installs what the
+/// lockfile pins; it does not re-resolve and move the pin.
+#[test]
+fn test_plain_install_fails_on_pinned_version_mismatch() {
+    let (checksum, _real_version) = vendored_checksum_and_version();
+    let (project, cache) = project_pinning("99999999", &checksum);
+    let before = read_lock(&project);
+
+    install(&project, &cache, &[])
+        .failure()
+        .stderr(predicate::str::contains("stacy.lock pins version"));
+
+    assert_eq!(
+        read_lock(&project),
+        before,
+        "install must not rewrite stacy.lock"
+    );
+}
+
+/// #96: a cold install whose bytes hash differently from the locked checksum
+/// must fail rather than re-lock the served copy.
+#[test]
+fn test_frozen_install_fails_on_checksum_mismatch() {
+    let (_checksum, version) = vendored_checksum_and_version();
+    let wrong = "0".repeat(64);
+    let (project, cache) = project_pinning(&version, &wrong);
+    let before = read_lock(&project);
+
+    install(&project, &cache, &["--frozen"])
+        .failure()
+        .stderr(predicate::str::contains("checksum mismatch"));
+
+    assert_eq!(
+        read_lock(&project),
+        before,
+        "--frozen must not rewrite stacy.lock"
+    );
+}
+
+/// #96: the happy path also leaves the lockfile alone. A cold `--frozen`
+/// install of a version the source can serve installs it into the cache and
+/// writes nothing.
+#[test]
+fn test_frozen_install_of_matching_pin_succeeds_without_touching_lock() {
+    let (checksum, version) = vendored_checksum_and_version();
+    let (project, cache) = project_pinning(&version, &checksum);
+    let before = read_lock(&project);
+
+    install(&project, &cache, &["--frozen"]).success();
+
+    assert_eq!(
+        read_lock(&project),
+        before,
+        "a successful install must not rewrite stacy.lock"
+    );
+
+    let installed = cache_packages_dir(cache.path())
+        .join("testpkg")
+        .join(&version)
+        .join("testpkg.ado");
+    assert!(
+        installed.exists(),
+        "the pinned version should be in the cache at {}",
+        installed.display()
+    );
+}

--- a/tests/test_lockfile_integrity.rs
+++ b/tests/test_lockfile_integrity.rs
@@ -1,10 +1,14 @@
-//! Regression tests for the lockfile integrity guarantee (#96).
+//! Regression tests for the lockfile integrity guarantees (#96, #97).
 //!
-//! `stacy install` materializes `stacy.lock`; it never rewrites it. On a cold
-//! cache it must fetch the pinned version and fail if the source no longer
+//! #96: `stacy install` materializes `stacy.lock`; it never rewrites it. On a
+//! cold cache it must fetch the pinned version and fail if the source no longer
 //! serves it, rather than quietly locking whatever the source serves today.
 //!
-//! These tests use a `local:` package source so they run without network.
+//! #97: `stacy run` checks the locked packages against the cache before it
+//! starts Stata, so a modified or absent package cannot run silently.
+//!
+//! These tests use a `local:` package source and a fake Stata binary, so they
+//! run without network and without Stata.
 
 use assert_cmd::{cargo_bin_cmd, Command};
 use predicates::prelude::*;
@@ -199,4 +203,100 @@ fn test_frozen_install_of_matching_pin_succeeds_without_touching_lock() {
         "the pinned version should be in the cache at {}",
         installed.display()
     );
+}
+
+// ============================================================================
+// #97: `stacy run` checks the cache against the lockfile before starting Stata
+// ============================================================================
+
+/// Put a package into the global cache by hand, as a completed install would.
+#[cfg(unix)]
+fn seed_cache(cache: &TempDir, version: &str, contents: &[u8]) {
+    let dir = cache_packages_dir(cache.path())
+        .join("testpkg")
+        .join(version);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("testpkg.ado"), contents).unwrap();
+}
+
+/// Stand-in for Stata: writes the log `stacy` expects, runs nothing.
+#[cfg(unix)]
+fn write_fake_stata(dir: &Path) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let path = dir.join("fake-stata");
+    fs::write(
+        &path,
+        "#!/bin/sh\n\
+         for arg in \"$@\"; do last=\"$arg\"; done\n\
+         stem=$(basename \"$last\" .do)\n\
+         printf '%s\\n' 'output' 'end of do-file' > \"$stem.log\"\n",
+    )
+    .unwrap();
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).unwrap();
+    path
+}
+
+#[cfg(unix)]
+fn run_script(project: &TempDir, cache: &TempDir) -> assert_cmd::assert::Assert {
+    fs::write(project.path().join("analysis.do"), "display 1\n").unwrap();
+    let fake = write_fake_stata(project.path());
+
+    stacy()
+        .arg("run")
+        .arg("analysis.do")
+        .current_dir(project.path())
+        .env("STATA_BINARY", &fake)
+        .env("XDG_CACHE_HOME", cache.path())
+        .env("LOCALAPPDATA", cache.path())
+        .assert()
+}
+
+/// #97: a cached package modified after install must not run.
+#[cfg(unix)]
+#[test]
+fn test_run_fails_on_modified_cached_package() {
+    let (checksum, version) = vendored_checksum_and_version();
+    let (project, cache) = project_pinning(&version, &checksum);
+
+    seed_cache(
+        &cache,
+        &version,
+        b"program define testpkg\nend\n* TAMPERED\n",
+    );
+
+    run_script(&project, &cache)
+        .failure()
+        .stderr(predicate::str::contains("does not match stacy.lock"))
+        .stderr(predicate::str::contains("modified since install"))
+        .stderr(predicate::str::contains("testpkg"));
+}
+
+/// #97: a locked package that is not in the cache must not run.
+#[cfg(unix)]
+#[test]
+fn test_run_fails_on_absent_cached_package() {
+    let (checksum, version) = vendored_checksum_and_version();
+    let (project, cache) = project_pinning(&version, &checksum);
+
+    // Cache left empty — nothing was ever installed.
+    run_script(&project, &cache)
+        .failure()
+        .stderr(predicate::str::contains("does not match stacy.lock"))
+        .stderr(predicate::str::contains("not installed"))
+        .stderr(predicate::str::contains("testpkg"));
+}
+
+/// #97 control: an intact cache runs. Without this, the two failure tests
+/// above would pass even if `run` were broken for unrelated reasons.
+#[cfg(unix)]
+#[test]
+fn test_run_succeeds_with_intact_cache() {
+    let (checksum, version) = vendored_checksum_and_version();
+    let (project, cache) = project_pinning(&version, &checksum);
+
+    seed_cache(&cache, &version, PKG_ADO);
+
+    run_script(&project, &cache).success();
 }

--- a/tests/test_lockfile_integrity.rs
+++ b/tests/test_lockfile_integrity.rs
@@ -7,8 +7,9 @@
 //! #97: `stacy run` checks the locked packages against the cache before it
 //! starts Stata, so a modified or absent package cannot run silently.
 //!
-//! These tests use a `local:` package source and a fake Stata binary, so they
-//! run without network and without Stata.
+//! These tests use a `local:` package source, a package server on 127.0.0.1,
+//! and a fake Stata binary, so they run without an internet connection and
+//! without Stata.
 
 use assert_cmd::{cargo_bin_cmd, Command};
 use predicates::prelude::*;
@@ -64,6 +65,11 @@ fn vendored_checksum_and_version() -> (String, String) {
 /// The lockfile pins `version` / `checksum` as given, so callers can pin the
 /// truth or a lie. Returns (project, cache).
 fn project_pinning(version: &str, checksum: &str) -> (TempDir, TempDir) {
+    project_pinning_in_group(version, checksum, "production")
+}
+
+/// As `project_pinning`, with the locked package placed in a dependency group.
+fn project_pinning_in_group(version: &str, checksum: &str, group: &str) -> (TempDir, TempDir) {
     let project = TempDir::new().unwrap();
     let cache = TempDir::new().unwrap();
 
@@ -72,10 +78,19 @@ fn project_pinning(version: &str, checksum: &str) -> (TempDir, TempDir) {
     fs::create_dir_all(&vendor).unwrap();
     fs::write(vendor.join("testpkg.ado"), PKG_ADO).unwrap();
 
+    let toml_table = match group {
+        "production" => "[packages.dependencies]",
+        "dev" => "[packages.dev]",
+        "test" => "[packages.test]",
+        other => panic!("unknown group {}", other),
+    };
     fs::write(
         project.path().join("stacy.toml"),
-        "[project]\nname = \"test-project\"\n\n\
-         [packages.dependencies]\ntestpkg = \"local:vendor/testpkg\"\n",
+        format!(
+            "[project]\nname = \"test-project\"\n\n\
+             {}\ntestpkg = \"local:vendor/testpkg\"\n",
+            toml_table
+        ),
     )
     .unwrap();
 
@@ -88,7 +103,7 @@ stacy_version = "{}"
 [packages.testpkg]
 version = "{}"
 checksum = "sha256:{}"
-group = "production"
+group = "{}"
 
 [packages.testpkg.source]
 type = "Local"
@@ -97,6 +112,7 @@ path = "vendor/testpkg"
             env!("CARGO_PKG_VERSION"),
             version,
             checksum,
+            group,
         ),
     )
     .unwrap();
@@ -240,12 +256,22 @@ fn write_fake_stata(dir: &Path) -> PathBuf {
 
 #[cfg(unix)]
 fn run_script(project: &TempDir, cache: &TempDir) -> assert_cmd::assert::Assert {
+    run_script_with(project, cache, &[])
+}
+
+#[cfg(unix)]
+fn run_script_with(
+    project: &TempDir,
+    cache: &TempDir,
+    extra: &[&str],
+) -> assert_cmd::assert::Assert {
     fs::write(project.path().join("analysis.do"), "display 1\n").unwrap();
     let fake = write_fake_stata(project.path());
 
     stacy()
         .arg("run")
         .arg("analysis.do")
+        .args(extra)
         .current_dir(project.path())
         .env("STATA_BINARY", &fake)
         .env("XDG_CACHE_HOME", cache.path())
@@ -299,4 +325,226 @@ fn test_run_succeeds_with_intact_cache() {
     seed_cache(&cache, &version, PKG_ADO);
 
     run_script(&project, &cache).success();
+}
+
+// ============================================================================
+// Dependency groups: `stacy install` installs production, so that is the group
+// `run` requires. A dev or test package is only checked once it is installed.
+// ============================================================================
+
+/// `stacy install` (production only) followed by `stacy run` must work in a
+/// project that has a dev dependency. The dev package is not installed, and
+/// requiring it would break the standard install-then-run flow.
+#[cfg(unix)]
+#[test]
+fn test_run_succeeds_with_uninstalled_dev_package() {
+    let (checksum, version) = vendored_checksum_and_version();
+    let (project, cache) = project_pinning_in_group(&version, &checksum, "dev");
+
+    // Installs the production group: nothing, and no error.
+    install(&project, &cache, &[]).success();
+
+    run_script(&project, &cache).success();
+}
+
+/// A dev package that *is* installed is still checked: it sits on the ado-path
+/// like any other locked package, so modified bytes must not run.
+#[cfg(unix)]
+#[test]
+fn test_run_fails_on_modified_dev_package() {
+    let (checksum, version) = vendored_checksum_and_version();
+    let (project, cache) = project_pinning_in_group(&version, &checksum, "dev");
+
+    seed_cache(
+        &cache,
+        &version,
+        b"program define testpkg\nend\n* TAMPERED\n",
+    );
+
+    run_script(&project, &cache)
+        .failure()
+        .stderr(predicate::str::contains("modified since install"))
+        .stderr(predicate::str::contains("testpkg"));
+}
+
+// ============================================================================
+// `--no-verify` on install and on run are counterparts: a cache installed
+// without checking does not match the lockfile, so run needs the same opt-out.
+// ============================================================================
+
+/// `stacy install --no-verify` installs a copy that does not match the locked
+/// checksum. `run` rejects that cache, and `run --no-verify` accepts it — the
+/// escape hatch the install hint points at has to lead somewhere.
+#[cfg(unix)]
+#[test]
+fn test_no_verify_install_then_run_needs_no_verify() {
+    let (_checksum, version) = vendored_checksum_and_version();
+    let stale = "0".repeat(64);
+    let (project, cache) = project_pinning(&version, &stale);
+
+    install(&project, &cache, &["--no-verify"]).success();
+
+    run_script(&project, &cache)
+        .failure()
+        .stderr(predicate::str::contains("does not match stacy.lock"));
+
+    run_script_with(&project, &cache, &["--no-verify"]).success();
+}
+
+// ============================================================================
+// Packages whose manifest names no version. `stacy add` records the date it
+// fetched them, which says nothing about the bytes — so the checksum, not the
+// version, decides whether a cold-cache install satisfies the pin.
+// ============================================================================
+
+/// A `.pkg` with no `Distribution-Date` line, plus the one file it lists.
+const NODATE_PKG: &[u8] =
+    b"d 'NODATE': a package that declares no distribution date\nf nodate.ado\n";
+const NODATE_ADO: &[u8] = b"program define nodate\nend\n";
+
+/// Serve fixed routes over HTTP on 127.0.0.1. Returns the base URL.
+///
+/// One request per connection, answered with `Connection: close`, which is all
+/// the package downloader needs and keeps the server to a few lines.
+fn serve(routes: Vec<(String, Vec<u8>)>) -> String {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let base = format!("http://{}/", listener.local_addr().unwrap());
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+
+            let mut buf = [0u8; 2048];
+            let read = stream.read(&mut buf).unwrap_or(0);
+            let request = String::from_utf8_lossy(&buf[..read]).to_string();
+            let path = request.split_whitespace().nth(1).unwrap_or("").to_string();
+
+            let body = routes
+                .iter()
+                .find(|(route, _)| *route == path)
+                .map(|(_, body)| body.clone());
+
+            let response = match body {
+                Some(body) => {
+                    let mut head = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    )
+                    .into_bytes();
+                    head.extend_from_slice(&body);
+                    head
+                }
+                None => b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    .to_vec(),
+            };
+
+            let _ = stream.write_all(&response);
+            let _ = stream.flush();
+        }
+    });
+
+    base
+}
+
+/// Project whose only package comes from `url`, pinned as given.
+fn project_pinning_net(url: &str, version: &str, checksum: &str) -> (TempDir, TempDir) {
+    let project = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+
+    fs::write(
+        project.path().join("stacy.toml"),
+        format!(
+            "[project]\nname = \"test-project\"\n\n\
+             [packages.dependencies]\nnodate = \"net:{}\"\n",
+            url
+        ),
+    )
+    .unwrap();
+
+    fs::write(
+        project.path().join("stacy.lock"),
+        format!(
+            r#"version = "1"
+stacy_version = "{}"
+
+[packages.nodate]
+version = "{}"
+checksum = "sha256:{}"
+group = "production"
+
+[packages.nodate.source]
+type = "Net"
+url = "{}"
+"#,
+            env!("CARGO_PKG_VERSION"),
+            version,
+            checksum,
+            url,
+        ),
+    )
+    .unwrap();
+
+    (project, cache)
+}
+
+/// A package with no `Distribution-Date` was locked with the date it was added.
+/// A cold-cache install on any later day must still install it: the checksum
+/// proves the bytes are the ones that were locked. Enforcing the version here
+/// would make the package permanently uninstallable the day after `stacy add`.
+#[test]
+fn test_install_of_undated_package_succeeds_when_checksum_matches() {
+    let url = serve(vec![
+        ("/nodate.pkg".to_string(), NODATE_PKG.to_vec()),
+        ("/nodate.ado".to_string(), NODATE_ADO.to_vec()),
+    ]);
+    let checksum = combined_checksum(&[sha256_hex(NODATE_ADO)]);
+
+    // Locked on some earlier day — the date the package was added.
+    let (project, cache) = project_pinning_net(&url, "20200101", &checksum);
+    let before = read_lock(&project);
+
+    install(&project, &cache, &["--frozen"]).success();
+
+    assert_eq!(
+        read_lock(&project),
+        before,
+        "install must not rewrite stacy.lock"
+    );
+
+    let installed = cache_packages_dir(cache.path())
+        .join("nodate")
+        .join("20200101")
+        .join("nodate.ado");
+    assert!(
+        installed.exists(),
+        "the package should be cached under the pinned version, at {}",
+        installed.display()
+    );
+}
+
+/// The checksum still guards an undated package: different bytes under the same
+/// pin fail, since the checksum is the only identity such a package has.
+#[test]
+fn test_install_of_undated_package_fails_on_checksum_mismatch() {
+    let url = serve(vec![
+        ("/nodate.pkg".to_string(), NODATE_PKG.to_vec()),
+        ("/nodate.ado".to_string(), NODATE_ADO.to_vec()),
+    ]);
+    let wrong = "0".repeat(64);
+
+    let (project, cache) = project_pinning_net(&url, "20200101", &wrong);
+    let before = read_lock(&project);
+
+    install(&project, &cache, &["--frozen"])
+        .failure()
+        .stderr(predicate::str::contains("checksum mismatch"));
+
+    assert_eq!(
+        read_lock(&project),
+        before,
+        "a failed install must not rewrite stacy.lock"
+    );
 }


### PR DESCRIPTION
Two holes in the lockfile guarantee.

`stacy install` resolved each package's version and checksum from whatever the source served and wrote that back to stacy.lock, so on a cold cache it moved the pin instead of installing it — `--frozen` included. Install now fetches the pinned version, checks it against the locked version and checksum, and never writes stacy.lock; a source that no longer serves the pin fails the install. SSC only serves the current revision, so a cold-cache install of a superseded pin cannot succeed and now says so.

`stacy run` built S_ADO from the lockfile without checking the cache, so a package modified after install ran silently. Run now verifies every locked package is present and still hashes to its locked checksum before Stata starts.

Closes #96
Closes #97