### PR TITLE
fix: drop the dead ado_dir key and repair the in-Stata tests

### DIFF
--- a/examples/sample-project/stacy.toml
+++ b/examples/sample-project/stacy.toml
@@ -11,5 +11,5 @@ show_progress = true
 # progress_interval_seconds = 10
 # max_log_size_mb = 50
 
-[packages]
-ado_dir = "ado"
+# [packages.dependencies]
+# estout = "ssc"

--- a/src/project/config.rs
+++ b/src/project/config.rs
@@ -447,12 +447,12 @@ fn unknown_key_hint(message: &str) -> Option<String> {
 /// Validate configuration values.
 ///
 /// Checks that specified paths exist and are valid.
-/// Note: log_dir and ado_dir are not validated for existence - they will be created at runtime.
+/// Note: log_dir is not validated for existence - it will be created at runtime.
 fn validate_config(_config: &Config, _project_root: &Path) -> Result<()> {
-    // Note: We don't validate log_dir and ado_dir paths here because:
-    // 1. They are relative paths that will be created at runtime
+    // Note: We don't validate the log_dir path here because:
+    // 1. It is a relative path that will be created at runtime
     // 2. The project might be shared and paths may not exist on all systems yet
-    // 3. stacy init and stacy run will create these directories as needed
+    // 3. stacy init and stacy run will create the directory as needed
     //
     // Stata binary is NOT in project config - it's in user config (~/.config/stacy/config.toml)
     // or set via STATA_BINARY environment variable.

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -651,7 +651,8 @@ fn test_run_inline_code_whitespace_rejected() {
 #[test]
 #[ignore]
 fn test_run_inline_code_success() {
-    // Simple successful inline code
+    // Simple successful inline code. Status goes to stderr, Stata's own output
+    // to stdout, so a redirected stdout holds the results and nothing else.
     stacy()
         .arg("run")
         .arg("-c")
@@ -659,7 +660,8 @@ fn test_run_inline_code_success() {
         .assert()
         .success()
         .stderr(predicate::str::contains("PASS"))
-        .stdout(predicate::str::contains("<inline code>"));
+        .stderr(predicate::str::contains("<inline code>"))
+        .stdout(predicate::str::contains("2"));
 }
 
 #[test]
@@ -2521,7 +2523,7 @@ fn test_run_parallel_with_jobs() {
         .arg(temp.path().join("second.do"))
         .assert()
         .success()
-        .stdout(predicate::str::contains("2 jobs"));
+        .stderr(predicate::str::contains("2 jobs"));
 }
 
 #[test]
@@ -2568,14 +2570,17 @@ fn test_run_parallel_runs_all_on_failure() {
 #[ignore]
 fn test_run_parallel_verbose_warning() {
     let temp = TempDir::new().unwrap();
-    fs::write(temp.path().join("test.do"), "display 1").unwrap();
+    fs::write(temp.path().join("first.do"), "display 1").unwrap();
+    fs::write(temp.path().join("second.do"), "display 2").unwrap();
 
-    // --verbose with --parallel should warn
+    // --verbose with --parallel should warn. Two scripts: one script never
+    // takes the parallel path, so the warning has nowhere to fire.
     stacy()
         .arg("run")
         .arg("--parallel")
         .arg("-v")
-        .arg(temp.path().join("test.do"))
+        .arg(temp.path().join("first.do"))
+        .arg(temp.path().join("second.do"))
         .assert()
         .success()
         .stderr(predicate::str::contains("verbose").or(predicate::str::contains("ignored")));
@@ -3088,7 +3093,7 @@ fn test_run_with_cache() {
         .arg("test.do")
         .assert()
         .success()
-        .stdout(predicate::str::contains("cache").or(predicate::str::contains("cached")));
+        .stderr(predicate::str::contains("cache").or(predicate::str::contains("cached")));
 }
 
 #[test]

--- a/tests/stata/fixtures/stacy.toml
+++ b/tests/stata/fixtures/stacy.toml
@@ -7,9 +7,6 @@ name = "wrapper-test-project"
 log_dir = "logs"
 show_progress = false
 
-[packages]
-ado_dir = "ado"
-
 # Define a simple task for testing stacy_task
 [scripts.test-task]
 description = "A simple test task"


### PR DESCRIPTION
Running the in-Stata suite against Stata (CI cannot) surfaced two things.

`[packages] ado_dir` is not a config field and no code reads it — it has always been silently ignored. Now that unknown keys are rejected (#100), it fails every command in any project that carries it, and `examples/sample-project/stacy.toml` carried it, so a project started from the sample no longer ran. Removed there and in the wrapper test fixture.

Four in-Stata tests were also stale: three asserted status output on stdout, where only Stata's own output goes, and the `--verbose`/`--parallel` warning test passed a single script, which never takes the parallel path.

With these, the full `cargo test -- --ignored` suite passes against Stata apart from `test_infinite_loop_with_timeout`, which fails identically on v1.4.0 and is tracked separately.