### PR TITLE
fix: kill the whole run on timeout, and stop waiting 5s to return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A killed run no longer leaves Stata running. Stata was signalled through the one process stacy spawned, which is not the process that keeps running, so a timeout — or stacy being killed, or Ctrl-C — could leave a Stata process burning a core indefinitely. Runs now get their own process group, and stacy signals the group and forwards SIGINT, SIGTERM and SIGHUP to it (#118).
+- `--timeout` returns when the run dies instead of 5 seconds later. The escalation to a forced kill was an unconditional wait; it is now cancelled by the run exiting, and only a run that ignores the first signal waits it out (#118).
+- `--timeout` does something on Windows. The kill was compiled in for Unix only, so the timeout expired and nothing happened; Windows now terminates the process tree (#118).
+
 ## [1.5.1] - 2026-07-30
 
 ### Fixed

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -4,6 +4,7 @@ pub mod log_reader;
 pub mod progress;
 pub mod run_paths;
 pub mod runner;
+pub mod signals;
 pub mod verbosity;
 pub mod wrapper;
 

--- a/src/executor/runner.rs
+++ b/src/executor/runner.rs
@@ -224,8 +224,31 @@ pub fn run_stata(script: &Path, options: RunOptions) -> Result<RunResult> {
         cmd.env(&env_key, value);
     }
 
+    // Run Stata in its own process group. `stata-mp` does not stay the process
+    // we spawned — it leaves an engine behind that outlives the process we hold
+    // a handle to, so signalling that handle alone left Stata spinning forever
+    // after a timeout or a crash (#118). A group can be signalled whole.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: `setpgid` is async-signal-safe, which is the requirement for
+        // anything run between fork and exec.
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::setpgid(0, 0) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+
     // Spawn process
     let mut child = cmd.spawn()?;
+
+    // The child leads its own group, so the terminal no longer delivers Ctrl-C
+    // to it. Forward signals for as long as it is alive.
+    let _forwarding = crate::executor::signals::register(child.id() as i32);
 
     // Drain stderr on a background thread so the kernel pipe buffer can't
     // deadlock the child if it writes more than ~64 KiB. The reader caps the
@@ -302,43 +325,86 @@ pub fn run_stata(script: &Path, options: RunOptions) -> Result<RunResult> {
     })
 }
 
+/// How long a timed-out run may take to go away on its own before it is killed
+/// outright. Only ever paid by a process that ignores the polite signal.
+const KILL_GRACE: Duration = Duration::from_secs(2);
+
 /// Wait for process with timeout
 ///
-/// If timeout expires, kills the process with SIGTERM, then SIGKILL after 5s.
-/// Uses channel-based cancellation so the watchdog is cleanly stopped when
-/// the process exits before the timeout.
+/// On timeout the whole process group is terminated, then killed outright if it
+/// is still there after `KILL_GRACE`. The wait for the grace period is
+/// cancellable, so a run that dies immediately — the normal case — returns at
+/// once instead of paying the grace period on every timeout (#118).
 fn wait_with_timeout(child: &mut std::process::Child, timeout: Duration) -> Result<ExitStatus> {
     use std::sync::mpsc;
     use std::thread;
 
-    #[cfg(unix)]
     let pid = child.id();
-
     let (tx, rx) = mpsc::channel();
 
     let watchdog = thread::spawn(move || {
-        // Wait for timeout OR cancellation signal
-        if rx.recv_timeout(timeout).is_err() {
-            // Timeout expired, no cancel received — kill process
-            #[cfg(unix)]
-            unsafe {
-                libc::kill(pid as i32, libc::SIGTERM);
-
-                // SIGKILL escalation — wait 5s, then force kill if still alive
-                thread::sleep(Duration::from_secs(5));
-                if libc::kill(pid as i32, 0) == 0 {
-                    libc::kill(pid as i32, libc::SIGKILL);
-                }
-            }
+        // Cancelled before the deadline: the run finished on its own.
+        if rx.recv_timeout(timeout).is_ok() {
+            return false;
         }
-        // If Ok(_) received, process exited normally — do nothing
+
+        terminate_group(pid);
+
+        // Escalate only if the run is still there when the grace period ends.
+        if rx.recv_timeout(KILL_GRACE).is_err() {
+            kill_group(pid);
+        }
+        true
     });
 
     let status = child.wait()?;
-    let _ = tx.send(()); // Cancel watchdog (ignore error if thread already exited)
-    let _ = watchdog.join(); // Wait for clean thread shutdown
+    let _ = tx.send(()); // Cancel the watchdog (ignored if it already finished)
+    let timed_out = watchdog.join().unwrap_or(false);
+
+    // The process we waited on is gone, but anything it spawned into the group
+    // may not be — that is how Stata used to survive its own timeout. Sweep the
+    // group, which is empty in the ordinary case and costs one failed syscall.
+    if timed_out {
+        kill_group(pid);
+    }
 
     Ok(status)
+}
+
+/// Ask every process in `pid`'s group to exit.
+fn terminate_group(pid: u32) {
+    #[cfg(unix)]
+    // SAFETY: a negative pid addresses the process group.
+    unsafe {
+        libc::kill(-(pid as i32), libc::SIGTERM);
+    }
+
+    #[cfg(windows)]
+    taskkill(pid);
+}
+
+/// Kill every process in `pid`'s group outright.
+fn kill_group(pid: u32) {
+    #[cfg(unix)]
+    // SAFETY: a negative pid addresses the process group.
+    unsafe {
+        libc::kill(-(pid as i32), libc::SIGKILL);
+    }
+
+    #[cfg(windows)]
+    taskkill(pid);
+}
+
+/// Windows has no process groups to signal and no SIGTERM to send. `taskkill
+/// /T` walks the process tree, which is the behavior we want, and ships with
+/// every supported version, which beats taking a dependency for it.
+#[cfg(windows)]
+fn taskkill(pid: u32) {
+    let _ = Command::new("taskkill")
+        .args(["/T", "/F", "/PID", &pid.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
 }
 
 /// True iff the process was terminated by a signal (Unix). Always false on
@@ -525,6 +591,106 @@ mod tests {
             "stderr should be capped at {} bytes, got {}",
             super::STDERR_CAPTURE_LIMIT,
             result.stderr.len()
+        );
+    }
+
+    /// A timed-out run used to pay a fixed 5s escalation wait before returning,
+    /// so `--timeout 2` took 7s (#118). Killing was never the slow part.
+    #[cfg(unix)]
+    #[test]
+    fn test_timeout_returns_without_waiting_out_the_grace_period() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let script = temp.path().join("sleeper.sh");
+        write_executable(&script, "#!/bin/sh\nsleep 60\n");
+        let script_str = script.to_str().unwrap();
+        let log_file = temp.path().join("dummy.log");
+
+        let result = (0..3)
+            .find_map(|attempt| {
+                let options = RunOptions::new(script_str)
+                    .with_log_file(log_file.clone())
+                    .with_timeout(Duration::from_secs(1));
+                match run_stata(Path::new("anything.do"), options) {
+                    Ok(r) => Some(r),
+                    Err(crate::error::Error::Io(e))
+                        if e.kind() == std::io::ErrorKind::ExecutableFileBusy =>
+                    {
+                        std::thread::sleep(Duration::from_millis(50 * (attempt + 1)));
+                        None
+                    }
+                    Err(e) => panic!("spawn: {e:?}"),
+                }
+            })
+            .expect("spawn after ETXTBSY retries");
+
+        assert!(!result.completed, "a killed run has not completed");
+        assert!(result.signaled, "should have been killed by a signal");
+        assert!(
+            result.duration < Duration::from_secs(3),
+            "returned after {:?}: the grace period should not be paid by a run \
+             that dies on the first signal",
+            result.duration
+        );
+    }
+
+    /// Stata leaves an engine running that is not the process stacy spawned, so
+    /// signalling only that process left Stata alive after the timeout (#118).
+    /// The stub has the same shape: a parent waiting on a process it spawned.
+    ///
+    /// The descendant announces itself by writing a file three seconds in, and
+    /// the test asserts that file never appears. Asserting on the marker rather
+    /// than on a pid keeps the test honest: a descendant that simply exited on
+    /// its own cannot be mistaken for one that was killed.
+    #[cfg(unix)]
+    #[test]
+    fn test_timeout_kills_what_the_run_spawned() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let script = temp.path().join("spawner.sh");
+        let marker = temp.path().join("survivor.marker");
+        write_executable(
+            &script,
+            &format!(
+                "#!/bin/sh\n( sleep 3; echo alive > {} ) &\nwait\n",
+                marker.display()
+            ),
+        );
+        let script_str = script.to_str().unwrap();
+        let log_file = temp.path().join("dummy.log");
+
+        let result = (0..3)
+            .find_map(|attempt| {
+                let options = RunOptions::new(script_str)
+                    .with_log_file(log_file.clone())
+                    .with_timeout(Duration::from_secs(1));
+                match run_stata(Path::new("anything.do"), options) {
+                    Ok(r) => Some(r),
+                    Err(crate::error::Error::Io(e))
+                        if e.kind() == std::io::ErrorKind::ExecutableFileBusy =>
+                    {
+                        std::thread::sleep(Duration::from_millis(50 * (attempt + 1)));
+                        None
+                    }
+                    Err(e) => panic!("spawn: {e:?}"),
+                }
+            })
+            .expect("spawn after ETXTBSY retries");
+        assert!(!result.completed, "a killed run has not completed");
+        assert!(
+            result.duration < Duration::from_secs(3),
+            "the run itself should have been killed at the timeout, not left to \
+             finish ({:?})",
+            result.duration
+        );
+
+        // Outlast the descendant's own schedule, so a survivor has every chance
+        // to write the marker.
+        std::thread::sleep(Duration::from_secs(4));
+
+        assert!(
+            !marker.exists(),
+            "a process the run spawned was still alive after the timeout — it \
+             wrote {}",
+            marker.display()
         );
     }
 

--- a/src/executor/signals.rs
+++ b/src/executor/signals.rs
@@ -1,0 +1,110 @@
+//! Forwarding terminal signals to Stata process groups
+//!
+//! Each Stata child runs in its own process group (see `runner::run_stata`), so
+//! a timeout can signal the whole tree instead of only the process stacy holds
+//! a handle to. That isolation costs the behavior the terminal used to provide
+//! for free: Ctrl-C reaches the foreground process group, which no longer
+//! contains Stata. Without forwarding, Ctrl-C would kill stacy and leave Stata
+//! running — the very thing #118 is about.
+//!
+//! So SIGINT, SIGTERM and SIGHUP are forwarded to every live child group, and
+//! then stacy dies of the same signal, keeping the exit status callers already
+//! expect (130 for Ctrl-C).
+//!
+//! Windows needs none of this: console events go to every process attached to
+//! the console, so Stata already hears Ctrl-C.
+
+#[cfg(unix)]
+use std::sync::atomic::{AtomicI32, Ordering};
+#[cfg(unix)]
+use std::sync::Once;
+
+/// Live child process groups. Fixed size and lock-free: the handler runs in
+/// signal context, where allocating and locking are not allowed. Parallel runs
+/// are bounded by core count, so the table cannot realistically fill; a child
+/// that finds no slot simply is not forwarded to.
+#[cfg(unix)]
+const MAX_GROUPS: usize = 128;
+#[cfg(unix)]
+static GROUPS: [AtomicI32; MAX_GROUPS] = [const { AtomicI32::new(0) }; MAX_GROUPS];
+#[cfg(unix)]
+static INSTALLED: Once = Once::new();
+
+/// Keeps a process group in the forwarding table. Dropping it removes the
+/// entry, so a reaped child's pid is never signalled again.
+pub struct Registration {
+    #[cfg(unix)]
+    slot: Option<usize>,
+}
+
+impl Drop for Registration {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        if let Some(slot) = self.slot {
+            GROUPS[slot].store(0, Ordering::SeqCst);
+        }
+    }
+}
+
+/// Forward signals to `pgid` until the returned guard is dropped.
+pub fn register(pgid: i32) -> Registration {
+    #[cfg(unix)]
+    {
+        install_handlers();
+
+        for (slot, entry) in GROUPS.iter().enumerate() {
+            if entry
+                .compare_exchange(0, pgid, Ordering::SeqCst, Ordering::Relaxed)
+                .is_ok()
+            {
+                return Registration { slot: Some(slot) };
+            }
+        }
+
+        Registration { slot: None }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = pgid;
+        Registration {}
+    }
+}
+
+/// Install the forwarding handlers once per process.
+#[cfg(unix)]
+fn install_handlers() {
+    INSTALLED.call_once(|| {
+        for signum in [libc::SIGINT, libc::SIGTERM, libc::SIGHUP] {
+            // Through a fn pointer: casting the function item straight to an
+            // integer is what `libc::signal` wants, but not what it means.
+            let handler = forward as extern "C" fn(libc::c_int);
+            // SAFETY: `forward` only performs async-signal-safe work.
+            unsafe {
+                libc::signal(signum, handler as libc::sighandler_t);
+            }
+        }
+    });
+}
+
+/// Signal handler: pass the signal on to every live child group, then die of
+/// it. Only atomic loads, `kill(2)` and `raise(3)` — all async-signal-safe.
+#[cfg(unix)]
+extern "C" fn forward(signum: libc::c_int) {
+    for entry in GROUPS.iter() {
+        let pgid = entry.load(Ordering::SeqCst);
+        if pgid > 0 {
+            // SAFETY: a negative pid signals the whole process group.
+            unsafe {
+                libc::kill(-pgid, signum);
+            }
+        }
+    }
+
+    // Restore the default disposition and re-raise, so stacy's own exit status
+    // stays what it was before this module existed.
+    unsafe {
+        libc::signal(signum, libc::SIG_DFL);
+        libc::raise(signum);
+    }
+}

--- a/tests/test_signal_handling.rs
+++ b/tests/test_signal_handling.rs
@@ -61,6 +61,111 @@ fn test_signal_exit_codes() {
     assert_eq!(sigkill_code, 137, "SIGKILL exit code");
 }
 
+/// A signal to stacy must reach the run it started. Stata is in its own process
+/// group now (#118), so the terminal no longer delivers Ctrl-C to it and stacy
+/// forwards the signal instead. Without that, killing stacy would leave Stata
+/// running — which is the bug this guards.
+///
+/// SIGTERM stands in for Ctrl-C here: a shell's background jobs ignore SIGINT
+/// when job control is off, which would make the stub, not stacy, decide the
+/// outcome. The forwarding path is the same for both signals; the exit status
+/// Ctrl-C produces is covered by the test below.
+#[cfg(unix)]
+#[test]
+fn test_signal_reaches_processes_the_run_spawned() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let marker = temp.path().join("survivor.marker");
+    let stub = write_stub(temp.path(), &marker);
+    std::fs::write(temp.path().join("dummy.do"), "display 1\n").unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_stacy"))
+        .args(["run", "dummy.do", "--engine"])
+        .arg(&stub)
+        .current_dir(temp.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("Failed to spawn stacy");
+
+    // Let the run get as far as spawning its descendant.
+    thread::sleep(Duration::from_millis(800));
+
+    unsafe {
+        libc::kill(child.id() as i32, libc::SIGTERM);
+    }
+    let _ = child.wait().expect("Failed to wait");
+
+    // Outlast the descendant's own schedule, so a survivor has every chance to
+    // write the marker.
+    thread::sleep(Duration::from_secs(4));
+
+    assert!(
+        !marker.exists(),
+        "a process the run spawned outlived stacy — the signal was not forwarded"
+    );
+}
+
+/// Forwarding must not change the status stacy itself exits with: Ctrl-C still
+/// has to look like Ctrl-C to whatever started stacy.
+#[cfg(unix)]
+#[test]
+fn test_sigint_still_kills_stacy_with_sigint() {
+    use std::os::unix::process::ExitStatusExt;
+
+    let temp = tempfile::TempDir::new().unwrap();
+    let marker = temp.path().join("unused.marker");
+    let stub = write_stub(temp.path(), &marker);
+    std::fs::write(temp.path().join("dummy.do"), "display 1\n").unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_stacy"))
+        .args(["run", "dummy.do", "--engine"])
+        .arg(&stub)
+        .current_dir(temp.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("Failed to spawn stacy");
+
+    thread::sleep(Duration::from_millis(800));
+
+    unsafe {
+        libc::kill(child.id() as i32, libc::SIGINT);
+    }
+    let status = child.wait().expect("Failed to wait");
+
+    assert_eq!(
+        status.signal(),
+        Some(libc::SIGINT),
+        "stacy should still die of the signal it was sent, giving callers 130"
+    );
+}
+
+/// A stand-in for Stata that leaves a process behind, like `stata-mp` does. The
+/// descendant announces itself by writing `marker` three seconds in, so a
+/// survivor is visible without depending on pid lifetimes.
+#[cfg(unix)]
+fn write_stub(dir: &std::path::Path, marker: &std::path::Path) -> std::path::PathBuf {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let stub = dir.join("stata_stub.sh");
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o755)
+        .open(&stub)
+        .unwrap();
+    write!(
+        f,
+        "#!/bin/sh\n( sleep 3; echo alive > {} ) &\nwait\n",
+        marker.display()
+    )
+    .unwrap();
+    f.sync_all().unwrap();
+    stub
+}
+
 #[test]
 #[ignore] // Slow test - spawns external process
 fn test_background_kill() {


### PR DESCRIPTION
Stata is signalled through the one process stacy spawned, and that is not the process that goes on running — `stata-mp` leaves an engine behind. A timed-out run killed the handle and left Stata reparented to init, burning a core until someone noticed. I caught one 16 minutes after its test run had finished; it exited the instant I sent it SIGTERM by hand, so nothing had ever signalled it.

Runs now get their own process group and the group is signalled, with one sweep after the run is reaped for anything that outlived it.

That isolation has a catch worth calling out: it takes Stata out of the terminal's foreground process group, so Ctrl-C stops reaching it. On its own, a process-group fix would orphan Stata on *every* Ctrl-C — worse than the bug. `executor::signals` forwards SIGINT, SIGTERM and SIGHUP to the live child groups and then re-raises with the default disposition, so stacy still exits 130 on Ctrl-C exactly as before. The table it keeps is a fixed-size lock-free array because the handler runs in signal context, where allocating and locking are not allowed.

Two smaller defects in the same function. The escalation to a forced kill was an unconditional 5s sleep that the main thread joined, so every timeout returned 5s late — `--timeout 2` measured 7.02s. It is now cancelled by the run exiting, and only a run that ignores the first signal waits it out. And the kill was `#[cfg(unix)]` only, so on Windows the timeout expired and nothing happened; `taskkill /T` terminates the tree there without taking a dependency for it.

Measured against the previous binary rather than assumed:

| | before | after |
|---|---|---|
| timeout, descendant left behind | survived | killed |
| stacy itself SIGTERM'd | survived | killed |
| `test_infinite_loop_with_timeout` | failing | passes |
| `test_run_timeout_kills_infinite_loop` | 11.14s, on its 10s bound | 3.78s |

`test_infinite_loop_with_timeout` passes for the first time — it was failing on the timing assertion, not on the kill. Four new tests cover both orphan paths using a stub that leaves a descendant running, so they need no Stata; I confirmed each fails against the current code before relying on it.

Closes #118