### PR TITLE
release: v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-07-30
+
 ### Fixed
 
 - Help files report the version they ship with. Every `.sthlp` header read `1.2.0` (`stacy_setup.sthlp`, `0.1.0`) while the `.ado` files read the package version, so `help stacy` disagreed with the command it documents (#114).
@@ -185,7 +187,8 @@ Initial public release.
 - `--format json` and `--format stata` output modes
 - Cross-platform support: macOS, Linux, Windows
 
-[Unreleased]: https://github.com/janfasnacht/stacy/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/janfasnacht/stacy/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/janfasnacht/stacy/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/janfasnacht/stacy/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/janfasnacht/stacy/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/janfasnacht/stacy/compare/v1.3.0...v1.3.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
     email: jfasnacht@uchicago.edu
 repository-code: https://github.com/janfasnacht/stacy
 license: MIT
-version: 1.5.0
-date-released: 2026-07-13
+version: 1.5.1
+date-released: 2026-07-30
 keywords:
   - stata
   - reproducibility

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacy"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "xtask"]
 
 [package]
 name = "stacy"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 rust-version = "1.87"
 authors = ["Jan Fasnacht <jfasnacht@uchicago.edu>"]

--- a/stata/_stacy_check_version.ado
+++ b/stata/_stacy_check_version.ado
@@ -1,6 +1,6 @@
 *! _stacy_check_version.ado - Wrapper/binary version compatibility check
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 
@@ -13,7 +13,7 @@ program define _stacy_check_version, rclass
         exit 0
     }
 
-    local expected "1.5.0"
+    local expected "1.5.1"
 
     * Capture `<binary> --version` output.
     tempfile ver_out

--- a/stata/_stacy_compat_version.ado
+++ b/stata/_stacy_compat_version.ado
@@ -1,10 +1,10 @@
 *! _stacy_compat_version.ado - Wrapper version constant
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 
 program define _stacy_compat_version, rclass
     version 14.0
-    return local version "1.5.0"
+    return local version "1.5.1"
 end

--- a/stata/_stacy_exec.ado
+++ b/stata/_stacy_exec.ado
@@ -1,6 +1,6 @@
 *! _stacy_exec.ado - Execute stacy command and capture Stata-native output
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 
 /*
     Execute a stacy CLI command and capture Stata-native output.

--- a/stata/_stacy_find_binary.ado
+++ b/stata/_stacy_find_binary.ado
@@ -1,6 +1,6 @@
 *! _stacy_find_binary.ado - Locate stacy binary
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 
 /*
     Find the stacy binary path.

--- a/stata/_stacy_semver_cmp.ado
+++ b/stata/_stacy_semver_cmp.ado
@@ -1,6 +1,6 @@
 *! _stacy_semver_cmp.ado - Semver comparison helper
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy.ado
+++ b/stata/stacy.ado
@@ -1,5 +1,5 @@
 *! stacy.ado - Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! Author: Jan Fasnacht
 *! URL: https://github.com/janfasnacht/stacy
 *! AUTO-GENERATED - DO NOT EDIT
@@ -109,7 +109,7 @@ program define stacy, rclass
         stacy_setup `0'
     }
     else if "`subcmd'" == "version" | "`subcmd'" == "--version" {
-        di as text "stacy Stata wrapper v1.5.0"
+        di as text "stacy Stata wrapper v1.5.1"
     }
     else if "`subcmd'" == "help" | "`subcmd'" == "--help" {
         help stacy

--- a/stata/stacy.pkg
+++ b/stata/stacy.pkg
@@ -9,7 +9,7 @@ d Support: https://github.com/janfasnacht/stacy
 d
 d Requires: Stata 14.0 or higher
 d
-d Distribution-Date: 20260713
+d Distribution-Date: 20260730
 d
 
 * Core utilities (internal)

--- a/stata/stacy.sthlp
+++ b/stata/stacy.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy##syntax"}{...}
 {viewerjumpto "Description" "stacy##description"}{...}
 {viewerjumpto "Commands" "stacy##commands"}{...}

--- a/stata/stacy_add.ado
+++ b/stata/stacy_add.ado
@@ -1,6 +1,6 @@
 *! stacy_add.ado - Add packages to project
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_add.sthlp
+++ b/stata/stacy_add.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_add##syntax"}{...}
 {viewerjumpto "Description" "stacy_add##description"}{...}
 {viewerjumpto "Options" "stacy_add##options"}{...}

--- a/stata/stacy_bench.ado
+++ b/stata/stacy_bench.ado
@@ -1,6 +1,6 @@
 *! stacy_bench.ado - Benchmark script execution
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_bench.sthlp
+++ b/stata/stacy_bench.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_bench##syntax"}{...}
 {viewerjumpto "Description" "stacy_bench##description"}{...}
 {viewerjumpto "Options" "stacy_bench##options"}{...}

--- a/stata/stacy_cache_clean.ado
+++ b/stata/stacy_cache_clean.ado
@@ -1,6 +1,6 @@
 *! stacy_cache_clean.ado - Remove cached entries
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_cache_clean.sthlp
+++ b/stata/stacy_cache_clean.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_cache_clean##syntax"}{...}
 {viewerjumpto "Description" "stacy_cache_clean##description"}{...}
 {viewerjumpto "Options" "stacy_cache_clean##options"}{...}

--- a/stata/stacy_cache_info.ado
+++ b/stata/stacy_cache_info.ado
@@ -1,6 +1,6 @@
 *! stacy_cache_info.ado - Show cache statistics
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_cache_info.sthlp
+++ b/stata/stacy_cache_info.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_cache_info##syntax"}{...}
 {viewerjumpto "Description" "stacy_cache_info##description"}{...}
 {viewerjumpto "Options" "stacy_cache_info##options"}{...}

--- a/stata/stacy_deps.ado
+++ b/stata/stacy_deps.ado
@@ -1,6 +1,6 @@
 *! stacy_deps.ado - Show dependency tree for Stata scripts
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_deps.sthlp
+++ b/stata/stacy_deps.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_deps##syntax"}{...}
 {viewerjumpto "Description" "stacy_deps##description"}{...}
 {viewerjumpto "Options" "stacy_deps##options"}{...}

--- a/stata/stacy_doctor.ado
+++ b/stata/stacy_doctor.ado
@@ -1,6 +1,6 @@
 *! stacy_doctor.ado - Run system diagnostics
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_doctor.sthlp
+++ b/stata/stacy_doctor.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_doctor##syntax"}{...}
 {viewerjumpto "Description" "stacy_doctor##description"}{...}
 {viewerjumpto "Options" "stacy_doctor##options"}{...}

--- a/stata/stacy_env.ado
+++ b/stata/stacy_env.ado
@@ -1,6 +1,6 @@
 *! stacy_env.ado - Show environment configuration
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_env.sthlp
+++ b/stata/stacy_env.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_env##syntax"}{...}
 {viewerjumpto "Description" "stacy_env##description"}{...}
 {viewerjumpto "Options" "stacy_env##options"}{...}

--- a/stata/stacy_explain.ado
+++ b/stata/stacy_explain.ado
@@ -1,6 +1,6 @@
 *! stacy_explain.ado - Look up Stata error code details
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_explain.sthlp
+++ b/stata/stacy_explain.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_explain##syntax"}{...}
 {viewerjumpto "Description" "stacy_explain##description"}{...}
 {viewerjumpto "Options" "stacy_explain##options"}{...}

--- a/stata/stacy_init.ado
+++ b/stata/stacy_init.ado
@@ -1,6 +1,6 @@
 *! stacy_init.ado - Initialize new stacy project
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_init.sthlp
+++ b/stata/stacy_init.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_init##syntax"}{...}
 {viewerjumpto "Description" "stacy_init##description"}{...}
 {viewerjumpto "Options" "stacy_init##options"}{...}

--- a/stata/stacy_install.ado
+++ b/stata/stacy_install.ado
@@ -1,6 +1,6 @@
 *! stacy_install.ado - Install packages from lockfile or SSC/GitHub
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_install.sthlp
+++ b/stata/stacy_install.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_install##syntax"}{...}
 {viewerjumpto "Description" "stacy_install##description"}{...}
 {viewerjumpto "Options" "stacy_install##options"}{...}

--- a/stata/stacy_list.ado
+++ b/stata/stacy_list.ado
@@ -1,6 +1,6 @@
 *! stacy_list.ado - List installed packages
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_list.sthlp
+++ b/stata/stacy_list.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_list##syntax"}{...}
 {viewerjumpto "Description" "stacy_list##description"}{...}
 {viewerjumpto "Options" "stacy_list##options"}{...}

--- a/stata/stacy_lock.ado
+++ b/stata/stacy_lock.ado
@@ -1,6 +1,6 @@
 *! stacy_lock.ado - Generate or verify lockfile
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_lock.sthlp
+++ b/stata/stacy_lock.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_lock##syntax"}{...}
 {viewerjumpto "Description" "stacy_lock##description"}{...}
 {viewerjumpto "Options" "stacy_lock##options"}{...}

--- a/stata/stacy_outdated.ado
+++ b/stata/stacy_outdated.ado
@@ -1,6 +1,6 @@
 *! stacy_outdated.ado - Check for package updates
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_outdated.sthlp
+++ b/stata/stacy_outdated.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_outdated##syntax"}{...}
 {viewerjumpto "Description" "stacy_outdated##description"}{...}
 {viewerjumpto "Options" "stacy_outdated##options"}{...}

--- a/stata/stacy_remove.ado
+++ b/stata/stacy_remove.ado
@@ -1,6 +1,6 @@
 *! stacy_remove.ado - Remove packages from project
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_remove.sthlp
+++ b/stata/stacy_remove.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_remove##syntax"}{...}
 {viewerjumpto "Description" "stacy_remove##description"}{...}
 {viewerjumpto "Options" "stacy_remove##options"}{...}

--- a/stata/stacy_run.ado
+++ b/stata/stacy_run.ado
@@ -1,6 +1,6 @@
 *! stacy_run.ado - Execute a Stata script with error detection
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_run.sthlp
+++ b/stata/stacy_run.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_run##syntax"}{...}
 {viewerjumpto "Description" "stacy_run##description"}{...}
 {viewerjumpto "Options" "stacy_run##options"}{...}

--- a/stata/stacy_setup.ado
+++ b/stata/stacy_setup.ado
@@ -1,6 +1,6 @@
 *! stacy_setup.ado - Download and install stacy binary
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 
 /*
     Download and install the stacy binary from GitHub releases.

--- a/stata/stacy_setup.sthlp
+++ b/stata/stacy_setup.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0}{...}
+{* *! version 1.5.1}{...}
 {viewerjumpto "Syntax" "stacy_setup##syntax"}{...}
 {viewerjumpto "Description" "stacy_setup##description"}{...}
 {viewerjumpto "Options" "stacy_setup##options"}{...}

--- a/stata/stacy_task.ado
+++ b/stata/stacy_task.ado
@@ -1,6 +1,6 @@
 *! stacy_task.ado - Run tasks from stacy.toml
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_task.sthlp
+++ b/stata/stacy_task.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_task##syntax"}{...}
 {viewerjumpto "Description" "stacy_task##description"}{...}
 {viewerjumpto "Options" "stacy_task##options"}{...}

--- a/stata/stacy_test.ado
+++ b/stata/stacy_test.ado
@@ -1,6 +1,6 @@
 *! stacy_test.ado - Run tests
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_test.sthlp
+++ b/stata/stacy_test.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_test##syntax"}{...}
 {viewerjumpto "Description" "stacy_test##description"}{...}
 {viewerjumpto "Options" "stacy_test##options"}{...}

--- a/stata/stacy_update.ado
+++ b/stata/stacy_update.ado
@@ -1,6 +1,6 @@
 *! stacy_update.ado - Update packages to latest versions
 *! Part of stacy: Reproducible Stata Workflow Tool
-*! Version: 1.5.0
+*! Version: 1.5.1
 *! AUTO-GENERATED - DO NOT EDIT
 *! Regenerate with: cargo xtask codegen
 

--- a/stata/stacy_update.sthlp
+++ b/stata/stacy_update.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.5.0 - AUTO-GENERATED}{...}
+{* *! version 1.5.1 - AUTO-GENERATED}{...}
 {viewerjumpto "Syntax" "stacy_update##syntax"}{...}
 {viewerjumpto "Description" "stacy_update##description"}{...}
 {viewerjumpto "Options" "stacy_update##options"}{...}

--- a/stata/stata.toc
+++ b/stata/stata.toc
@@ -15,6 +15,6 @@ d   - Project initialization and configuration
 d
 d Requires: Stata 14.0 or higher
 d
-d Distribution-Date: 20260713
+d Distribution-Date: 20260730
 d
 p stacy Reproducible Stata Workflow Tool


### PR DESCRIPTION
Patch release for the version and date that shipped stale in the Stata wrappers (#114, merged in #115).

Regenerated for 1.5.1: `.ado` and `.sthlp` headers read 1.5.1, `stacy.pkg` and `stata.toc` read `Distribution-Date: 20260730`, `CITATION.cff` reads 1.5.1 / 2026-07-30. No behavior changes.

Verified before tagging:

- `make check` clean.
- `cargo test --no-fail-fast -- --ignored` against StataNow 19.5. The in-Stata wrapper suite passes, as does the wrapper/binary version guard. Four pre-existing failures, each reproduced identically at v1.5.0: `test_infinite_loop_with_timeout` (tracked separately), `test_nested_success`/`test_nested_error` (need log fixtures that are generated locally, not committed), and three doc examples marked `ignore` that were never meant to compile. `test_outdated_checks_ssc_integration` timed out against SSC under parallel load and passes on its own.
- Release-notes extraction and the tag/Cargo.toml/CITATION.cff guards dry-run correctly for this tag.