### PR TITLE
release: v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-13
+
+Commands that could not finish their work used to exit 0. They now exit nonzero, which will surface failures a script or CI step previously ran past. See Changed.
+
+### Changed
+
+- Package commands exit nonzero when their work did not complete, and report a non-success `status` in `--format json`/`stata`. `install`, `lock`, `outdated`, `add`, `update` and `deps` all treated a resolve, install or version-check failure as a warning and exited 0 (#94).
+- `stacy.toml` rejects unknown keys, naming the offending one. A misplaced or misspelled key — a dependency under `[dependencies]` instead of `[packages.dependencies]`, a typo'd `verison` pin — was dropped without a word (#100).
+- `[packages] ado_dir` is rejected along with them. Nothing has ever read it; local ado directories are `[paths] ado`. Remove the key if your `stacy.toml` carries it (#100).
+- `stacy install` no longer writes `stacy.lock`. It installs the pinned version and fails when the source no longer serves it, instead of re-resolving and moving the pin. SSC serves only the current revision, so a cold-cache install of a superseded pin now fails rather than silently installing something else (#96).
+- `stacy run` checks every locked package against the cache before starting Stata and fails on a missing or modified one. `run --no-verify` skips the check (#97).
+- A successful run removes its log in every output format. `--format json`/`stata` kept it, so each in-Stata `stacy_run` left one behind (#98).
+
 ### Fixed
 
+- `stacy run` no longer drops streamed output that looks like a command echo. Echo detection ran on the trimmed line, so indented result lines went with it: every data row of `list`, the missing-value row of `tabulate, missing`, `display "1. step"`. The log was never affected (#95).
+- `[run] log_dir` is honored. Per-script logs were written to the project root and kept after a successful run (#98).
+- `stacy env` checks the cache before calling a locked package installed. A cold cache reported every package as installed (#99).
+- `stacy add <name> --source local:<dir>` requires the directory to hold the named package instead of installing whatever it contains (#100).
+- `stacy doctor` no longer reports a package's own shipped files as missing dependencies. ftools' internal `.mata` files were listed as missing SSC packages, with a `stacy add` tip that could not work (#101).
 - A task that defines no work — a table without `script` or `parallel` (e.g. a typo'd key, which TOML parsing silently drops) or an empty array — now fails with a config error instead of succeeding as a no-op (#92).
 
 ## [1.4.0] - 2026-07-13

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
     email: jfasnacht@uchicago.edu
 repository-code: https://github.com/janfasnacht/stacy
 license: MIT
-version: 1.4.0
+version: 1.5.0
 date-released: 2026-07-13
 keywords:
   - stata

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,7 +1624,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacy"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "xtask"]
 
 [package]
 name = "stacy"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 rust-version = "1.87"
 authors = ["Jan Fasnacht <jfasnacht@uchicago.edu>"]

--- a/stata/_stacy_check_version.ado
+++ b/stata/_stacy_check_version.ado
@@ -1,6 +1,6 @@
 *! _stacy_check_version.ado - Wrapper/binary version compatibility check
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 
@@ -13,7 +13,7 @@ program define _stacy_check_version, rclass
         exit 0
     }
 
-    local expected "1.4.0"
+    local expected "1.5.0"
 
     * Capture `<binary> --version` output.
     tempfile ver_out

--- a/stata/_stacy_compat_version.ado
+++ b/stata/_stacy_compat_version.ado
@@ -1,10 +1,10 @@
 *! _stacy_compat_version.ado - Wrapper version constant
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 
 program define _stacy_compat_version, rclass
     version 14.0
-    return local version "1.4.0"
+    return local version "1.5.0"
 end

--- a/stata/_stacy_exec.ado
+++ b/stata/_stacy_exec.ado
@@ -1,6 +1,6 @@
 *! _stacy_exec.ado - Execute stacy command and capture Stata-native output
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 
 /*
     Execute a stacy CLI command and capture Stata-native output.

--- a/stata/_stacy_find_binary.ado
+++ b/stata/_stacy_find_binary.ado
@@ -1,6 +1,6 @@
 *! _stacy_find_binary.ado - Locate stacy binary
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 
 /*
     Find the stacy binary path.

--- a/stata/_stacy_semver_cmp.ado
+++ b/stata/_stacy_semver_cmp.ado
@@ -1,6 +1,6 @@
 *! _stacy_semver_cmp.ado - Semver comparison helper
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy.ado
+++ b/stata/stacy.ado
@@ -1,5 +1,5 @@
 *! stacy.ado - Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! Author: Jan Fasnacht
 *! URL: https://github.com/janfasnacht/stacy
 *! AUTO-GENERATED - DO NOT EDIT
@@ -109,7 +109,7 @@ program define stacy, rclass
         stacy_setup `0'
     }
     else if "`subcmd'" == "version" | "`subcmd'" == "--version" {
-        di as text "stacy Stata wrapper v1.4.0"
+        di as text "stacy Stata wrapper v1.5.0"
     }
     else if "`subcmd'" == "help" | "`subcmd'" == "--help" {
         help stacy

--- a/stata/stacy_add.ado
+++ b/stata/stacy_add.ado
@@ -1,6 +1,6 @@
 *! stacy_add.ado - Add packages to project
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_bench.ado
+++ b/stata/stacy_bench.ado
@@ -1,6 +1,6 @@
 *! stacy_bench.ado - Benchmark script execution
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_cache_clean.ado
+++ b/stata/stacy_cache_clean.ado
@@ -1,6 +1,6 @@
 *! stacy_cache_clean.ado - Remove cached entries
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_cache_info.ado
+++ b/stata/stacy_cache_info.ado
@@ -1,6 +1,6 @@
 *! stacy_cache_info.ado - Show cache statistics
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_deps.ado
+++ b/stata/stacy_deps.ado
@@ -1,6 +1,6 @@
 *! stacy_deps.ado - Show dependency tree for Stata scripts
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_doctor.ado
+++ b/stata/stacy_doctor.ado
@@ -1,6 +1,6 @@
 *! stacy_doctor.ado - Run system diagnostics
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_env.ado
+++ b/stata/stacy_env.ado
@@ -1,6 +1,6 @@
 *! stacy_env.ado - Show environment configuration
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_explain.ado
+++ b/stata/stacy_explain.ado
@@ -1,6 +1,6 @@
 *! stacy_explain.ado - Look up Stata error code details
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_init.ado
+++ b/stata/stacy_init.ado
@@ -1,6 +1,6 @@
 *! stacy_init.ado - Initialize new stacy project
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_install.ado
+++ b/stata/stacy_install.ado
@@ -1,6 +1,6 @@
 *! stacy_install.ado - Install packages from lockfile or SSC/GitHub
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_list.ado
+++ b/stata/stacy_list.ado
@@ -1,6 +1,6 @@
 *! stacy_list.ado - List installed packages
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_lock.ado
+++ b/stata/stacy_lock.ado
@@ -1,6 +1,6 @@
 *! stacy_lock.ado - Generate or verify lockfile
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_outdated.ado
+++ b/stata/stacy_outdated.ado
@@ -1,6 +1,6 @@
 *! stacy_outdated.ado - Check for package updates
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_remove.ado
+++ b/stata/stacy_remove.ado
@@ -1,6 +1,6 @@
 *! stacy_remove.ado - Remove packages from project
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_run.ado
+++ b/stata/stacy_run.ado
@@ -1,6 +1,6 @@
 *! stacy_run.ado - Execute a Stata script with error detection
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_setup.ado
+++ b/stata/stacy_setup.ado
@@ -1,6 +1,6 @@
 *! stacy_setup.ado - Download and install stacy binary
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 
 /*
     Download and install the stacy binary from GitHub releases.

--- a/stata/stacy_task.ado
+++ b/stata/stacy_task.ado
@@ -1,6 +1,6 @@
 *! stacy_task.ado - Run tasks from stacy.toml
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_test.ado
+++ b/stata/stacy_test.ado
@@ -1,6 +1,6 @@
 *! stacy_test.ado - Run tests
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_update.ado
+++ b/stata/stacy_update.ado
@@ -1,6 +1,6 @@
 *! stacy_update.ado - Update packages to latest versions
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.4.0
+*! Version: 1.5.0
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 


### PR DESCRIPTION
Eight fixes (#94–#101), plus the two follow-ups found by running the in-Stata suite against Stata.

The headline is behavioral: package commands that could not finish their work used to exit 0, and now exit nonzero. That will surface failures a script or CI step previously ran past. `stacy.toml` also rejects unknown keys now, and `install` no longer rewrites `stacy.lock`. The changelog leads with these under Changed.

`make check` passes, and `cargo test -- --ignored` passes against Stata apart from #109, which fails identically on 1.4.0.