### PR TITLE
fix: help files and package manifests advertise the shipped release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Help files report the version they ship with. Every `.sthlp` header read `1.2.0` (`stacy_setup.sthlp`, `0.1.0`) while the `.ado` files read the package version, so `help stacy` disagreed with the command it documents (#114).
+- `stacy.pkg` and `stata.toc` carry the release date, so `adoupdate` sees new releases. Both had advertised `20260118` since 1.0.0 (#114).
+
 ## [1.5.0] - 2026-07-13
 
 Commands that could not finish their work used to exit 0. They now exit nonzero, which will surface failures a script or CI step previously ran past. See Changed.
@@ -180,6 +185,12 @@ Initial public release.
 - `--format json` and `--format stata` output modes
 - Cross-platform support: macOS, Linux, Windows
 
+[Unreleased]: https://github.com/janfasnacht/stacy/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/janfasnacht/stacy/compare/v1.4.0...v1.5.0
+[1.4.0]: https://github.com/janfasnacht/stacy/compare/v1.3.1...v1.4.0
+[1.3.1]: https://github.com/janfasnacht/stacy/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/janfasnacht/stacy/compare/v1.2.1...v1.3.0
+[1.2.1]: https://github.com/janfasnacht/stacy/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/janfasnacht/stacy/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/janfasnacht/stacy/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/janfasnacht/stacy/compare/v1.0.1...v1.0.2

--- a/schema/commands.toml
+++ b/schema/commands.toml
@@ -7,11 +7,10 @@
 #   3. Help files (stata/*.sthlp) - generated from this schema
 #   4. Documentation (docs/src/commands/*.md) - generated from this schema
 #
-# Version: 1.2.0
-# Last Updated: 2026-03-15
+# Versions shown in generated files come from Cargo.toml, not from here.
+# Last Updated: 2026-07-30
 
 [meta]
-version = "1.2.0"
 stata_minimum = "14.0"
 description = "Reproducible Stata Workflow Tool"
 

--- a/stata/stacy.pkg
+++ b/stata/stacy.pkg
@@ -9,7 +9,7 @@ d Support: https://github.com/janfasnacht/stacy
 d
 d Requires: Stata 14.0 or higher
 d
-d Distribution-Date: 20260118
+d Distribution-Date: 20260713
 d
 
 * Core utilities (internal)

--- a/stata/stacy.sthlp
+++ b/stata/stacy.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy##syntax"}{...}
 {viewerjumpto "Description" "stacy##description"}{...}
 {viewerjumpto "Commands" "stacy##commands"}{...}

--- a/stata/stacy_add.sthlp
+++ b/stata/stacy_add.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_add##syntax"}{...}
 {viewerjumpto "Description" "stacy_add##description"}{...}
 {viewerjumpto "Options" "stacy_add##options"}{...}

--- a/stata/stacy_bench.sthlp
+++ b/stata/stacy_bench.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_bench##syntax"}{...}
 {viewerjumpto "Description" "stacy_bench##description"}{...}
 {viewerjumpto "Options" "stacy_bench##options"}{...}

--- a/stata/stacy_cache_clean.sthlp
+++ b/stata/stacy_cache_clean.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_cache_clean##syntax"}{...}
 {viewerjumpto "Description" "stacy_cache_clean##description"}{...}
 {viewerjumpto "Options" "stacy_cache_clean##options"}{...}

--- a/stata/stacy_cache_info.sthlp
+++ b/stata/stacy_cache_info.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_cache_info##syntax"}{...}
 {viewerjumpto "Description" "stacy_cache_info##description"}{...}
 {viewerjumpto "Options" "stacy_cache_info##options"}{...}

--- a/stata/stacy_deps.sthlp
+++ b/stata/stacy_deps.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_deps##syntax"}{...}
 {viewerjumpto "Description" "stacy_deps##description"}{...}
 {viewerjumpto "Options" "stacy_deps##options"}{...}

--- a/stata/stacy_doctor.sthlp
+++ b/stata/stacy_doctor.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_doctor##syntax"}{...}
 {viewerjumpto "Description" "stacy_doctor##description"}{...}
 {viewerjumpto "Options" "stacy_doctor##options"}{...}

--- a/stata/stacy_env.sthlp
+++ b/stata/stacy_env.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_env##syntax"}{...}
 {viewerjumpto "Description" "stacy_env##description"}{...}
 {viewerjumpto "Options" "stacy_env##options"}{...}

--- a/stata/stacy_explain.sthlp
+++ b/stata/stacy_explain.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_explain##syntax"}{...}
 {viewerjumpto "Description" "stacy_explain##description"}{...}
 {viewerjumpto "Options" "stacy_explain##options"}{...}

--- a/stata/stacy_init.sthlp
+++ b/stata/stacy_init.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_init##syntax"}{...}
 {viewerjumpto "Description" "stacy_init##description"}{...}
 {viewerjumpto "Options" "stacy_init##options"}{...}

--- a/stata/stacy_install.sthlp
+++ b/stata/stacy_install.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_install##syntax"}{...}
 {viewerjumpto "Description" "stacy_install##description"}{...}
 {viewerjumpto "Options" "stacy_install##options"}{...}

--- a/stata/stacy_list.sthlp
+++ b/stata/stacy_list.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_list##syntax"}{...}
 {viewerjumpto "Description" "stacy_list##description"}{...}
 {viewerjumpto "Options" "stacy_list##options"}{...}

--- a/stata/stacy_lock.sthlp
+++ b/stata/stacy_lock.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_lock##syntax"}{...}
 {viewerjumpto "Description" "stacy_lock##description"}{...}
 {viewerjumpto "Options" "stacy_lock##options"}{...}

--- a/stata/stacy_outdated.sthlp
+++ b/stata/stacy_outdated.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_outdated##syntax"}{...}
 {viewerjumpto "Description" "stacy_outdated##description"}{...}
 {viewerjumpto "Options" "stacy_outdated##options"}{...}

--- a/stata/stacy_remove.sthlp
+++ b/stata/stacy_remove.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_remove##syntax"}{...}
 {viewerjumpto "Description" "stacy_remove##description"}{...}
 {viewerjumpto "Options" "stacy_remove##options"}{...}

--- a/stata/stacy_run.sthlp
+++ b/stata/stacy_run.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_run##syntax"}{...}
 {viewerjumpto "Description" "stacy_run##description"}{...}
 {viewerjumpto "Options" "stacy_run##options"}{...}

--- a/stata/stacy_setup.sthlp
+++ b/stata/stacy_setup.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 0.1.0 18jan2026}{...}
+{* *! version 1.5.0}{...}
 {viewerjumpto "Syntax" "stacy_setup##syntax"}{...}
 {viewerjumpto "Description" "stacy_setup##description"}{...}
 {viewerjumpto "Options" "stacy_setup##options"}{...}

--- a/stata/stacy_task.sthlp
+++ b/stata/stacy_task.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_task##syntax"}{...}
 {viewerjumpto "Description" "stacy_task##description"}{...}
 {viewerjumpto "Options" "stacy_task##options"}{...}

--- a/stata/stacy_test.sthlp
+++ b/stata/stacy_test.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_test##syntax"}{...}
 {viewerjumpto "Description" "stacy_test##description"}{...}
 {viewerjumpto "Options" "stacy_test##options"}{...}

--- a/stata/stacy_update.sthlp
+++ b/stata/stacy_update.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.2.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.0 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_update##syntax"}{...}
 {viewerjumpto "Description" "stacy_update##description"}{...}
 {viewerjumpto "Options" "stacy_update##options"}{...}

--- a/stata/stata.toc
+++ b/stata/stata.toc
@@ -15,6 +15,6 @@ d   - Project initialization and configuration
 d
 d Requires: Stata 14.0 or higher
 d
-d Distribution-Date: 20260118
+d Distribution-Date: 20260713
 d
 p stacy Reproducible Stata Workflow Tool

--- a/tests/test_schema_conformance.rs
+++ b/tests/test_schema_conformance.rs
@@ -678,6 +678,84 @@ fn test_version_compat_ados_match_cargo_toml() {
     );
 }
 
+/// The package version from Cargo.toml.
+fn package_version() -> String {
+    let cargo_toml = fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+        .expect("Failed to read Cargo.toml");
+    let parsed: toml::Value = toml::from_str(&cargo_toml).expect("Failed to parse Cargo.toml");
+    parsed["package"]["version"]
+        .as_str()
+        .expect("Cargo.toml missing package.version")
+        .to_string()
+}
+
+/// Every `.sthlp` header must carry the package version, or `help stacy`
+/// reports a different version than the command it documents (issue #114).
+#[test]
+fn test_sthlp_headers_match_cargo_toml() {
+    let pkg_version = package_version();
+    let stata_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("stata");
+    let expected = format!("{{* *! version {}", pkg_version);
+
+    let entries = fs::read_dir(&stata_dir).expect("Failed to read stata/");
+    for entry in entries {
+        let entry = entry.expect("Failed to read dir entry");
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("sthlp") {
+            continue;
+        }
+        let content = fs::read_to_string(&path)
+            .unwrap_or_else(|_| panic!("Failed to read {}", path.display()));
+        let header = content
+            .lines()
+            .find(|line| line.starts_with("{* *! version "))
+            .unwrap_or_else(|| panic!("{} has no version header", path.display()));
+
+        assert!(
+            header.starts_with(&expected),
+            "{}: header `{}` does not match Cargo.toml ({}). Run `cargo xtask codegen`.",
+            path.display(),
+            header,
+            pkg_version,
+        );
+    }
+}
+
+/// Stata compares `Distribution-Date` against the installed copy to decide
+/// whether `adoupdate` has anything to offer, so it must move with each
+/// release (issue #114).
+#[test]
+fn test_manifest_distribution_date_matches_changelog() {
+    let pkg_version = package_version();
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let changelog =
+        fs::read_to_string(root.join("CHANGELOG.md")).expect("Failed to read CHANGELOG");
+
+    // An unreleased version has no CHANGELOG entry yet; codegen leaves the
+    // manifests alone until it does.
+    let Some(date) = changelog
+        .lines()
+        .find(|line| line.starts_with(&format!("## [{}]", pkg_version)))
+        .and_then(|line| line.split(" - ").nth(1))
+        .map(|date| date.trim().replace('-', ""))
+    else {
+        return;
+    };
+
+    let expected = format!("d Distribution-Date: {}", date);
+    for file in ["stacy.pkg", "stata.toc"] {
+        let content = fs::read_to_string(root.join("stata").join(file))
+            .unwrap_or_else(|_| panic!("Failed to read {}", file));
+        assert!(
+            content.lines().any(|line| line == expected),
+            "{} does not carry the {} release date ({}). Run `cargo xtask codegen`.",
+            file,
+            pkg_version,
+            date,
+        );
+    }
+}
+
 /// Stata only autoloads an `.ado` when its basename matches the first
 /// `program define` — otherwise callers hit `r(199)` (issue #37).
 #[test]

--- a/xtask/src/codegen.rs
+++ b/xtask/src/codegen.rs
@@ -36,14 +36,50 @@ const HAND_MAINTAINED_VERSIONED_ADOS: &[&str] = &[
     "stacy_setup.ado",
 ];
 
+/// Hand-maintained .sthlp files whose `{* *! version ...}` header is kept in
+/// sync with `Cargo.toml` by codegen. The bodies remain hand-edited.
+const HAND_MAINTAINED_VERSIONED_HELP: &[&str] = &["stacy_setup.sthlp"];
+
+/// Hand-maintained package manifests whose `d Distribution-Date:` line is kept
+/// in sync with the release date of the current version. Stata compares this
+/// date to decide whether `adoupdate` has anything to offer, so a stale one
+/// hides every release from users who installed with `net install`.
+const HAND_MAINTAINED_DATED_MANIFESTS: &[&str] = &["stacy.pkg", "stata.toc"];
+
 /// Replace the `*! Version: ...` header line in a hand-maintained .ado file
 /// with the current package version. Other lines are preserved verbatim.
 fn rewrite_version_header(content: &str, version: &str) -> String {
+    rewrite_prefixed_line(content, "*! Version: ", &format!("*! Version: {}", version))
+}
+
+/// Replace the `{* *! version ...}` header line in a hand-maintained .sthlp
+/// file with the current package version. Other lines are preserved verbatim.
+fn rewrite_help_version_header(content: &str, version: &str) -> String {
+    rewrite_prefixed_line(
+        content,
+        "{* *! version ",
+        &format!("{{* *! version {}}}{{...}}", version),
+    )
+}
+
+/// Replace the `d Distribution-Date: ...` line in a hand-maintained `.pkg` or
+/// `.toc` with `date` (YYYYMMDD). Other lines are preserved verbatim.
+fn rewrite_distribution_date(content: &str, date: &str) -> String {
+    rewrite_prefixed_line(
+        content,
+        "d Distribution-Date: ",
+        &format!("d Distribution-Date: {}", date),
+    )
+}
+
+/// Rewrite every line starting with `prefix` to `replacement`, keeping line
+/// endings and all other lines verbatim.
+fn rewrite_prefixed_line(content: &str, prefix: &str, replacement: &str) -> String {
     let mut out = String::with_capacity(content.len());
     for line in content.split_inclusive('\n') {
         let stripped = line.strip_suffix('\n').unwrap_or(line);
-        if stripped.starts_with("*! Version: ") {
-            out.push_str(&format!("*! Version: {}", version));
+        if stripped.starts_with(prefix) {
+            out.push_str(replacement);
             if line.ends_with('\n') {
                 out.push('\n');
             }
@@ -52,6 +88,13 @@ fn rewrite_version_header(content: &str, version: &str) -> String {
         }
     }
     out
+}
+
+/// The release date of `version` as YYYYMMDD, from CHANGELOG.md. `None` when
+/// the version has no entry yet, in which case manifests are left alone rather
+/// than stamped with a date that would change on every run.
+fn distribution_date(version: &str) -> Option<String> {
+    Some(extract_changelog_date(version)?.replace('-', ""))
 }
 
 /// Run code generation
@@ -80,7 +123,7 @@ pub fn run(check: bool, verbose: bool) -> Result<()> {
         let ado_path = stata_dir.join(format!("{}.ado", command.stata_command));
 
         // Generate .sthlp file
-        let sthlp_content = generate_sthlp(name, command, &schema)?;
+        let sthlp_content = generate_sthlp(name, command, &version)?;
         let sthlp_path = stata_dir.join(format!("{}.sthlp", command.stata_command));
 
         generated_files.push((ado_path, ado_content));
@@ -92,7 +135,7 @@ pub fn run(check: bool, verbose: bool) -> Result<()> {
     generated_files.push((stata_dir.join("stacy.ado"), main_ado));
 
     // Generate main stacy.sthlp
-    let main_sthlp = generate_main_sthlp(&schema)?;
+    let main_sthlp = generate_main_sthlp(&schema, &version)?;
     generated_files.push((stata_dir.join("stacy.sthlp"), main_sthlp));
 
     // Generate wrapper/binary version-compatibility helpers. Split into three
@@ -119,6 +162,26 @@ pub fn run(check: bool, verbose: bool) -> Result<()> {
             .with_context(|| format!("Failed to read {}", path.display()))?;
         let updated = rewrite_version_header(&existing, &version);
         generated_files.push((path, updated));
+    }
+
+    for file in HAND_MAINTAINED_VERSIONED_HELP {
+        let path = stata_dir.join(file);
+        let existing = std::fs::read_to_string(&path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        let updated = rewrite_help_version_header(&existing, &version);
+        generated_files.push((path, updated));
+    }
+
+    // Stamp the release date of this version on the package manifests so
+    // adoupdate sees a new distribution.
+    if let Some(date) = distribution_date(&version) {
+        for file in HAND_MAINTAINED_DATED_MANIFESTS {
+            let path = stata_dir.join(file);
+            let existing = std::fs::read_to_string(&path)
+                .with_context(|| format!("Failed to read {}", path.display()))?;
+            let updated = rewrite_distribution_date(&existing, &date);
+            generated_files.push((path, updated));
+        }
     }
 
     // Generate documentation markdown files
@@ -456,14 +519,14 @@ fn build_stata_syntax(command: &Command) -> String {
 // =============================================================================
 
 /// Generate a command help .sthlp file
-fn generate_sthlp(name: &str, command: &Command, schema: &Schema) -> Result<String> {
+fn generate_sthlp(name: &str, command: &Command, version: &str) -> Result<String> {
     let mut out = String::new();
 
     // Header
     out.push_str("{smcl}\n");
     out.push_str(&format!(
         "{{* *! version {} - AUTO-GENERATED}}{{...}}\n",
-        schema.meta.version
+        version
     ));
     out.push_str(&format!(
         "{{viewerjumpto \"Syntax\" \"{}##syntax\"}}{{...}}\n",
@@ -726,13 +789,13 @@ fn generate_main_ado(schema: &Schema, version: &str) -> Result<String> {
 }
 
 /// Generate the main stacy.sthlp help file
-fn generate_main_sthlp(schema: &Schema) -> Result<String> {
+fn generate_main_sthlp(schema: &Schema, version: &str) -> Result<String> {
     let mut out = String::new();
 
     out.push_str("{smcl}\n");
     out.push_str(&format!(
         "{{* *! version {} - AUTO-GENERATED}}{{...}}\n",
-        schema.meta.version
+        version
     ));
     out.push_str("{viewerjumpto \"Syntax\" \"stacy##syntax\"}{...}\n");
     out.push_str("{viewerjumpto \"Description\" \"stacy##description\"}{...}\n");
@@ -1348,4 +1411,33 @@ fn chrono_free_today() -> String {
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|| "1970-01-01".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrites_only_the_help_version_line() {
+        let content = "{smcl}\n{* *! version 0.1.0 18jan2026}{...}\n{title:Title}\n";
+        assert_eq!(
+            rewrite_help_version_header(content, "1.5.1"),
+            "{smcl}\n{* *! version 1.5.1}{...}\n{title:Title}\n"
+        );
+    }
+
+    #[test]
+    fn rewrites_only_the_distribution_date_line() {
+        let content = "d Requires: Stata 14.0 or higher\nd Distribution-Date: 20260118\nd\n";
+        assert_eq!(
+            rewrite_distribution_date(content, "20260713"),
+            "d Requires: Stata 14.0 or higher\nd Distribution-Date: 20260713\nd\n"
+        );
+    }
+
+    #[test]
+    fn leaves_a_file_without_the_line_untouched() {
+        let content = "d stacy\nf stacy.ado\n";
+        assert_eq!(rewrite_distribution_date(content, "20260713"), content);
+    }
 }

--- a/xtask/src/schema.rs
+++ b/xtask/src/schema.rs
@@ -37,9 +37,6 @@ pub struct ExitCodeDef {
 /// Schema metadata
 #[derive(Debug, Deserialize)]
 pub struct Meta {
-    /// Schema version (for compatibility tracking)
-    #[allow(dead_code)]
-    pub version: String,
     /// Minimum Stata version required
     #[allow(dead_code)]
     pub stata_minimum: String,
@@ -251,10 +248,6 @@ mod tests {
 
         let schema = Schema::load(&schema_path).expect("Failed to load schema");
 
-        assert!(
-            !schema.meta.version.is_empty(),
-            "schema version should not be empty"
-        );
         assert!(schema.commands.contains_key("run"));
         assert!(schema.commands.contains_key("doctor"));
     }


### PR DESCRIPTION
`help stacy` named a different version than the command it documents. The `.sthlp` headers took their version from `[meta] version` in `schema/commands.toml`, last touched at 1.2.0, while the `.ado` files took theirs from `Cargo.toml`. `stacy_setup.sthlp` is hand-maintained and read 0.1.0. Codegen now writes the package version into every help header, including the hand-maintained one, and the key that caused it is gone — nothing else read it.

The same class of bug, found while fixing that one: `stacy.pkg` and `stata.toc` had advertised `Distribution-Date: 20260118` since 1.0.0. Stata compares that date against the installed copy, so `adoupdate` reported every release as up to date and no one who installed with `net install` was ever offered an upgrade. Codegen now stamps the release date of the current version, read from `CHANGELOG.md`, and leaves the manifests alone when the version has no entry yet, so a run before the entry exists cannot stamp a date that moves daily.

Conformance tests assert every help header against `Cargo.toml` and both manifest dates against `CHANGELOG.md`, so a bump without codegen fails CI. Unit tests cover the three header rewrites.

The changelog's compare links also stopped at 1.2.0, which left every heading from 1.2.1 on as plain text on the docs site; added in a separate commit.

Closes #114